### PR TITLE
bump required golang version

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Trickster Helm Charts are located at <https://helm.tricksterproxy.io> for instal
 ### Building from source
 
 To build Trickster from the source code yourself you need to have a working
-Go environment with [version 1.9 or greater installed](http://golang.org/doc/install).
+Go environment with [version 1.16 or greater installed](http://golang.org/doc/install).
 
 You can directly use the `go` tool to download and install the `trickster`
 binary into your `GOPATH`:


### PR DESCRIPTION
pkg/encoding/brotli (among others) requires 1.16

```
github.com/trickstercache/trickster/pkg/backends/irondb/model
# github.com/trickstercache/trickster/pkg/backends/irondb/model
pkg/backends/irondb/model/model.go:395:10: undefined: io.ReadAll
note: module requires Go 1.16
github.com/trickstercache/trickster/pkg/errors
github.com/trickstercache/trickster/pkg/util/timeconv
github.com/trickstercache/trickster/pkg/util/base64
github.com/trickstercache/trickster/pkg/util/sha1
internal/profile
github.com/trickstercache/trickster/pkg/encoding/zstd
github.com/trickstercache/trickster/pkg/encoding/brotli
runtime/pprof
# github.com/trickstercache/trickster/pkg/encoding/brotli
pkg/encoding/brotli/brotli.go:31:9: undefined: io.ReadAll
note: module requires Go 1.16
os/signal
net/http/pprof
github.com/influxdata/influxql/internal
github.com/influxdata/influxql
make: *** [Makefile:58: build] Error 2
```