### PR TITLE
Cache Chunking

### DIFF
--- a/pkg/cache/options/defaults/defaults.go
+++ b/pkg/cache/options/defaults/defaults.go
@@ -24,4 +24,6 @@ const (
 	// DefaultCacheProviderID is the default cache providers ID for any defined cache
 	// and should align with DefaultCacheProvider
 	DefaultCacheProviderID = providers.Memory
+	// DefaultTimeseriesChunkFactor determines the extent of timeseries chunks, based on timeseries query step duration.
+	DefaultTimeseriesChunkFactor = 420
 )

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -40,11 +40,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const (
-	doCacheChunk = bool(true)
-	chunkFactor  = time.Duration(420)
-)
-
 func query(rsc *request.Resources, c cache.Cache, key string,
 	ranges byterange.Ranges, trq *timeseries.TimeRangeQuery,
 	span trace.Span) (*HTTPDocument, status.LookupStatus, byterange.Ranges, error) {
@@ -122,6 +117,8 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 	ranges byterange.Ranges, trq *timeseries.TimeRangeQuery) (*HTTPDocument, status.LookupStatus, byterange.Ranges, error) {
 
 	rsc := tc.Resources(ctx).(*request.Resources)
+	doCacheChunk := c.Configuration().UseCacheChunking
+	chunkFactor := time.Duration(c.Configuration().TimeseriesChunkFactor)
 
 	ctx, span := tspan.NewChildSpan(ctx, rsc.Tracer, "QueryCache")
 	if span != nil {
@@ -286,6 +283,8 @@ func write(rsc *request.Resources, c cache.Cache, d *HTTPDocument, key string, t
 func WriteCache(ctx context.Context, c cache.Cache, key string, d *HTTPDocument,
 	ttl time.Duration, compressTypes map[string]interface{}) error {
 
+	doCacheChunk := c.Configuration().UseCacheChunking
+	chunkFactor := time.Duration(c.Configuration().TimeseriesChunkFactor)
 	rsc := tc.Resources(ctx).(*request.Resources)
 
 	ctx, span := tspan.NewChildSpan(ctx, rsc.Tracer, "WriteCache")

--- a/pkg/proxy/engines/cache_test.go
+++ b/pkg/proxy/engines/cache_test.go
@@ -117,7 +117,7 @@ func TestCacheHitRangeRequest(t *testing.T) {
 	}
 
 	ranges := byterange.Ranges{byterange.Range{Start: 5, End: 10}}
-	d2, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges)
+	d2, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -161,7 +161,7 @@ func TestCacheHitRangeRequest2(t *testing.T) {
 	}
 
 	ranges := byterange.Ranges{byterange.Range{Start: 5, End: 10}}
-	d2, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges)
+	d2, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -204,7 +204,7 @@ func TestCacheHitRangeRequest3(t *testing.T) {
 	}
 
 	qrange := byterange.Ranges{byterange.Range{Start: 5, End: 10}}
-	_, _, deltas, err := QueryCache(ctx, cache, "testKey", qrange)
+	_, _, deltas, err := QueryCache(ctx, cache, "testKey", qrange, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -245,7 +245,7 @@ func TestPartialCacheMissRangeRequest(t *testing.T) {
 	}
 
 	ranges := byterange.Ranges{byterange.Range{Start: 5, End: 20}}
-	_, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges)
+	_, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -289,7 +289,7 @@ func TestFullCacheMissRangeRequest(t *testing.T) {
 	}
 
 	ranges := byterange.Ranges{byterange.Range{Start: 15, End: 20}}
-	_, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges)
+	_, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -340,7 +340,7 @@ func TestRangeRequestFromClient(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, _, deltas, err := QueryCache(ctx, cache, "testKey2", want)
+	_, _, deltas, err := QueryCache(ctx, cache, "testKey2", want, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -349,7 +349,7 @@ func TestRangeRequestFromClient(t *testing.T) {
 	}
 	want[0].Start = 20
 	want[0].End = 35
-	_, _, deltas, err = QueryCache(ctx, cache, "testKey2", want)
+	_, _, deltas, err = QueryCache(ctx, cache, "testKey2", want, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -392,7 +392,7 @@ func TestQueryCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	d2, _, _, err := QueryCache(ctx, cache, "testKey", nil)
+	d2, _, _, err := QueryCache(ctx, cache, "testKey", nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -405,7 +405,7 @@ func TestQueryCache(t *testing.T) {
 		t.Errorf("expected %d got %d", 200, d2.StatusCode)
 	}
 
-	_, _, _, err = QueryCache(ctx, cache, "testKey2", nil)
+	_, _, _, err = QueryCache(ctx, cache, "testKey2", nil, nil)
 	if err == nil {
 		t.Errorf("expected error")
 	}
@@ -414,7 +414,7 @@ func TestQueryCache(t *testing.T) {
 	cache.Remove("testKey")
 	cache.Configuration().Provider = "test"
 
-	_, _, _, err = QueryCache(ctx, cache, "testKey", byterange.Ranges{{Start: 0, End: 1}})
+	_, _, _, err = QueryCache(ctx, cache, "testKey", byterange.Ranges{{Start: 0, End: 1}}, nil)
 	if err == nil {
 		t.Errorf("expected error")
 	}
@@ -424,7 +424,7 @@ func TestQueryCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	d2, _, _, err = QueryCache(ctx, cache, "testKey", nil)
+	d2, _, _, err = QueryCache(ctx, cache, "testKey", nil, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/proxy/engines/document.go
+++ b/pkg/proxy/engines/document.go
@@ -64,6 +64,29 @@ func (d *HTTPDocument) SafeHeaderClone() http.Header {
 	return h
 }
 
+func (d *HTTPDocument) CloneEmptyContent() *HTTPDocument {
+	dd := &HTTPDocument{
+		StatusCode:    d.StatusCode,
+		Status:        d.Status,
+		Headers:       d.SafeHeaderClone(),
+		Body:          []byte{},
+		ContentLength: d.ContentLength,
+		ContentType:   d.ContentType,
+		// Ranges
+		// RangeParts
+		// StoredRangeParts
+		rangePartsLoaded: d.rangePartsLoaded,
+		isFulfillment:    d.isFulfillment,
+		isLoaded:         d.isLoaded,
+		timeseries:       nil,
+		headerLock:       sync.Mutex{},
+	}
+	if d.CachingPolicy != nil {
+		dd.CachingPolicy = d.CachingPolicy.Clone()
+	}
+	return dd
+}
+
 // Size returns the size of the HTTPDocument's headers, CachingPolicy, RangeParts, Body and timeseries data
 func (d *HTTPDocument) Size() int {
 	var i int

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -430,7 +430,7 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 
 	var err error
 	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, err =
-		QueryCache(pr.upstreamRequest.Context(), cc, pr.key, pr.wantedRanges)
+		QueryCache(pr.upstreamRequest.Context(), cc, pr.key, pr.wantedRanges, nil)
 	if err == nil || err == cache.ErrKNF {
 		if f, ok := cacheResponseHandlers[pr.cacheStatus]; ok {
 			f(pr)

--- a/pkg/proxy/engines/objectproxycache_test.go
+++ b/pkg/proxy/engines/objectproxycache_test.go
@@ -399,7 +399,7 @@ func TestObjectProxyCachePartialHitNotFresh(t *testing.T) {
 	cc := rsc.CacheClient
 	pr.cachingPolicy = GetRequestCachingPolicy(pr.Header)
 	pr.key = o.Host + "." + pr.DeriveCacheKey("")
-	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, _ = QueryCache(ctx, cc, pr.key, pr.wantedRanges)
+	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, _ = QueryCache(ctx, cc, pr.key, pr.wantedRanges, nil)
 	handleCacheKeyMiss(pr)
 
 	pr.cachingPolicy.CanRevalidate = false
@@ -434,7 +434,7 @@ func TestObjectProxyCachePartialHitFullResponse(t *testing.T) {
 	cc := rsc.CacheClient
 	pr.cachingPolicy = GetRequestCachingPolicy(pr.Header)
 	pr.key = o.Host + "." + pr.DeriveCacheKey("")
-	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, _ = QueryCache(ctx, cc, pr.key, pr.wantedRanges)
+	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, _ = QueryCache(ctx, cc, pr.key, pr.wantedRanges, nil)
 	handleCacheKeyMiss(pr)
 	handleCachePartialHit(pr)
 

--- a/pkg/proxy/request/resources.go
+++ b/pkg/proxy/request/resources.go
@@ -49,6 +49,8 @@ type Resources struct {
 	TSUnmarshaler     timeseries.UnmarshalerFunc
 	TSMarshaler       timeseries.MarshalWriterFunc
 	TSTransformer     func(timeseries.Timeseries)
+	CacheUnmarshaler  timeseries.UnmarshalerFunc
+	CacheMarshaler    timeseries.MarshalerFunc
 	TS                timeseries.Timeseries
 	TSReqestOptions   *timeseries.RequestOptions
 	Response          *http.Response


### PR DESCRIPTION
WIP pull request for cache chunking functionality. Currently:

- Setting `use_cache_chunking` in cache config allows timeseries data to be split into even-duration chunks to be cached, reducing the overhead of getting small amounts of data from remote caches
- Setting `timeseries_chunk_factor` in cache config will determine the `Extent` that a single chunk encompasses. By default, this is `420 * step`.

This functionality is supported by all caches except memory.

Work remaining:

- [ ] Non-timeseries chunking; determine chunk size and key without alignment (time.Truncate)
- [ ] Documentation update; cache documentation needs a description of the new feature
- [ ] Testing; figure out a way to run current tests on a cache with chunking enabled