### PR TITLE
use path instead of upstream_path

### DIFF
--- a/pkg/backends/healthcheck/options/options.go
+++ b/pkg/backends/healthcheck/options/options.go
@@ -129,7 +129,7 @@ func (o *Options) Overlay(name string, custom *Options) {
 	if custom == nil || custom.md == nil {
 		return
 	}
-	if custom.md.IsDefined("backends", name, "healthcheck", "upstream_path") {
+	if custom.md.IsDefined("backends", name, "healthcheck", "path") {
 		o.Path = custom.Path
 	}
 	if custom.md.IsDefined("backends", name, "healthcheck", "verb") {

--- a/pkg/backends/healthcheck/options/options_test.go
+++ b/pkg/backends/healthcheck/options/options_test.go
@@ -121,7 +121,7 @@ const hcTOML = `
 backends:
   test:
     healthcheck:
-      upstream_path: test_path
+      path: test_path
       verb: POST
       query: '?myqueryparam=myqueryval'
       body: custom body

--- a/pkg/backends/options/options_data_test.go
+++ b/pkg/backends/options/options_data_test.go
@@ -54,10 +54,6 @@ backends:
     backfill_tolerance_ms: 301000
     backfill_tolerance_points: 2
     timeout_ms: 37000
-    health_check_endpoint: /test_health
-    health_check_upstream_path: /test/upstream/endpoint
-    health_check_verb: test_verb
-    health_check_query: query=1234
     timeseries_ttl_ms: 8666000
     max_ttl_ms: 300000
     fastforward_ttl_ms: 382000
@@ -74,6 +70,9 @@ backends:
     healthcheck:
       headers:
         Authorization: Basic SomeHash
+      path: /test/upstream/endpoint
+      verb: test_verb
+      query: query=1234
     paths:
       series:
         path: /series


### PR DESCRIPTION
This corrects a few places where the legacy 1.x config value for health checks of `upstream_path` was not updated to just `path` when migrating code over to 2.x

fixes #617