### PR TITLE
Cache Chunking

### DIFF
--- a/docs/chunked-caching.md
+++ b/docs/chunked-caching.md
@@ -1,0 +1,43 @@
+# Chunked Caching
+
+## Overview
+
+In some use cases, it may be desirable to reduce the amount of data being transmitted from the cache for small requests. Trickster accomplishes this by *chunking* cache data, or splitting it into subdivisions of a configurable maximum size. Chunking can be configured per-cache and applies to both timeseries and byterange data.
+
+## Configuration
+
+Chunked caching can be enabled and disabled using `use_cache_chunking`:
+
+```yaml
+fs1:
+    cache_type: filesystem
+    provider: filesystem
+    use_cache_chunking: true
+    timeseries_chunk_factor: 420
+    byterange_chunk_size: 4096
+```
+
+`timeseries_chunk_factor` determines the maximum extent of timerange chunks, and `byterange_chunk_size` determines the maximum size of byterange chunks. See [Detail](#detail) for more information.
+
+## Detail
+
+### Timeseries
+
+Timeseries chunking splits the timeseries to be cached into parts with the same *duration*, but not necessarily the same literal size.
+
+- Determine a *chunk duration* by multiplying the timerange step by `timerange_chunk_factor` (default 420)
+- Determine the smallest possible extent that is aligned to the epoch along the chunk duration, while containing the entire timeseries
+- To write: Write each chunk size subextent under a subkey
+- To read: Read each subkey and merge the timeseries results
+
+### Byterange
+
+Byterange chunking splits the byterange into pieces with the same literal size. There are also some extra steps compared to the timeseries implementation to preserve the integrity of both full and partial responses being cached.
+
+- Determine a *chunk size* from `byterange_chunk_size` (default 4096)
+- Determine a range from the cache read/write request using the provided range or content length
+  - Failure to determine a range on write results in an error
+  - Failure to determine a range on read will read until the query fails
+- Determine a maximum range aligned along the chunk size that contains the entire byterange
+- To write: Write each chunk size range with `RangeParts` of all provided ranges cropped to that chunk range, under a subkey
+- To read: Read each subkey and reconsitute a body from `RangeParts`, if able

--- a/pkg/cache/options/defaults/defaults.go
+++ b/pkg/cache/options/defaults/defaults.go
@@ -24,4 +24,6 @@ const (
 	// DefaultCacheProviderID is the default cache providers ID for any defined cache
 	// and should align with DefaultCacheProvider
 	DefaultCacheProviderID = providers.Memory
+	// DefaultTimeseriesChunkFactor determines the extent of timeseries chunks, based on timeseries query step duration.
+	DefaultTimeseriesChunkFactor = 420
 )

--- a/pkg/cache/options/defaults/defaults.go
+++ b/pkg/cache/options/defaults/defaults.go
@@ -24,6 +24,8 @@ const (
 	// DefaultCacheProviderID is the default cache providers ID for any defined cache
 	// and should align with DefaultCacheProvider
 	DefaultCacheProviderID = providers.Memory
+	// DefaultUseCacheChunking determines if caches use chunking when no value is set in config.
+	DefaultUseCacheChunking = false
 	// DefaultTimeseriesChunkFactor determines the extent of timeseries chunks, based on timeseries query step duration.
 	DefaultTimeseriesChunkFactor = 420
 	// DefaultByterangeChunkSize determines the size of byterange chunks.

--- a/pkg/cache/options/defaults/defaults.go
+++ b/pkg/cache/options/defaults/defaults.go
@@ -26,4 +26,6 @@ const (
 	DefaultCacheProviderID = providers.Memory
 	// DefaultTimeseriesChunkFactor determines the extent of timeseries chunks, based on timeseries query step duration.
 	DefaultTimeseriesChunkFactor = 420
+	// DefaultByterangeChunkSize determines the size of byterange chunks.
+	DefaultByterangeChunkSize = 4096
 )

--- a/pkg/cache/options/options.go
+++ b/pkg/cache/options/options.go
@@ -72,6 +72,7 @@ func New() *Options {
 		BBolt:                 bbolt.New(),
 		Badger:                badger.New(),
 		Index:                 index.New(),
+		UseCacheChunking:      defaults.DefaultUseCacheChunking,
 		TimeseriesChunkFactor: defaults.DefaultTimeseriesChunkFactor,
 		ByterangeChunkSize:    defaults.DefaultByterangeChunkSize,
 	}

--- a/pkg/cache/options/options.go
+++ b/pkg/cache/options/options.go
@@ -55,6 +55,7 @@ type Options struct {
 	//  Synthetic Values
 	UseCacheChunking      bool `yaml:"use_cache_chunking"`
 	TimeseriesChunkFactor int  `yaml:"timeseries_chunk_factor"`
+	ByterangeChunkSize    int  `yaml:"byterange_chunk_size"`
 
 	// ProviderID represents the internal constant for the provided Provider string
 	// and is automatically populated at startup
@@ -72,6 +73,7 @@ func New() *Options {
 		Badger:                badger.New(),
 		Index:                 index.New(),
 		TimeseriesChunkFactor: defaults.DefaultTimeseriesChunkFactor,
+		ByterangeChunkSize:    defaults.DefaultByterangeChunkSize,
 	}
 }
 
@@ -122,6 +124,7 @@ func (cc *Options) Clone() *Options {
 
 	c.UseCacheChunking = cc.UseCacheChunking
 	c.TimeseriesChunkFactor = cc.TimeseriesChunkFactor
+	c.ByterangeChunkSize = cc.ByterangeChunkSize
 
 	return c
 
@@ -139,7 +142,8 @@ func (cc *Options) Equal(cc2 *Options) bool {
 		cc.Provider == cc2.Provider &&
 		cc.ProviderID == cc2.ProviderID &&
 		cc.UseCacheChunking == cc2.UseCacheChunking &&
-		cc.TimeseriesChunkFactor == cc2.TimeseriesChunkFactor
+		cc.TimeseriesChunkFactor == cc2.TimeseriesChunkFactor &&
+		cc.ByterangeChunkSize == cc2.ByterangeChunkSize
 }
 
 var errMaxSizeBackoffBytesTooBig = errors.New("MaxSizeBackoffBytes can't be larger than MaxSizeBytes")
@@ -325,6 +329,10 @@ func (l Lookup) SetDefaults(metadata yamlx.KeyLookup, activeCaches strutil.Looku
 
 		if metadata.IsDefined("caches", k, "timeseries_chunk_factor") {
 			cc.TimeseriesChunkFactor = v.TimeseriesChunkFactor
+		}
+
+		if metadata.IsDefined("caches", k, "byterange_chunk_size") {
+			cc.ByterangeChunkSize = v.ByterangeChunkSize
 		}
 
 		l[k] = cc

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -40,11 +40,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const (
-	doCacheChunk = bool(true)
-	chunkFactor  = time.Duration(420)
-)
-
 func query(rsc *request.Resources, c cache.Cache, key string,
 	ranges byterange.Ranges, trq *timeseries.TimeRangeQuery,
 	span trace.Span) (*HTTPDocument, status.LookupStatus, byterange.Ranges, error) {
@@ -122,6 +117,8 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 	ranges byterange.Ranges, trq *timeseries.TimeRangeQuery) (*HTTPDocument, status.LookupStatus, byterange.Ranges, error) {
 
 	rsc := tc.Resources(ctx).(*request.Resources)
+	doCacheChunk := c.Configuration().UseCacheChunking
+	chunkFactor := time.Duration(c.Configuration().TimeseriesChunkFactor)
 
 	ctx, span := tspan.NewChildSpan(ctx, rsc.Tracer, "QueryCache")
 	if span != nil {
@@ -286,6 +283,8 @@ func write(rsc *request.Resources, c cache.Cache, d *HTTPDocument, key string, t
 func WriteCache(ctx context.Context, c cache.Cache, key string, d *HTTPDocument,
 	ttl time.Duration, compressTypes map[string]interface{}) error {
 
+	doCacheChunk := c.Configuration().UseCacheChunking
+	chunkFactor := time.Duration(c.Configuration().TimeseriesChunkFactor)
 	rsc := tc.Resources(ctx).(*request.Resources)
 
 	ctx, span := tspan.NewChildSpan(ctx, rsc.Tracer, "WriteCache")

--- a/pkg/proxy/engines/cache_test.go
+++ b/pkg/proxy/engines/cache_test.go
@@ -117,7 +117,7 @@ func TestCacheHitRangeRequest(t *testing.T) {
 	}
 
 	ranges := byterange.Ranges{byterange.Range{Start: 5, End: 10}}
-	d2, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges)
+	d2, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -161,7 +161,7 @@ func TestCacheHitRangeRequest2(t *testing.T) {
 	}
 
 	ranges := byterange.Ranges{byterange.Range{Start: 5, End: 10}}
-	d2, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges)
+	d2, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -204,7 +204,7 @@ func TestCacheHitRangeRequest3(t *testing.T) {
 	}
 
 	qrange := byterange.Ranges{byterange.Range{Start: 5, End: 10}}
-	_, _, deltas, err := QueryCache(ctx, cache, "testKey", qrange)
+	_, _, deltas, err := QueryCache(ctx, cache, "testKey", qrange, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -245,7 +245,7 @@ func TestPartialCacheMissRangeRequest(t *testing.T) {
 	}
 
 	ranges := byterange.Ranges{byterange.Range{Start: 5, End: 20}}
-	_, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges)
+	_, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -289,7 +289,7 @@ func TestFullCacheMissRangeRequest(t *testing.T) {
 	}
 
 	ranges := byterange.Ranges{byterange.Range{Start: 15, End: 20}}
-	_, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges)
+	_, _, deltas, err := QueryCache(ctx, cache, "testKey", ranges, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -340,7 +340,7 @@ func TestRangeRequestFromClient(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	_, _, deltas, err := QueryCache(ctx, cache, "testKey2", want)
+	_, _, deltas, err := QueryCache(ctx, cache, "testKey2", want, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -349,7 +349,7 @@ func TestRangeRequestFromClient(t *testing.T) {
 	}
 	want[0].Start = 20
 	want[0].End = 35
-	_, _, deltas, err = QueryCache(ctx, cache, "testKey2", want)
+	_, _, deltas, err = QueryCache(ctx, cache, "testKey2", want, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -392,7 +392,7 @@ func TestQueryCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	d2, _, _, err := QueryCache(ctx, cache, "testKey", nil)
+	d2, _, _, err := QueryCache(ctx, cache, "testKey", nil, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -405,7 +405,7 @@ func TestQueryCache(t *testing.T) {
 		t.Errorf("expected %d got %d", 200, d2.StatusCode)
 	}
 
-	_, _, _, err = QueryCache(ctx, cache, "testKey2", nil)
+	_, _, _, err = QueryCache(ctx, cache, "testKey2", nil, nil)
 	if err == nil {
 		t.Errorf("expected error")
 	}
@@ -414,7 +414,7 @@ func TestQueryCache(t *testing.T) {
 	cache.Remove("testKey")
 	cache.Configuration().Provider = "test"
 
-	_, _, _, err = QueryCache(ctx, cache, "testKey", byterange.Ranges{{Start: 0, End: 1}})
+	_, _, _, err = QueryCache(ctx, cache, "testKey", byterange.Ranges{{Start: 0, End: 1}}, nil)
 	if err == nil {
 		t.Errorf("expected error")
 	}
@@ -424,7 +424,7 @@ func TestQueryCache(t *testing.T) {
 		t.Error(err)
 	}
 
-	d2, _, _, err = QueryCache(ctx, cache, "testKey", nil)
+	d2, _, _, err = QueryCache(ctx, cache, "testKey", nil, nil)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/proxy/engines/deltaproxycache_test.go
+++ b/pkg/proxy/engines/deltaproxycache_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
-	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	tu "github.com/trickstercache/trickster/v2/pkg/testutil"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
 // test queries
@@ -1076,7 +1076,8 @@ func TestDeltaProxyCacheRequestWithUnmarshalAndUpstreamErrors(t *testing.T) {
 
 	client := rsc.BackendClient.(*TestClient)
 	o := rsc.BackendOptions
-	rsc.CacheConfig.Provider = "test" // disable direct-memory and force marshaling
+	rsc.CacheConfig.Provider = "test"        // disable direct-memory and force marshaling
+	rsc.CacheConfig.UseCacheChunking = false // this test writes directly to cache, bypassing chunk key derivation
 
 	client.RangeCacheKey = "testkey"
 

--- a/pkg/proxy/engines/document.go
+++ b/pkg/proxy/engines/document.go
@@ -64,6 +64,29 @@ func (d *HTTPDocument) SafeHeaderClone() http.Header {
 	return h
 }
 
+func (d *HTTPDocument) CloneEmptyContent() *HTTPDocument {
+	dd := &HTTPDocument{
+		StatusCode:    d.StatusCode,
+		Status:        d.Status,
+		Headers:       d.SafeHeaderClone(),
+		Body:          []byte{},
+		ContentLength: d.ContentLength,
+		ContentType:   d.ContentType,
+		// Ranges
+		// RangeParts
+		// StoredRangeParts
+		rangePartsLoaded: d.rangePartsLoaded,
+		isFulfillment:    d.isFulfillment,
+		isLoaded:         d.isLoaded,
+		timeseries:       nil,
+		headerLock:       sync.Mutex{},
+	}
+	if d.CachingPolicy != nil {
+		dd.CachingPolicy = d.CachingPolicy.Clone()
+	}
+	return dd
+}
+
 // Size returns the size of the HTTPDocument's headers, CachingPolicy, RangeParts, Body and timeseries data
 func (d *HTTPDocument) Size() int {
 	var i int

--- a/pkg/proxy/engines/document.go
+++ b/pkg/proxy/engines/document.go
@@ -73,7 +73,7 @@ func (d *HTTPDocument) CloneEmptyContent() *HTTPDocument {
 		ContentLength: d.ContentLength,
 		ContentType:   d.ContentType,
 		// Ranges
-		// RangeParts
+		RangeParts: make(byterange.MultipartByteRanges),
 		// StoredRangeParts
 		rangePartsLoaded: d.rangePartsLoaded,
 		isFulfillment:    d.isFulfillment,

--- a/pkg/proxy/engines/objectproxycache.go
+++ b/pkg/proxy/engines/objectproxycache.go
@@ -430,7 +430,7 @@ func fetchViaObjectProxyCache(w io.Writer, r *http.Request) (*http.Response, sta
 
 	var err error
 	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, err =
-		QueryCache(pr.upstreamRequest.Context(), cc, pr.key, pr.wantedRanges)
+		QueryCache(pr.upstreamRequest.Context(), cc, pr.key, pr.wantedRanges, nil)
 	if err == nil || err == cache.ErrKNF {
 		if f, ok := cacheResponseHandlers[pr.cacheStatus]; ok {
 			f(pr)

--- a/pkg/proxy/engines/objectproxycache_test.go
+++ b/pkg/proxy/engines/objectproxycache_test.go
@@ -399,7 +399,7 @@ func TestObjectProxyCachePartialHitNotFresh(t *testing.T) {
 	cc := rsc.CacheClient
 	pr.cachingPolicy = GetRequestCachingPolicy(pr.Header)
 	pr.key = o.Host + "." + pr.DeriveCacheKey("")
-	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, _ = QueryCache(ctx, cc, pr.key, pr.wantedRanges)
+	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, _ = QueryCache(ctx, cc, pr.key, pr.wantedRanges, nil)
 	handleCacheKeyMiss(pr)
 
 	pr.cachingPolicy.CanRevalidate = false
@@ -434,7 +434,7 @@ func TestObjectProxyCachePartialHitFullResponse(t *testing.T) {
 	cc := rsc.CacheClient
 	pr.cachingPolicy = GetRequestCachingPolicy(pr.Header)
 	pr.key = o.Host + "." + pr.DeriveCacheKey("")
-	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, _ = QueryCache(ctx, cc, pr.key, pr.wantedRanges)
+	pr.cacheDocument, pr.cacheStatus, pr.neededRanges, _ = QueryCache(ctx, cc, pr.key, pr.wantedRanges, nil)
 	handleCacheKeyMiss(pr)
 	handleCachePartialHit(pr)
 

--- a/pkg/proxy/engines/proxy_request_test.go
+++ b/pkg/proxy/engines/proxy_request_test.go
@@ -350,7 +350,7 @@ func TestStoreTrueContentType(t *testing.T) {
 	pr.trueContentType = expected
 
 	err := pr.store()
-	if err != nil {
+	if err != nil && !request.GetResources(r).CacheConfig.UseCacheChunking {
 		t.Error(err)
 	}
 

--- a/pkg/proxy/ranges/byterange/range.go
+++ b/pkg/proxy/ranges/byterange/range.go
@@ -231,6 +231,20 @@ func ParseContentRangeHeader(input string) (Range, int64, error) {
 	return Range{}, -1, errors.New("invalid input format")
 }
 
+func (brs Ranges) Compressed() Ranges {
+	out := Ranges{}
+	i := 0
+	for _, br := range brs {
+		if i > 0 && out[i-1].End == br.Start-1 {
+			out[i-1].End = br.End
+		} else {
+			out = append(out, br)
+			i++
+		}
+	}
+	return out
+}
+
 // ParseRangeHeader returns a Ranges list from the provided input,
 // which must be a properly-formatted HTTP 'Range' Request Header value
 func ParseRangeHeader(input string) Ranges {

--- a/pkg/proxy/request/resources.go
+++ b/pkg/proxy/request/resources.go
@@ -49,6 +49,8 @@ type Resources struct {
 	TSUnmarshaler     timeseries.UnmarshalerFunc
 	TSMarshaler       timeseries.MarshalWriterFunc
 	TSTransformer     func(timeseries.Timeseries)
+	CacheUnmarshaler  timeseries.UnmarshalerFunc
+	CacheMarshaler    timeseries.MarshalerFunc
 	TS                timeseries.Timeseries
 	TSReqestOptions   *timeseries.RequestOptions
 	Response          *http.Response


### PR DESCRIPTION
Introduced _chunking_ to cache functionality, splitting data into smaller chunks to allow for more efficient access, especially in remote caches like Redis.

- [x] Timeseries data + configuration
- [x] Byte data + configuration
- [ ] Testing
- [x] Documentation