### PR TITLE
add simulated latency functionality

### DIFF
--- a/docs/simulated-latency.md
+++ b/docs/simulated-latency.md
@@ -1,0 +1,29 @@
+# Simulated Latency
+
+Trickster supports simulating latency on a per-backend basis, and can simulate both consistent and random durations of latency. Simulated latency is introduced in the frontend part of the proxy, and thus works with any backend provider.
+
+In `rule`, `alb` and other backend providers, where a request may transit multiple backend routes, only the Simulated Latency configs associated with the request entrypoint (first route) will be procssed, and not any subsequent routes the request is sent through.
+
+## Consistent Latency Duration
+
+In the Backend configuration, add a `latency_min_ms` value > 0, and the configured amount of latency will be introduced for each incoming request.
+
+## Random Latency
+
+ To simulate random latency, set `latency_max_ms` to a value > `latency_min_ms`, which may be 0 for random latency. Trickster will introduce a random amount of latency between (inclusive) the provided values.
+
+## Example Config
+
+```yaml
+frontend:
+  listen_port: 8480
+
+backends:
+  default:
+    origin_url: https://www.example.com
+    provider: reverseproxy
+    #
+    # introduce random latency between 50 and 150 milliseconds on each request
+    latency_min_ms: 50
+    latency_max_ms: 150
+```

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -358,6 +358,12 @@ backends:
 #     # default is 0
 #     shard_step_ms: 0
 
+#     # Simulated Latency
+#     # set latency_min_ms > 0 to apply a consistent latency to each request to this backend
+#     # set latency_max_ms > latency_max_ms (which can be 0) to apply a random latency between the two
+#     latency_max_ms = 0
+#     latency_max_ms = 0
+
 #     #
 #     # Each backend provider implements their own defaults for health checking
 #     # which can be overridden per backend configuration. See /docs/health.md for more information


### PR DESCRIPTION
this patch will allow the user to provide latency_min_ms and/or latency_max_ms values to introduce simulated latency into inbound requests.