### PR TITLE
build and report correct target os/arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ BUILD_TIME     := $(shell date -u +%FT%T%z)
 GIT_LATEST_COMMIT_ID     := $(shell git rev-parse HEAD)
 IMAGE_TAG      ?= latest
 IMAGE_ARCH     ?= amd64
-GOHOSTARCH     ?= amd64
+GOARCH         ?= amd64
 TAGVER         ?= unspecified
-LDFLAGS         =-ldflags "-extldflags '-static' -w -s -X main.applicationBuildTime=$(BUILD_TIME) -X main.applicationGitCommitID=$(GIT_LATEST_COMMIT_ID) -X main.applicationGoHostArch=$(GOHOSTARCH)"
+LDFLAGS         =-ldflags "-extldflags '-static' -w -s -X main.applicationBuildTime=$(BUILD_TIME) -X main.applicationGitCommitID=$(GIT_LATEST_COMMIT_ID)"
 BUILD_SUBDIR   := OPATH
 PACKAGE_DIR    := ./$(BUILD_SUBDIR)/trickster-$(PROGVER)
 BIN_DIR        := $(PACKAGE_DIR)/bin
@@ -54,7 +54,7 @@ test-go-mod:
 
 .PHONY: build
 build: go-mod-tidy go-mod-vendor
-	GOOS=$(GOOS) GOHOSTARCH=$(GOHOSTARCH) CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o ./$(BUILD_SUBDIR)/trickster -a -v $(TRICKSTER_MAIN)/*.go
+	CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o ./$(BUILD_SUBDIR)/trickster -a -v $(TRICKSTER_MAIN)/*.go
 
 rpm: build
 	mkdir -p ./$(BUILD_SUBDIR)/SOURCES
@@ -89,11 +89,11 @@ release-artifacts: clean
 	cp ./LICENSE $(PACKAGE_DIR)
 	cp ./examples/conf/*.yaml $(CONF_DIR)
 
-	GOOS=darwin  GOHOSTARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).darwin-amd64  -a -v $(TRICKSTER_MAIN)/*.go
-	GOOS=darwin  GOHOSTARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).darwin-arm64  -a -v $(TRICKSTER_MAIN)/*.go
-	GOOS=linux   GOHOSTARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).linux-amd64   -a -v $(TRICKSTER_MAIN)/*.go
-	GOOS=linux   GOHOSTARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).linux-arm64   -a -v $(TRICKSTER_MAIN)/*.go
-	GOOS=windows GOHOSTARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).windows-amd64 -a -v $(TRICKSTER_MAIN)/*.go
+	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).darwin-amd64  -a -v $(TRICKSTER_MAIN)/*.go
+	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).darwin-arm64  -a -v $(TRICKSTER_MAIN)/*.go
+	GOOS=linux   GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).linux-amd64   -a -v $(TRICKSTER_MAIN)/*.go
+	GOOS=linux   GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).linux-arm64   -a -v $(TRICKSTER_MAIN)/*.go
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).windows-amd64 -a -v $(TRICKSTER_MAIN)/*.go
 
 	cd ./$(BUILD_SUBDIR) && tar cvfz ./trickster-$(PROGVER).tar.gz ./trickster-$(PROGVER)/*
 
@@ -119,14 +119,14 @@ kube-local:
 
 .PHONY: docker
 docker:
-	docker build --build-arg IMAGE_ARCH=$(IMAGE_ARCH) --build-arg GOHOSTARCH=$(GOHOSTARCH) -f ./deploy/Dockerfile -t trickster:$(PROGVER) .
+	docker build --build-arg IMAGE_ARCH=$(IMAGE_ARCH)  --build-arg GOARCH=$(GOARCH) -f ./deploy/Dockerfile -t trickster:$(PROGVER) .
 
 .PHONY: docker-release
 docker-release:
 # linux x86 image
-	docker build --build-arg IMAGE_ARCH=amd64 --build-arg GOHOSTARCH=amd64 -f ./deploy/Dockerfile -t trickstercache/trickster:$(IMAGE_TAG) .
+	docker build --build-arg IMAGE_ARCH=amd64 --build-arg GOARCH=amd64 -f ./deploy/Dockerfile -t trickstercache/trickster:$(IMAGE_TAG) .
 # linux arm image
-	docker build --build-arg IMAGE_ARCH=arm64v8 --build-arg GOHOSTARCH=arm64 -f ./deploy/Dockerfile -t trickstercache/trickster:arm64v8-$(IMAGE_TAG) .
+	docker build --build-arg IMAGE_ARCH=arm64v8 --build-arg GOARCH=arm64 -f ./deploy/Dockerfile -t trickstercache/trickster:arm64v8-$(IMAGE_TAG) .
 
 .PHONY: style
 style:

--- a/cmd/trickster/config.go
+++ b/cmd/trickster/config.go
@@ -261,15 +261,16 @@ func initLogger(c *config.Config) *tl.Logger {
 	logger := tl.New(c)
 	tl.Info(logger, "application loaded from configuration",
 		tl.Pairs{
-			"name":       runtime.ApplicationName,
-			"version":    runtime.ApplicationVersion,
-			"goVersion":  goruntime.Version(),
-			"goHostArch": applicationGoHostArch,
-			"commitID":   applicationGitCommitID,
-			"buildTime":  applicationBuildTime,
-			"logLevel":   c.Logging.LogLevel,
-			"config":     c.ConfigFilePath(),
-			"pid":        os.Getpid(),
+			"name":      runtime.ApplicationName,
+			"version":   runtime.ApplicationVersion,
+			"goVersion": goruntime.Version(),
+			"goArch":    goruntime.GOARCH,
+			"goOS":      goruntime.GOOS,
+			"commitID":  applicationGitCommitID,
+			"buildTime": applicationBuildTime,
+			"logLevel":  c.Logging.LogLevel,
+			"config":    c.ConfigFilePath(),
+			"pid":       os.Getpid(),
 		},
 	)
 	return logger

--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -27,7 +27,6 @@ import (
 var (
 	applicationGitCommitID string
 	applicationBuildTime   string
-	applicationGoHostArch  string
 )
 
 const (

--- a/cmd/trickster/usage.go
+++ b/cmd/trickster/usage.go
@@ -72,14 +72,19 @@ https://github.com/trickstercache/trickster
 func version() string {
 
 	goVer := goruntime.Version()
-	// the version printer uses an empty string for Go Version during unit tests
+	arch := goruntime.GOARCH
+	os := goruntime.GOOS
+	// use an empty string for goVer, arch, and os during unit tests
 	// to accommodate rigid tests like ExamplePrintVersion and ExamplePrintUsage
 	if runtime.ApplicationVersion == "test" {
 		goVer = ""
+		arch = ""
+		os = ""
 	}
 
-	return fmt.Sprintf("Trickster version: %s, buildInfo: %s %s, goVersion: %s, copyright: © 2018 The Trickster Authors",
+	return fmt.Sprintf("Trickster version: %s (%s/%s), buildInfo: %s %s, goVersion: %s, copyright: © 2018 The Trickster Authors",
 		runtime.ApplicationVersion,
+		os, arch,
 		applicationBuildTime, applicationGitCommitID,
 		goVer,
 	)

--- a/cmd/trickster/usage_test.go
+++ b/cmd/trickster/usage_test.go
@@ -20,18 +20,19 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/runtime"
 )
 
-// ExamplePrintVersion tests the output of the printVersion() func
+// ExamplePrintVersion tests the output of the PrintVersion() func
 func ExamplePrintVersion() {
 	runtime.ApplicationVersion = "test"
 	PrintVersion()
-	// Output: Trickster version: test, buildInfo:  , goVersion: , copyright: © 2018 The Trickster Authors
+	// Output: Trickster version: test (/), buildInfo:  , goVersion: , copyright: © 2018 The Trickster Authors
 }
 
+// ExamplePrintUsage tests the output of the PrintUsage() func
 func ExamplePrintUsage() {
 
 	runtime.ApplicationVersion = "test"
 	PrintUsage()
-	// Output: Trickster version: test, buildInfo:  , goVersion: , copyright: © 2018 The Trickster Authors
+	// Output: Trickster version: test (/), buildInfo:  , goVersion: , copyright: © 2018 The Trickster Authors
 	//
 	// Trickster Usage:
 	//


### PR DESCRIPTION
This patch updates the `initLogger()` and `PrintVersion()` functions to use the correct flags for reporting a build's target os, arch, and go version at runtime from the compiled binary.

Signed-off-by: James Ranson <james@ranson.org>