### PR TITLE
Flux fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This docker file is for local dev, the official Dockerfile is at
 # https://github.com/trickstercache/trickster-docker-images/
 
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 COPY . /go/src/github.com/trickstercache/trickster
 WORKDIR /go/src/github.com/trickstercache/trickster
 

--- a/pkg/backends/influxdb/flux/flux.go
+++ b/pkg/backends/influxdb/flux/flux.go
@@ -37,7 +37,9 @@ type RangeStatement struct {
 
 func (stmt *RangeStatement) Kind() StatementKind { return Range }
 func (stmt *RangeStatement) String() string {
-	return fmt.Sprintf("|> range(start: %d, stop: %d)\n", stmt.ext.Start.UnixNano(), stmt.ext.End.UnixNano())
+	start := stmt.ext.Start.Format(time.RFC3339)
+	stop := stmt.ext.End.Format(time.RFC3339)
+	return fmt.Sprintf("|> range(start: %s, stop: %s)\n", start, stop)
 }
 
 type Query struct {

--- a/pkg/backends/influxdb/flux/flux.go
+++ b/pkg/backends/influxdb/flux/flux.go
@@ -1,13 +1,65 @@
 package flux
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
+const (
+	// ConstStatements are any statements that Trickster doesn't care about modifying.
+	// This is most statements.
+	Const = StatementKind(iota)
+	// RangeStatements are the range(...) contained in the query.
+	Range
+)
+
+type StatementKind int
+
+type Statement interface {
+	// Kind() returns the StatementKind of the statement.
+	Kind() StatementKind
+	// String() returns a string representation of the statement.
+	String() string
+}
+
+type ConstStatement struct {
+	stmt string
+}
+
+func (stmt *ConstStatement) Kind() StatementKind { return Const }
+func (stmt *ConstStatement) String() string      { return stmt.stmt }
+
+type RangeStatement struct {
+	ext timeseries.Extent
+}
+
+func (stmt *RangeStatement) Kind() StatementKind { return Range }
+func (stmt *RangeStatement) String() string {
+	return fmt.Sprintf("|> range(start: %d, stop: %d)\n", stmt.ext.Start.UnixNano(), stmt.ext.End.UnixNano())
+}
+
 type Query struct {
-	Extent    timeseries.Extent
-	Step      time.Duration
-	Statement string
+	stmts  []Statement
+	Extent timeseries.Extent
+	Step   time.Duration
+}
+
+func (q *Query) SetExtent(ext timeseries.Extent) {
+	q.Extent = ext
+	for _, stmt := range q.stmts {
+		if rs, ok := stmt.(*RangeStatement); ok {
+			rs.ext = ext
+			break
+		}
+	}
+}
+
+func (q *Query) String() string {
+	var out string
+	for _, stmt := range q.stmts {
+		out += stmt.String()
+	}
+	return out
 }

--- a/pkg/backends/influxdb/flux/flux.go
+++ b/pkg/backends/influxdb/flux/flux.go
@@ -1,8 +1,13 @@
 package flux
 
-import "github.com/trickstercache/trickster/v2/pkg/timeseries"
+import (
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+)
 
 type Query struct {
 	Extent    timeseries.Extent
+	Step      time.Duration
 	Statement string
 }

--- a/pkg/backends/influxdb/flux/parser.go
+++ b/pkg/backends/influxdb/flux/parser.go
@@ -34,6 +34,7 @@ func (p *Parser) ParseQuery() (*Query, bool, error) {
 	var hasRange, hasWindow bool
 	for {
 		line, err := r.ReadString('\n')
+		line = strings.TrimSpace(line) + "\n"
 		var stmt Statement
 		if err != nil {
 			if err == io.EOF {
@@ -119,6 +120,9 @@ func parseRangeFilter(query string, at int) (Statement, error) {
 	}
 	if start.IsZero() {
 		return nil, ErrFluxSemantics("range() expressions require a valid start argument")
+	}
+	if stop.IsZero() {
+		stop = time.Now()
 	}
 	return &RangeStatement{timeseries.Extent{Start: start, End: stop}}, nil
 }

--- a/pkg/backends/influxdb/flux/parser.go
+++ b/pkg/backends/influxdb/flux/parser.go
@@ -50,6 +50,7 @@ func (p *Parser) ParseQuery() (*Query, bool, error) {
 		if err != nil {
 			return nil, false, err
 		}
+		q.Statement = content
 	}
 	return q, false, nil
 }

--- a/pkg/backends/influxdb/flux/parser_test.go
+++ b/pkg/backends/influxdb/flux/parser_test.go
@@ -52,7 +52,7 @@ func TestParserOK(t *testing.T) {
 	for test, script := range testsOK {
 		t.Run(test, func(t *testing.T) {
 			p := NewParser(strings.NewReader(script))
-			_, err := p.ParseQuery()
+			_, _, err := p.ParseQuery()
 			if err != nil {
 				t.Errorf("failed to parse valid script: %s", err)
 			}
@@ -61,7 +61,7 @@ func TestParserOK(t *testing.T) {
 	for test, script := range testsNotOK {
 		t.Run(test, func(t *testing.T) {
 			p := NewParser(strings.NewReader(script))
-			_, err := p.ParseQuery()
+			_, _, err := p.ParseQuery()
 			if err == nil {
 				t.Errorf("parsed invalid script")
 			}
@@ -72,7 +72,7 @@ func TestParserOK(t *testing.T) {
 func TestRelativeDuration(t *testing.T) {
 	p := NewParser(strings.NewReader(testRelativeDuration))
 	now := time.Now()
-	q, err := p.ParseQuery()
+	q, _, err := p.ParseQuery()
 	if err != nil {
 		t.Errorf("failed to parse valid script: %s", err)
 		t.FailNow()
@@ -94,7 +94,7 @@ func TestRelativeDuration(t *testing.T) {
 
 func TestRFC3999Time(t *testing.T) {
 	p := NewParser(strings.NewReader(testAbsoluteTime))
-	q, err := p.ParseQuery()
+	q, _, err := p.ParseQuery()
 	if err != nil {
 		t.Errorf("failed to parse valid script: %s", err)
 		t.FailNow()
@@ -114,7 +114,7 @@ func TestRFC3999Time(t *testing.T) {
 
 func TestUnixTime(t *testing.T) {
 	p := NewParser(strings.NewReader(testUnixTime))
-	q, err := p.ParseQuery()
+	q, _, err := p.ParseQuery()
 	if err != nil {
 		t.Errorf("failed to parse valid script: %s", err)
 		t.FailNow()

--- a/pkg/backends/influxdb/flux/parser_test.go
+++ b/pkg/backends/influxdb/flux/parser_test.go
@@ -12,29 +12,29 @@ var testRelativeDuration string = `from("test-bucket")
 	|> range(start: -7d, stop: -6d)
 	|> window(every: 1m)
 	|> mean()
-	|> window(every: inf)
+	|> window(every: 10s)
 `
 var testAbsoluteTime string = `from("test-bucket")
 	|> range(start: 2023-01-01T00:00:00Z, stop: 2023-01-08T00:00:00Z)
 	|> window(every: 5m)
 	|> mean()
-	|> window(every: inf)
+	|> window(every: 10s)
 `
-var testUnixTime string = `from("test-bucket"
+var testUnixTime string = `from("test-bucket")
 	|> range(start: 1672531200, stop: 1673136000)
 	|> aggregateWindow(every: 30s, fn: mean)
 `
 
-var testNoRange string = `from("test-bucket
+var testNoRange string = `from("test-bucket")
 	|> aggregateWindow(every: 30s, fn: mean)
-)`
-var testNoStart string = `from("test-bucket
+`
+var testNoStart string = `from("test-bucket")
 	|> range(stop: 10)
 	|> aggregateWindow(every: 30s, fn: mean)
-)`
-var testNoWindow string = `from("test-bucket"
+`
+var testNoWindow string = `from("test-bucket")
 	|> range(start: 0, stop: 10)
-)`
+`
 
 var testsOK map[string]string = map[string]string{
 	"RelativeDuration": testRelativeDuration,

--- a/pkg/backends/influxdb/flux/parser_test.go
+++ b/pkg/backends/influxdb/flux/parser_test.go
@@ -10,18 +10,42 @@ import (
 
 var testRelativeDuration string = `from("test-bucket")
 	|> range(start: -7d, stop: -6d)
+	|> window(every: 1m)
+	|> mean()
+	|> window(every: inf)
 `
 var testAbsoluteTime string = `from("test-bucket")
 	|> range(start: 2023-01-01T00:00:00Z, stop: 2023-01-08T00:00:00Z)
+	|> window(every: 5m)
+	|> mean()
+	|> window(every: inf)
 `
 var testUnixTime string = `from("test-bucket"
 	|> range(start: 1672531200, stop: 1673136000)
+	|> aggregateWindow(every: 30s, fn: mean)
 `
+
+var testNoRange string = `from("test-bucket
+	|> aggregateWindow(every: 30s, fn: mean)
+)`
+var testNoStart string = `from("test-bucket
+	|> range(stop: 10)
+	|> aggregateWindow(every: 30s, fn: mean)
+)`
+var testNoWindow string = `from("test-bucket"
+	|> range(start: 0, stop: 10)
+)`
 
 var testsOK map[string]string = map[string]string{
 	"RelativeDuration": testRelativeDuration,
 	"AbsoluteTime":     testAbsoluteTime,
 	"UnixTime":         testUnixTime,
+}
+
+var testsNotOK map[string]string = map[string]string{
+	"FailNoRange":  testNoRange,
+	"FailNoStart":  testNoStart,
+	"FailNoWindow": testNoWindow,
 }
 
 func TestParserOK(t *testing.T) {
@@ -31,6 +55,15 @@ func TestParserOK(t *testing.T) {
 			_, err := p.ParseQuery()
 			if err != nil {
 				t.Errorf("failed to parse valid script: %s", err)
+			}
+		})
+	}
+	for test, script := range testsNotOK {
+		t.Run(test, func(t *testing.T) {
+			p := NewParser(strings.NewReader(script))
+			_, err := p.ParseQuery()
+			if err == nil {
+				t.Errorf("parsed invalid script")
 			}
 		})
 	}
@@ -54,6 +87,9 @@ func TestRelativeDuration(t *testing.T) {
 	if !stop.Equal(qStopApprox) {
 		t.Errorf("query stop time incorrect; got %v, should be %v", qStopApprox, stop)
 	}
+	if q.Step != timeconv.Minute {
+		t.Errorf("query step incorrect; got %v, should be %v", q.Step, timeconv.Minute)
+	}
 }
 
 func TestRFC3999Time(t *testing.T) {
@@ -71,6 +107,9 @@ func TestRFC3999Time(t *testing.T) {
 	if !stop.Equal(q.Extent.End) {
 		t.Errorf("query stop time incorrect; got %v, should be %v", q.Extent.End, stop)
 	}
+	if q.Step != 5*timeconv.Minute {
+		t.Errorf("query step incorrect; got %v, should be %v", q.Step, 5*timeconv.Minute)
+	}
 }
 
 func TestUnixTime(t *testing.T) {
@@ -87,5 +126,8 @@ func TestUnixTime(t *testing.T) {
 	}
 	if !stop.Equal(q.Extent.End) {
 		t.Errorf("query stop time incorrect; got %v, should be %v", q.Extent.End, stop)
+	}
+	if q.Step != 30*timeconv.Second {
+		t.Errorf("query step incorrect; got %v, should be %v", q.Step, 30*timeconv.Second)
 	}
 }

--- a/pkg/backends/influxdb/handler_query.go
+++ b/pkg/backends/influxdb/handler_query.go
@@ -104,7 +104,7 @@ func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuer
 
 	// Try to parse using Flux.
 	fp := flux.NewParser(strings.NewReader(trq.Statement))
-	if fq, err := fp.ParseQuery(); err == nil {
+	if fq, canOPC, err := fp.ParseQuery(); err == nil || canOPC {
 		if fq.Extent.End.IsZero() {
 			fq.Extent.End = time.Now()
 		}
@@ -123,7 +123,7 @@ func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuer
 		qt.Set(upQuery, trq.Statement)
 		// Swap in the Tokenzed Query in the Url Params
 		trq.TemplateURL.RawQuery = qt.Encode()
-		return trq, rlo, cacheError != nil, cacheError
+		return trq, rlo, canOPC || cacheError != nil, cacheError
 	}
 
 	p := influxql.NewParser(strings.NewReader(trq.Statement))

--- a/pkg/backends/influxdb/handler_query.go
+++ b/pkg/backends/influxdb/handler_query.go
@@ -73,27 +73,25 @@ func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuer
 
 	var valuer = &influxql.NowValuer{Now: time.Now()}
 
-	v, _, _ := params.GetRequestValues(r)
-	statement := v.Get(upQuery)
+	values, _, _ := params.GetRequestValues(r)
+	statement := values.Get(upQuery)
 	if methods.HasBody(r.Method) {
 		raw, err := io.ReadAll(r.Body)
 		if err != nil {
 			return nil, nil, false, errors.ParseRequestBody(err)
 		}
 		statement = string(raw)
-		v.Del(upQuery)
-		r.URL.RawQuery = v.Encode()
 	}
 	if statement == "" {
 		return nil, nil, false, errors.MissingURLParam(upQuery)
 	}
 	trq.Statement = statement
 
-	if b, ok := epochToFlag[v.Get(upEpoch)]; ok {
+	if b, ok := epochToFlag[values.Get(upEpoch)]; ok {
 		rlo.TimeFormat = b
 	}
 
-	if v.Get(upPretty) == "true" {
+	if values.Get(upPretty) == "true" {
 		rlo.OutputFormat = 1
 	} else if r != nil && r.Header != nil &&
 		r.Header.Get(headers.NameAccept) == headers.ValueApplicationCSV {
@@ -119,7 +117,7 @@ func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuer
 		trq.Statement = fq.Statement
 		trq.ParsedQuery = fq
 		trq.TemplateURL = urls.Clone(r.URL)
-		qt := url.Values(http.Header(v).Clone())
+		qt := url.Values(http.Header(values).Clone())
 		qt.Set(upQuery, trq.Statement)
 		// Swap in the Tokenzed Query in the Url Params
 		trq.TemplateURL.RawQuery = qt.Encode()
@@ -191,7 +189,7 @@ func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuer
 	trq.Statement = strings.Join(statements, " ; ")
 	trq.ParsedQuery = q
 	trq.TemplateURL = urls.Clone(r.URL)
-	qt := url.Values(http.Header(v).Clone())
+	qt := url.Values(http.Header(values).Clone())
 	qt.Set(upQuery, trq.Statement)
 
 	// Swap in the Tokenzed Query in the Url Params

--- a/pkg/backends/influxdb/handler_query.go
+++ b/pkg/backends/influxdb/handler_query.go
@@ -125,7 +125,7 @@ func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuer
 			cacheError = errors.ErrNotTimeRangeQuery
 		}
 		trq.Step = fq.Step
-		trq.Statement = fq.Statement
+		trq.Statement = fq.String()
 		trq.ParsedQuery = fq
 		trq.TemplateURL = urls.Clone(r.URL)
 		qt := url.Values(http.Header(values).Clone())

--- a/pkg/backends/influxdb/handler_query.go
+++ b/pkg/backends/influxdb/handler_query.go
@@ -18,7 +18,6 @@ package influxdb
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -43,12 +42,9 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 	qp, qb, fromBody := params.GetRequestValues(r)
 	q := strings.Trim(strings.ToLower(qp.Get(upQuery)), " \t\n")
 	if q == "" {
-		fmt.Println("no query")
 		if qb != "" && fromBody {
-			fmt.Println("using body")
 			q = qb
 		} else {
-			fmt.Println("proxying")
 			c.ProxyHandler(w, r)
 			return
 		}

--- a/pkg/backends/influxdb/handler_query.go
+++ b/pkg/backends/influxdb/handler_query.go
@@ -115,6 +115,7 @@ func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuer
 			// different time ranges
 			cacheError = errors.ErrNotTimeRangeQuery
 		}
+		trq.Step = fq.Step
 		trq.Statement = fq.Statement
 		trq.ParsedQuery = fq
 		trq.TemplateURL = urls.Clone(r.URL)

--- a/pkg/backends/influxdb/handler_query_test.go
+++ b/pkg/backends/influxdb/handler_query_test.go
@@ -69,7 +69,6 @@ func TestParseTimeRangeQuery(t *testing.T) {
 
 	body := testVals["q"][0]
 	req, _ = http.NewRequest(http.MethodPost, "http://blah.com/", io.NopCloser(strings.NewReader(body)))
-	// req.Header.Set("Content-Type", "text/plain")
 	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
 
 	res, _, _, err = client.ParseTimeRangeQuery(req)

--- a/pkg/backends/influxdb/handler_query_test.go
+++ b/pkg/backends/influxdb/handler_query_test.go
@@ -17,12 +17,11 @@
 package influxdb
 
 import (
-	"bytes"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
@@ -39,6 +38,7 @@ var testRawQuery = testVals.Encode()
 var testFluxVals = url.Values(map[string][]string{
 	"q": {`from("test-bucket")
 	|> range(start: -7d, stop: -6d)
+	|> aggregateWindow(every: 1m, func: mean)
 	`},
 	"epoch": {"ms"},
 })
@@ -67,10 +67,10 @@ func TestParseTimeRangeQuery(t *testing.T) {
 		}
 	}
 
-	req, _ = http.NewRequest(http.MethodPost, "http://blah.com/",
-		io.Reader(bytes.NewBufferString(testRawQuery)))
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Content-Length", strconv.Itoa(len(testRawQuery)))
+	body := testVals["q"][0]
+	req, _ = http.NewRequest(http.MethodPost, "http://blah.com/", io.NopCloser(strings.NewReader(body)))
+	// req.Header.Set("Content-Type", "text/plain")
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
 
 	res, _, _, err = client.ParseTimeRangeQuery(req)
 	if err != nil {
@@ -92,7 +92,6 @@ func TestParseTimeRangeQuery(t *testing.T) {
 			Path:     "/",
 			RawQuery: testFluxQuery,
 		}}
-	fmt.Println(req.URL.RawQuery)
 	res, _, _, err = client.ParseTimeRangeQuery(req)
 	if err != nil {
 		t.Error(err)

--- a/pkg/backends/influxdb/model/unmarshal.go
+++ b/pkg/backends/influxdb/model/unmarshal.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
+	"fmt"
 	"io"
 	"sort"
 	"strconv"
@@ -55,6 +56,7 @@ func decodeCSV(reader io.Reader) (*WFDocument, error) {
 	if err != nil {
 		return nil, err
 	}
+	fmt.Println(records)
 	var columns []string
 	var rows int = len(records) - 1
 	if len(records) == 0 {
@@ -102,9 +104,9 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 	}
 	var bck bytes.Buffer
 	tr := io.TeeReader(reader, &bck)
-	wfd, err := decodeCSV(tr)
+	wfd, err := decodeJSON(tr)
 	if err != nil {
-		wfd, err = decodeJSON(&bck)
+		wfd, err = decodeCSV(&bck)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/backends/influxdb/model/unmarshal.go
+++ b/pkg/backends/influxdb/model/unmarshal.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
-	"fmt"
 	"io"
 	"sort"
 	"strconv"
@@ -52,11 +51,12 @@ func decodeJSON(reader io.Reader) (*WFDocument, error) {
 }
 
 func decodeCSV(reader io.Reader) (*WFDocument, error) {
+	b, _ := io.ReadAll(reader)
+	reader = bytes.NewReader(b)
 	records, err := csv.NewReader(reader).ReadAll()
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(records)
 	var columns []string
 	var rows int = len(records) - 1
 	if len(records) == 0 {
@@ -104,9 +104,9 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 	}
 	var bck bytes.Buffer
 	tr := io.TeeReader(reader, &bck)
-	wfd, err := decodeJSON(tr)
+	wfd, err := decodeCSV(tr)
 	if err != nil {
-		wfd, err = decodeCSV(&bck)
+		wfd, err = decodeJSON(&bck)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/backends/influxdb/model/unmarshal.go
+++ b/pkg/backends/influxdb/model/unmarshal.go
@@ -56,9 +56,13 @@ func decodeCSV(reader io.Reader) (*WFDocument, error) {
 		return nil, err
 	}
 	var columns []string
+	var rows int = len(records) - 1
+	if len(records) == 0 {
+		rows = 0
+	}
 	wfd := &WFDocument{
 		Results: []WFResult{
-			{StatementID: 0, SeriesList: make([]models.Row, len(records)-1)},
+			{StatementID: 0, SeriesList: make([]models.Row, rows)},
 		},
 	}
 	for ri, r := range records {

--- a/pkg/backends/influxdb/model/unmarshal_test.go
+++ b/pkg/backends/influxdb/model/unmarshal_test.go
@@ -55,11 +55,6 @@ func TestUnmarshalTimeseries(t *testing.T) {
 		Statement: "hello",
 	}
 
-	_, err = UnmarshalTimeseries([]byte("{}"), trq)
-	if err != timeseries.ErrInvalidBody {
-		t.Error("expected ErrInvalidBody got", err)
-	}
-
 	_, err = UnmarshalTimeseries([]byte(testDoc01), trq)
 	if err != nil {
 		t.Error(err)

--- a/pkg/backends/influxdb/model/unmarshal_test.go
+++ b/pkg/backends/influxdb/model/unmarshal_test.go
@@ -17,7 +17,6 @@
 package model
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
@@ -54,11 +53,6 @@ func TestUnmarshalTimeseries(t *testing.T) {
 
 	trq := &timeseries.TimeRangeQuery{
 		Statement: "hello",
-	}
-
-	_, err = UnmarshalTimeseries([]byte("not-json:"), trq)
-	if !strings.HasPrefix(err.Error(), "invalid character ") {
-		t.Error("expected error for invalid character, got", err)
 	}
 
 	_, err = UnmarshalTimeseries([]byte("{}"), trq)

--- a/pkg/backends/influxdb/routes.go
+++ b/pkg/backends/influxdb/routes.go
@@ -50,6 +50,15 @@ func (c *Client) DefaultPathConfigs(o *bo.Options) map[string]*po.Options {
 			MatchTypeName:   "exact",
 			MatchType:       matching.PathMatchTypeExact,
 		},
+		"/" + apiv2Query: {
+			Path:            "/" + apiv2Query,
+			HandlerName:     mnQuery,
+			Methods:         []string{http.MethodGet, http.MethodPost},
+			CacheKeyParams:  []string{upDB, upQuery, "u", "p"},
+			CacheKeyHeaders: []string{},
+			MatchTypeName:   "exact",
+			MatchType:       matching.PathMatchTypeExact,
+		},
 		"/": {
 			Path:          "/",
 			HandlerName:   "proxy",

--- a/pkg/backends/influxdb/routes_test.go
+++ b/pkg/backends/influxdb/routes_test.go
@@ -59,9 +59,9 @@ func TestDefaultPathConfigs(t *testing.T) {
 		t.Errorf("expected to find path named: %s", "/")
 	}
 
-	const expectedLen = 2
+	const expectedLen = 3
 	if len(rsc.BackendOptions.Paths) != expectedLen {
-		t.Errorf("expected ordered length to be: %d", expectedLen)
+		t.Errorf("expected ordered length to be: %d, got: %d", expectedLen, len(rsc.BackendOptions.Paths))
 	}
 
 }

--- a/pkg/backends/influxdb/url.go
+++ b/pkg/backends/influxdb/url.go
@@ -74,7 +74,7 @@ func (c *Client) SetExtent(r *http.Request, trq *timeseries.TimeRangeQuery, exte
 	v.Set(upEpoch, "ns") // request nanosecond epoch timestamp format from server
 	v.Del(upChunked)     // we do not support chunked output or handling chunked server responses
 	v.Del(upPretty)
-	//params.SetRequestValues(r, v)
+	params.SetRequestValues(r, v)
 	if !methods.HasBody(r.Method) {
 		r.URL.RawQuery = v.Encode()
 	}

--- a/pkg/backends/influxdb/url.go
+++ b/pkg/backends/influxdb/url.go
@@ -64,8 +64,8 @@ func (c *Client) SetExtent(r *http.Request, trq *timeseries.TimeRangeQuery, exte
 		}
 		uq = q.String()
 	} else if q, ok := trq.ParsedQuery.(*flux.Query); ok {
-		q.Extent.End = q.Extent.End.Add(trq.Step)
-		uq = q.Statement
+		q.SetExtent(*extent)
+		uq = q.String()
 	} else {
 		return
 	}

--- a/pkg/backends/influxdb/url_test.go
+++ b/pkg/backends/influxdb/url_test.go
@@ -18,6 +18,7 @@ package influxdb
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -26,13 +27,14 @@ import (
 	"time"
 
 	"github.com/trickstercache/trickster/v2/cmd/trickster/config"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
 const expectedTokenized = "SELECT * FROM some_column WHERE time >= '$START_TIME$' AND time < '$END_TIME$' GROUP BY time(1m)"
 
-func TestSetExtent(t *testing.T) {
+func TestSetExtentInfluxQL(t *testing.T) {
 
 	start := time.Now().UTC().Add(time.Duration(-6) * time.Hour).Truncate(time.Second)
 	end := time.Now().UTC().Truncate(time.Second)
@@ -81,4 +83,44 @@ func TestSetExtent(t *testing.T) {
 		t.Errorf("\nexpected [%s]\ngot    [%s]", expected, v.Get("q"))
 	}
 
+}
+
+var testQuery = `from("test-bucket")
+|> $RANGE
+|> window(every: 1m)
+`
+
+func TestSetExtentFlux(t *testing.T) {
+	conf, _, err := config.Load("trickster", "test",
+		[]string{"-origin-url", "none:9090", "-provider", "influxdb", "-log-level", "debug"})
+	if err != nil {
+		t.Fatalf("Could not load configuration: %s", err.Error())
+	}
+
+	o := conf.Backends["default"]
+
+	client, err := NewClient("default", o, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ic := client.(*Client)
+
+	start := time.Now().Add(-1 * time.Hour)
+	end := time.Now()
+
+	r, _ := http.NewRequest(http.MethodGet, "", nil)
+	r.Method = http.MethodPost
+	r.Header.Add(headers.NameContentType, headers.ValueApplicationFlux)
+	body := strings.Replace(testQuery, "$RANGE", "range(start: -7d, stop: -6d)", 1)
+	r.Body = io.NopCloser(bytes.NewBufferString(body))
+	trq := &timeseries.TimeRangeQuery{Step: time.Second * 60}
+	e := &timeseries.Extent{Start: start, End: end}
+	ic.SetExtent(r, trq, e)
+
+	newRange := fmt.Sprintf("range(start: %s, stop: %s)", start.Format(time.RFC3339), end.Format(time.RFC3339))
+	expected := strings.Replace(testQuery, "$RANGE", newRange, 1)
+	b, _ := io.ReadAll(r.Body)
+	if string(b) != expected {
+		t.Errorf("expected %s, got %s", expected, string(b))
+	}
 }

--- a/pkg/backends/influxdb/url_test.go
+++ b/pkg/backends/influxdb/url_test.go
@@ -55,7 +55,7 @@ func TestSetExtent(t *testing.T) {
 		t.Error(err)
 	}
 
-	const tokenized = "q=select * FROM some_column where time >= now() - 6h group by time(1m)"
+	const tokenized = "q=SELECT * FROM some_column WHERE time >= now() - 6h GROUP BY time(1m)"
 
 	tu := &url.URL{RawQuery: tokenized}
 
@@ -70,13 +70,15 @@ func TestSetExtent(t *testing.T) {
 		t.Errorf("\nexpected [%s]\ngot    [%s]", expected, r.URL.Query().Get("q"))
 	}
 
+	const body = "q=SELECT * FROM some_column WHERE time >= now() - 6h GROUP BY time(1m)"
+
 	r.Method = http.MethodPost
-	r.Body = io.NopCloser(bytes.NewBufferString(tokenized))
+	r.Body = io.NopCloser(bytes.NewBufferString(body))
 	ic.SetExtent(r, trq, e)
 	v, _, _ := params.GetRequestValues(r)
 
 	if expected != v.Get("q") {
-		t.Errorf("\nexpected [%s]\ngot    [%s]", expected, v.Get("q'"))
+		t.Errorf("\nexpected [%s]\ngot    [%s]", expected, v.Get("q"))
 	}
 
 }

--- a/pkg/backends/prometheus/url_test.go
+++ b/pkg/backends/prometheus/url_test.go
@@ -19,6 +19,7 @@ package prometheus
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -70,8 +71,10 @@ func TestSetExtent(t *testing.T) {
 	r, _ = http.NewRequest(http.MethodPost, u2.String(), b)
 
 	pc.SetExtent(r, nil, e)
-	if r.ContentLength != 31 {
-		t.Errorf("expected 31 got %d", r.ContentLength)
+	if int(r.ContentLength) != len(expected) {
+		b, _ := io.ReadAll(r.Body)
+		fmt.Println(string(b))
+		t.Errorf("expected %d got %d", len(expected), r.ContentLength)
 	}
 
 }

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -19,6 +19,7 @@ package engines
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"sync"
@@ -73,6 +74,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 	trq, rlo, canOPC, err := client.ParseTimeRangeQuery(r)
 	rsc.TimeRangeQuery = trq
 	rsc.TSReqestOptions = rlo
+	fmt.Println(len(request.GetBody(r)))
 	if err != nil {
 		if canOPC {
 			tl.Debug(rsc.Logger, "could not parse time range query, using object proxy cache", tl.Pairs{"error": err.Error()})
@@ -84,14 +86,14 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 		DoProxy(w, r, true)
 		return
 	}
-
+	fmt.Println(len(request.GetBody(r)))
 	var cacheStatus status.LookupStatus
 
 	pr := newProxyRequest(r, w)
 	rlo.FastForwardDisable = o.FastForwardDisable || rlo.FastForwardDisable
 	trq.NormalizeExtent()
 	now := time.Now()
-
+	fmt.Println(len(request.GetBody(pr.upstreamRequest)))
 	bt := trq.GetBackfillTolerance(o.BackfillTolerance, o.BackfillTolerancePoints)
 	bfs := now.Add(-bt).Truncate(trq.Step) // start of the backfill tolerance window
 
@@ -110,6 +112,8 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 	client.SetExtent(pr.upstreamRequest, trq, &trq.Extent)
 	key := o.CacheKeyPrefix + ".dpc." + pr.DeriveCacheKey("")
 	pr.cacheLock, _ = locker.RAcquire(key)
+
+	fmt.Println(len(request.GetBody(pr.upstreamRequest)))
 
 	// this is used to determine if Fast Forward should be activated for this request
 	normalizedNow := &timeseries.TimeRangeQuery{
@@ -142,6 +146,7 @@ checkCache:
 	} else {
 		doc, cacheStatus, _, err = QueryCache(ctx, cache, key, nil)
 		if cacheStatus == status.LookupStatusKeyMiss && err == tc.ErrKNF {
+			fmt.Println(len(request.GetBody(pr.upstreamRequest)))
 			cts, doc, elapsed, err = fetchTimeseries(pr, trq, client, modeler)
 			if err != nil {
 				pr.cacheLock.RRelease()
@@ -597,19 +602,25 @@ func fetchExtents(el timeseries.ExtentList, rsc *request.Resources, h http.Heade
 		// This concurrently fetches gaps from the origin and adds their datasets to the merge list
 		go func(e *timeseries.Extent, rq *proxyRequest) {
 			defer wg.Done()
+			fmt.Println("a", len(request.GetBody(rq.upstreamRequest)))
 			mrsc := rsc.Clone()
+			// upstreamRequest body is removed here
 			rq.upstreamRequest = rq.WithContext(tctx.WithResources(
 				trace.ContextWithSpan(context.Background(), span),
 				mrsc))
+			fmt.Println("b", len(request.GetBody(rq.upstreamRequest)))
 			rq.upstreamRequest = rq.upstreamRequest.WithContext(profile.ToContext(rq.upstreamRequest.Context(),
 				dpcEncodingProfile.Clone()))
+			fmt.Println("c", len(request.GetBody(rq.upstreamRequest)))
 			client.SetExtent(rq.upstreamRequest, rsc.TimeRangeQuery, e)
+			fmt.Println("d", len(request.GetBody(rq.upstreamRequest)))
 
 			ctxMR, spanMR := tspan.NewChildSpan(rq.upstreamRequest.Context(), rsc.Tracer, "FetchRange")
 			if spanMR != nil {
 				rq.upstreamRequest = rq.upstreamRequest.WithContext(ctxMR)
 				defer spanMR.End()
 			}
+			fmt.Println("e", len(request.GetBody(rq.upstreamRequest)))
 
 			body, resp, _ := rq.Fetch()
 

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -604,8 +604,7 @@ func fetchExtents(el timeseries.ExtentList, rsc *request.Resources, h http.Heade
 			defer wg.Done()
 			fmt.Println("a", len(request.GetBody(rq.upstreamRequest)))
 			mrsc := rsc.Clone()
-			// upstreamRequest body is removed here
-			rq.upstreamRequest = rq.WithContext(tctx.WithResources(
+			rq.upstreamRequest = rq.upstreamRequest.WithContext(tctx.WithResources(
 				trace.ContextWithSpan(context.Background(), span),
 				mrsc))
 			fmt.Println("b", len(request.GetBody(rq.upstreamRequest)))

--- a/pkg/proxy/engines/key.go
+++ b/pkg/proxy/engines/key.go
@@ -24,12 +24,12 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
-	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
 )
 
 // DeriveCacheKey calculates a query-specific keyname based on the user request

--- a/pkg/proxy/headers/headers.go
+++ b/pkg/proxy/headers/headers.go
@@ -32,6 +32,8 @@ const (
 	ValueApplicationCSV = "application/csv"
 	// ValueApplicationJSON represents the HTTP Header Value of "application/json"
 	ValueApplicationJSON = "application/json"
+	// ValueApplicationFlux represents the HTTP Header Value of "application/vnd.flux"
+	ValueApplicationFlux = "application/vnd.flux"
 	// ValueChunked represents the HTTP Header Value of "chunked"
 	ValueChunked = "chunked"
 	// ValueMaxAge represents the HTTP Header Value of "max-age"

--- a/pkg/proxy/params/params.go
+++ b/pkg/proxy/params/params.go
@@ -19,7 +19,6 @@ package params
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -70,7 +69,6 @@ func isQueryBody(r *http.Request) bool {
 		headers.ValueApplicationFlux,
 	}
 	ct := r.Header.Get(headers.NameContentType)
-	fmt.Println(ct)
 	for _, nqb := range nqbs {
 		if ct == nqb {
 			return false

--- a/pkg/proxy/params/params.go
+++ b/pkg/proxy/params/params.go
@@ -70,6 +70,7 @@ func GetRequestValues(r *http.Request) (url.Values, string, bool) {
 		r.ParseForm()
 		v = r.PostForm
 		s = v.Encode()
+		isBody = true
 	}
 	return v, s, isBody
 }

--- a/pkg/proxy/params/params.go
+++ b/pkg/proxy/params/params.go
@@ -70,9 +70,6 @@ func GetRequestValues(r *http.Request) (url.Values, string, bool) {
 		r.ParseForm()
 		v = r.PostForm
 		s = v.Encode()
-		isBody = true
-		r.ContentLength = int64(len(s))
-		r.Body = io.NopCloser(bytes.NewReader([]byte(s)))
 	}
 	return v, s, isBody
 }

--- a/pkg/proxy/params/params.go
+++ b/pkg/proxy/params/params.go
@@ -19,9 +19,11 @@ package params
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
@@ -50,6 +52,33 @@ func UpdateParams(params url.Values, updates map[string]string) {
 	}
 }
 
+// isMultipartOrForm checks if the request may contain form data.
+func isMultipartOrForm(r *http.Request) bool {
+	h := r.Header
+	if ct := h.Get(headers.NameContentType); strings.Contains(ct, headers.ValueMultipartFormData) {
+		return true
+	} else if strings.Contains(ct, headers.ValueXFormURLEncoded) {
+		return true
+	}
+	return false
+}
+
+// isQueryBody checks if the request body is a query string or actual content.
+func isQueryBody(r *http.Request) bool {
+	nqbs := []string{
+		headers.ValueApplicationCSV, headers.ValueApplicationJSON,
+		headers.ValueApplicationFlux,
+	}
+	ct := r.Header.Get(headers.NameContentType)
+	fmt.Println(ct)
+	for _, nqb := range nqbs {
+		if ct == nqb {
+			return false
+		}
+	}
+	return true
+}
+
 // GetRequestValues returns the Query Parameters for the request
 // regardless of method
 func GetRequestValues(r *http.Request) (url.Values, string, bool) {
@@ -59,19 +88,27 @@ func GetRequestValues(r *http.Request) (url.Values, string, bool) {
 	if !methods.HasBody(r.Method) {
 		v = r.URL.Query()
 		s = r.URL.RawQuery
-	} else if ct := r.Header.Get(headers.NameContentType); ct == headers.ValueMultipartFormData || ct == headers.ValueXFormURLEncoded {
+	} else if isMultipartOrForm(r) {
 		r.ParseForm()
 		v = r.PostForm
 		s = v.Encode()
 		isBody = true
 	} else {
-		v = url.Values{}
+		v = r.URL.Query()
 		b, _ := io.ReadAll(r.Body)
 		r.Body.Close()
 		r.Body = io.NopCloser(bytes.NewReader(b))
 		s = string(b)
-		if vs, err := url.ParseQuery(s); err == nil {
-			v = vs
+		if vs, err := url.ParseQuery(s); err == nil && isQueryBody(r) {
+			for vsk := range vs {
+				for _, vsv := range vs[vsk] {
+					if !v.Has(vsk) {
+						v.Set(vsk, vsv)
+					} else {
+						v.Add(vsk, vsv)
+					}
+				}
+			}
 		}
 		isBody = true
 	}

--- a/pkg/proxy/params/params_test.go
+++ b/pkg/proxy/params/params_test.go
@@ -110,7 +110,7 @@ func TestGetSetRequestValues(t *testing.T) {
 	r.Header.Set(headers.NameContentType, headers.ValueApplicationJSON)
 	v, s, hb = GetRequestValues(r)
 	if len(v) != 0 {
-		t.Errorf("expected %d got %d", 0, len(v))
+		t.Errorf("expected %d got %d", 1, len(v))
 	}
 	if s != params {
 		t.Errorf("expected %s got %s", params, s)


### PR DESCRIPTION
Fixing some errors that I left in the Flux implementation. Queries should now properly parse from the request body for POST requests (idiomatic for flux), and should use the OPC if there's no timestep, which is now parsed out of the first `window()` or `aggregateWindow()` found in the query, since using different timesteps for data in the DeltaProxyCache is probably bad.

Running some tests with InfluxDB 2.0 locally and will undraft once that's done and confirmed OK.