### PR TITLE
Cache examples

### DIFF
--- a/examples/packages/cache/bbolt/README.md
+++ b/examples/packages/cache/bbolt/README.md
@@ -1,0 +1,3 @@
+# bbolt Cache Example
+
+This example app shows how to incorporate the Trickster cache into your own application using the bbolt cache provider.

--- a/examples/packages/cache/bbolt/main.go
+++ b/examples/packages/cache/bbolt/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/cache"
+	"github.com/trickstercache/trickster/v2/pkg/cache/bbolt"
+)
+
+func main() {
+
+	const secs time.Duration = 3
+	const ttl = time.Second * secs
+
+	const myKey, myValue = "myKeyName", "myValue"
+
+	// create a new memory cache
+	c, err := bbolt.New("/Users/jranson/test.bbolt", "trickster")
+	// this starts some background threads for object lifecycle management, so
+	// be sure to Close() once ready for the cache to be garbage collected
+	if err != nil {
+		panic(err)
+	}
+
+	// Optional - Set the max cache size (default is 512MB):
+	cfg := c.Configuration()
+	cfg.Index.MaxSizeBytes = 4 * 1024 * 1024 * 1024 // 4GB
+	//
+
+	// store an object in the cache with 3s TTL
+	fmt.Printf("Storing w/ TTL: key=[%s] value=[%s] ttl=[%s]\n", myKey, myValue, ttl.String())
+	err = c.Store(myKey, []byte(myValue), ttl)
+	if err != nil {
+		panic(err)
+	}
+
+	// store an object in the cache with no TTL
+	key2 := myKey + "2"
+	val2 := myValue + "2"
+	fmt.Printf("Storing no TTL: key=[%s] value=[%s] ttl=[0]\n", key2, val2)
+	err = c.Store(key2, []byte(val2), 0)
+	if err != nil {
+		panic(err)
+	}
+
+	// retrieve the object from cache
+	value, status, err := c.Retrieve(myKey, false)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Retrieve: key=[%s] status=[%s] value=[%s]\n",
+		myKey, status.String(), string(value))
+
+	// retrieve the second object from cache
+	value, status, err = c.Retrieve(key2, false)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Retrieve: key=[%s] status=[%s] value=[%s]\n",
+		myKey, status.String(), string(value))
+
+	// sleep slightly longer than the TTL so the object has been reaped
+	fmt.Printf("sleeping %d.25 seconds\n", secs)
+	time.Sleep(ttl + (time.Millisecond * 250))
+
+	// retrieve the ttl'ed object from cache again, should be a cache miss
+	value, status, err = c.Retrieve(myKey, false)
+	if err != nil && err != cache.ErrKNF {
+		panic(err)
+	}
+	fmt.Printf("2nd Retrieve: key=[%s] status=[%s] value=[%s]\n",
+		myKey, status.String(), string(value))
+
+	// retrieve the non-ttl'ed object from cache again, should still cache hit
+	value, status, err = c.Retrieve(key2, false)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("2nd Retrieve: key=[%s] status=[%s] value=[%s]\n",
+		key2, status.String(), string(value))
+
+	// close the cache when you're ready for it to be garbage collected,
+	// or the background threads will continue to run
+	c.Close()
+
+}

--- a/examples/packages/cache/memory/README.md
+++ b/examples/packages/cache/memory/README.md
@@ -1,0 +1,3 @@
+# Memory Cache Example
+
+This example app shows how to use the Trickster memory cache in your own application, including how to set the maximum cache size and object TTL's.

--- a/examples/packages/cache/memory/main.go
+++ b/examples/packages/cache/memory/main.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/cache"
+	"github.com/trickstercache/trickster/v2/pkg/cache/memory"
+)
+
+func main() {
+
+	const secs time.Duration = 3
+	const ttl = time.Second * secs
+
+	const myKey, myValue = "myKeyName", "myValue"
+
+	// create a new memory cache
+	c, err := memory.New()
+	// this starts some background threads for object lifecycle management, so
+	// be sure to Close() once ready for the cache to be garbage collected
+	if err != nil {
+		panic(err)
+	}
+
+	// Optional - Set the max cache size (default is 512MB):
+	cfg := c.Configuration()
+	cfg.Index.MaxSizeBytes = 32 * 1024 * 1024 // 32MB
+	//
+
+	// store an object in the cache with 3s TTL
+	fmt.Printf("Storing w/ TTL: key=[%s] value=[%s] ttl=[%s]\n", myKey, myValue, ttl.String())
+	err = c.Store(myKey, []byte(myValue), ttl)
+	if err != nil {
+		panic(err)
+	}
+
+	// store an object in the cache with no TTL
+	key2 := myKey + "2"
+	val2 := myValue + "2"
+	fmt.Printf("Storing no TTL: key=[%s] value=[%s] ttl=[0]\n", key2, val2)
+	err = c.Store(key2, []byte(val2), 0)
+	if err != nil {
+		panic(err)
+	}
+
+	// retrieve the object from cache
+	value, status, err := c.Retrieve(myKey, false)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Retrieve: key=[%s] status=[%s] value=[%s]\n",
+		myKey, status.String(), string(value))
+
+	// retrieve the second object from cache
+	value, status, err = c.Retrieve(key2, false)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("Retrieve: key=[%s] status=[%s] value=[%s]\n",
+		myKey, status.String(), string(value))
+
+	// sleep slightly longer than the TTL so the object has been reaped
+	fmt.Printf("sleeping %d.25 seconds\n", secs)
+	time.Sleep(ttl + (time.Millisecond * 250))
+
+	// retrieve the ttl'ed object from cache again, should be a cache miss
+	value, status, err = c.Retrieve(myKey, false)
+	if err != nil && err != cache.ErrKNF {
+		panic(err)
+	}
+	fmt.Printf("2nd Retrieve: key=[%s] status=[%s] value=[%s]\n",
+		myKey, status.String(), string(value))
+
+	// retrieve the non-ttl'ed object from cache again, should still cache hit
+	value, status, err = c.Retrieve(key2, false)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("2nd Retrieve: key=[%s] status=[%s] value=[%s]\n",
+		key2, status.String(), string(value))
+
+	// close the cache when you're ready for it to be garbage collected,
+	// or the background threads will continue to run
+	c.Close()
+
+}

--- a/pkg/cache/index/options/options.go
+++ b/pkg/cache/index/options/options.go
@@ -47,7 +47,9 @@ type Options struct {
 func New() *Options {
 	return &Options{
 		ReapIntervalMS:        DefaultCacheIndexReap,
+		ReapInterval:          time.Duration(DefaultCacheIndexReap) * time.Millisecond,
 		FlushIntervalMS:       DefaultCacheIndexFlush,
+		FlushInterval:         time.Duration(DefaultCacheIndexFlush) * time.Millisecond,
 		MaxSizeBytes:          DefaultCacheMaxSizeBytes,
 		MaxSizeBackoffBytes:   DefaultMaxSizeBackoffBytes,
 		MaxSizeObjects:        DefaultMaxSizeObjects,


### PR DESCRIPTION
This PR makes it much easier for other go projects to import and use the Trickster memory and bbolt caches, and provides example apps for each.