### PR TITLE
reliably print fatal startup errors

### DIFF
--- a/pkg/observability/logging/logging.go
+++ b/pkg/observability/logging/logging.go
@@ -136,6 +136,23 @@ func Error(logger interface{}, event string, detail Pairs) {
 	}
 }
 
+func ErrorSynchronous(logger interface{}, event string, detail Pairs) {
+	if logger == nil {
+		return
+	}
+	detail["caller"] = pkgCaller{stack.Caller(1)}
+	switch l := logger.(type) {
+	case *Logger:
+		l.Error(event, detail)
+	case *SyncLogger:
+		l.Error(event, detail)
+	case *log.Logger:
+		l.Print("")
+	case gkl.Logger:
+		level.Error(l).Log(detail.ToList(event)...)
+	}
+}
+
 // Fatal sends a "FATAL" event to the Logger and exits the program with the provided exit code
 func Fatal(logger interface{}, code int, event string, detail Pairs) {
 	// go-kit/log/level does not support Fatal, so implemented separately here

--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -182,7 +182,7 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 	var err error
 	l.Listener, err = NewListener(address, port, connectionsLimit, tlsConfig, drainTimeout, logger)
 	if err != nil {
-		tl.Error(logger,
+		tl.ErrorSynchronous(logger,
 			"http listener startup failed", tl.Pairs{"name": listenerName, "detail": err})
 		if f != nil {
 			f()
@@ -207,7 +207,7 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 		l.server = svr
 		err = svr.Serve(l)
 		if err != nil {
-			tl.Error(logger,
+			tl.ErrorSynchronous(logger,
 				"https listener stopping", tl.Pairs{"name": listenerName, "detail": err})
 			if l.exitOnError {
 				os.Exit(1)
@@ -222,7 +222,7 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 	l.server = svr
 	err = svr.Serve(l)
 	if err != nil {
-		tl.Error(logger,
+		tl.ErrorSynchronous(logger,
 			"http listener stopping", tl.Pairs{"name": listenerName, "detail": err})
 		if l.exitOnError {
 			os.Exit(1)


### PR DESCRIPTION
this patch ensures that fatal startup errors are reliably logged before the application exits

Signed-off-by: James Ranson <james@ranson.org>

fixes #627 