### PR TITLE
add nil pointer check on tags injection

### DIFF
--- a/pkg/timeseries/dataset/dataset.go
+++ b/pkg/timeseries/dataset/dataset.go
@@ -456,6 +456,9 @@ func (ds *DataSet) DefaultRangeCropper(e timeseries.Extent) {
 func (ds *DataSet) SeriesCount() int {
 	var cnt int
 	for i := range ds.Results {
+		if ds.Results[i] == nil {
+			continue
+		}
 		cnt += len(ds.Results[i].SeriesList)
 	}
 	return cnt

--- a/pkg/timeseries/dataset/dataset.go
+++ b/pkg/timeseries/dataset/dataset.go
@@ -99,6 +99,9 @@ func (ds *DataSet) CroppedClone(e timeseries.Extent) timeseries.Timeseries {
 	// range, return empty set and bail
 	if ds.ExtentList.OutsideOf(e) {
 		for i := range ds.Results {
+			if ds.Results[i] == nil {
+				continue
+			}
 			clone.Results[i] = &Result{
 				StatementID: ds.Results[i].StatementID,
 				Error:       ds.Results[i].Error,
@@ -196,6 +199,9 @@ func (ds *DataSet) Clone() timeseries.Timeseries {
 	}
 
 	for i := range ds.Results {
+		if ds.Results[i] == nil {
+			continue
+		}
 		clone.Results[i] = ds.Results[i].Clone()
 	}
 	return clone
@@ -367,6 +373,9 @@ func (ds *DataSet) DefaultRangeCropper(e timeseries.Extent) {
 	// The DataSet has no extents, so no need to do anything
 	if x == 0 {
 		for i := range ds.Results {
+			if ds.Results[i] == nil {
+				continue
+			}
 			ds.Results[i].SeriesList = make([]*Series, 0)
 		}
 		ds.ExtentList = timeseries.ExtentList{}
@@ -376,6 +385,9 @@ func (ds *DataSet) DefaultRangeCropper(e timeseries.Extent) {
 	// range, return empty set and bail
 	if ds.ExtentList.OutsideOf(e) {
 		for i := range ds.Results {
+			if ds.Results[i] == nil {
+				continue
+			}
 			ds.Results[i].SeriesList = make([]*Series, 0)
 		}
 		ds.ExtentList = timeseries.ExtentList{}
@@ -401,6 +413,9 @@ func (ds *DataSet) DefaultRangeCropper(e timeseries.Extent) {
 	endNS := epoch.Epoch(e.End.UnixNano())
 
 	for i := range ds.Results {
+		if ds.Results[i] == nil {
+			continue
+		}
 		var wg sync.WaitGroup
 		if len(ds.Results[i].SeriesList) == 0 {
 			continue
@@ -450,6 +465,9 @@ func (ds *DataSet) SeriesCount() int {
 func (ds *DataSet) ValueCount() int64 {
 	var cnt int64
 	for i := range ds.Results {
+		if ds.Results[i] == nil {
+			continue
+		}
 		if len(ds.Results[i].SeriesList) == 0 {
 			continue
 		}

--- a/pkg/timeseries/dataset/dataset_test.go
+++ b/pkg/timeseries/dataset/dataset_test.go
@@ -99,6 +99,7 @@ func testDataSet2() *DataSet {
 		StatementID: 0,
 		SeriesList: []*Series{
 			{sh1, newPoints(), s},
+			nil,
 		},
 	}
 
@@ -113,7 +114,7 @@ func testDataSet2() *DataSet {
 
 	ds := &DataSet{
 		TimeRangeQuery: &timeseries.TimeRangeQuery{Step: time.Duration(5 * timeseries.Second)},
-		Results:        []*Result{r1, r2},
+		Results:        []*Result{r1, r2, nil},
 		ExtentList:     timeseries.ExtentList{timeseries.Extent{Start: time.Unix(5, 0), End: time.Unix(30, 0)}},
 	}
 

--- a/pkg/timeseries/dataset/dataset_test.go
+++ b/pkg/timeseries/dataset/dataset_test.go
@@ -214,7 +214,7 @@ func TestMerge(t *testing.T) {
 
 	ds.Merge(false, ds2)
 
-	if ds.SeriesCount() != 4 {
+	if ds.SeriesCount() != 5 {
 		t.Errorf("expected %d got %d", 4, ds.SeriesCount())
 	}
 }

--- a/pkg/timeseries/dataset/series_list.go
+++ b/pkg/timeseries/dataset/series_list.go
@@ -75,6 +75,9 @@ func (sl SeriesList) Equal(sl2 SeriesList) bool {
 		return false
 	}
 	for i, v := range sl {
+		if v == nil {
+			continue
+		}
 		if v.Header.CalculateHash() != sl2[i].Header.CalculateHash() {
 			return false
 		}

--- a/pkg/timeseries/dataset/tags.go
+++ b/pkg/timeseries/dataset/tags.go
@@ -34,7 +34,13 @@ func (ds *DataSet) InjectTags(tags Tags) {
 	var wg sync.WaitGroup
 	var mtx sync.Mutex
 	for _, r := range ds.Results {
+		if r == nil {
+			continue
+		}
 		for _, s := range r.SeriesList {
+			if s == nil {
+				continue
+			}
 			wg.Add(1)
 			go func(s1 *Series) {
 				mtx.Lock()


### PR DESCRIPTION
this eliminates a potential nil pointer panic when a series may be nil during tag injection. fixes #633 

Signed-off-by: James Ranson <james@ranson.org>