### PR TITLE
Replace atomic call in roundrobin

### DIFF
--- a/pkg/backends/alb/pool/pool.go
+++ b/pkg/backends/alb/pool/pool.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 )
@@ -76,7 +77,7 @@ type pool struct {
 	targets      []*Target
 	healthy      []http.Handler
 	healthyFloor int
-	pos          uint64
+	pos          atomic.Uint64
 	mtx          sync.RWMutex
 	ctx          context.Context
 	ch           chan bool

--- a/pkg/backends/alb/pool/round_robin.go
+++ b/pkg/backends/alb/pool/round_robin.go
@@ -18,7 +18,6 @@ package pool
 
 import (
 	"net/http"
-	"sync/atomic"
 )
 
 func nextRoundRobin(p *pool) []http.Handler {
@@ -28,6 +27,6 @@ func nextRoundRobin(p *pool) []http.Handler {
 	if len(t) == 0 {
 		return nil
 	}
-	i := atomic.AddUint64(&p.pos, 1) % uint64(len(t))
+	i := p.pos.Add(1) % uint64(len(t))
 	return []http.Handler{t[i]}
 }

--- a/pkg/backends/healthcheck/status_test.go
+++ b/pkg/backends/healthcheck/status_test.go
@@ -28,10 +28,10 @@ func TestString(t *testing.T) {
 	status := &Status{
 		name:         "test",
 		description:  "test-description",
-		status:       -1,
 		detail:       "status-detail",
 		failingSince: tm,
 	}
+	status.status.Store(-1)
 	const expected = "target: test\nstatus: -1\ndetail: status-detail\nsince: 0"
 	s := status.String()
 	if s != expected {
@@ -68,7 +68,8 @@ func TestProber(t *testing.T) {
 
 func TestGet(t *testing.T) {
 
-	status := &Status{status: 8480}
+	status := &Status{}
+	status.status.Store(8480)
 	if status.Get() != 8480 {
 		t.Error("expected 8480 got", status.Get())
 	}

--- a/pkg/backends/healthcheck/target_test.go
+++ b/pkg/backends/healthcheck/target_test.go
@@ -226,15 +226,15 @@ func TestProbe(t *testing.T) {
 		ec:          []int{200},
 	}
 	target.probe()
-	if target.successConsecutiveCnt != 1 {
+	if target.successConsecutiveCnt.Load() != 1 {
 		t.Error("expected 1 got ", target.successConsecutiveCnt)
 	}
 	target.ec[0] = 404
 	target.probe()
-	if target.successConsecutiveCnt != 0 {
+	if target.successConsecutiveCnt.Load() != 0 {
 		t.Error("expected 0 got ", target.successConsecutiveCnt)
 	}
-	if target.failConsecutiveCnt != 1 {
+	if target.failConsecutiveCnt.Load() != 1 {
 		t.Error("expected 1 got ", target.failConsecutiveCnt)
 	}
 
@@ -262,7 +262,7 @@ func TestDemandProbe(t *testing.T) {
 
 	// simulate a failed probe (bad response)
 	w = httptest.NewRecorder()
-	target.status.status = -1
+	target.status.status.Store(-1)
 	target.demandProbe(w)
 
 	if w.Code != 200 {
@@ -272,7 +272,7 @@ func TestDemandProbe(t *testing.T) {
 	// simulate a failed probe (unreachable)
 	ts.Close()
 	w = httptest.NewRecorder()
-	target.status.status = -1
+	target.status.status.Store(-1)
 	target.demandProbe(w)
 
 	if w.Code != 500 {

--- a/pkg/backends/influxdb/flux/errors_test.go
+++ b/pkg/backends/influxdb/flux/errors_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package flux
 
 import "testing"

--- a/pkg/encoding/reader/reader.go
+++ b/pkg/encoding/reader/reader.go
@@ -44,7 +44,7 @@ type nopReadCloserResetter struct {
 // readCloserResetter implements ReadCloserResetter
 type readCloserResetter struct {
 	io.Reader
-	closeCnt int32
+	closeCnt atomic.Int32
 	resetter Resetter
 }
 
@@ -53,7 +53,7 @@ type readCloserResetter struct {
 func (rc *readCloserResetter) Close() error {
 	// This gracefully handles when Close is called more than once and ensures
 	// only the first caller, even in a burst, is able to proceed.
-	if atomic.AddInt32(&rc.closeCnt, 1) != 1 {
+	if rc.closeCnt.Add(1) != 1 {
 		return nil
 	}
 	// if the underlying io.Reader is actually itself an io.ReadCloser, call

--- a/pkg/proxy/handlers/switch.go
+++ b/pkg/proxy/handlers/switch.go
@@ -26,7 +26,7 @@ import (
 type SwitchHandler struct {
 	router    http.Handler
 	oldRouter http.Handler
-	reloading int32
+	reloading atomic.Int32
 }
 
 // NewSwitchHandler returns a New *SwitchHandler
@@ -60,13 +60,13 @@ func (s *SwitchHandler) Handler() http.Handler {
 }
 
 func (s *SwitchHandler) isReloading() bool {
-	return atomic.LoadInt32(&s.reloading) != 0
+	return s.reloading.Load() != 0
 }
 
 func (s *SwitchHandler) setReloading(isReloading bool) {
 	if isReloading {
-		atomic.StoreInt32(&s.reloading, 1)
+		s.reloading.Store(1)
 		return
 	}
-	atomic.StoreInt32(&s.reloading, 0)
+	s.reloading.Store(0)
 }

--- a/pkg/router/middleware.go
+++ b/pkg/router/middleware.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
 // https://github.com/gorilla/mux/blob/master/LICENSE
 // Gorilla Mux was archived in December 2022--this is a duplicate of its source to use in Trickster.

--- a/pkg/router/regexp.go
+++ b/pkg/router/regexp.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
 // https://github.com/gorilla/mux/blob/master/LICENSE
 // Gorilla Mux was archived in December 2022--this is a duplicate of its source to use in Trickster.

--- a/pkg/router/regexp_test.go
+++ b/pkg/router/regexp_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
 // https://github.com/gorilla/mux/blob/master/LICENSE
 // Gorilla Mux was archived in December 2022--this is a duplicate of its source to use in Trickster.

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
 // https://github.com/gorilla/mux/blob/master/LICENSE
 // Gorilla Mux was archived in December 2022--this is a duplicate of its source to use in Trickster.

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
 // https://github.com/gorilla/mux/blob/master/LICENSE
 // Gorilla Mux was archived in December 2022--this is a duplicate of its source to use in Trickster.

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 // Copyright (c) 2012-2018 The Gorilla Authors. All rights reserved.
 // https://github.com/gorilla/mux/blob/master/LICENSE
 // Gorilla Mux was archived in December 2022--this is a duplicate of its source to use in Trickster.

--- a/pkg/testutil/readers/bad_reader.go
+++ b/pkg/testutil/readers/bad_reader.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package readers
 
 import "errors"

--- a/pkg/testutil/readers/bad_reader_test.go
+++ b/pkg/testutil/readers/bad_reader_test.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package readers
 
 import "testing"

--- a/pkg/timeseries/dataset/point.go
+++ b/pkg/timeseries/dataset/point.go
@@ -50,17 +50,18 @@ func (p *Point) Clone() Point {
 
 // Size returns the memory utilization of the Points in bytes
 func (p Points) Size() int64 {
-	var c int64 = 16
+	var c atomic.Int64
+	c.Store(16)
 	var wg sync.WaitGroup
 	for i, pt := range p {
 		wg.Add(1)
 		go func(s, e int64, j int) {
-			atomic.AddInt64(&c, s)
+			c.Add(s)
 			wg.Done()
 		}(int64(pt.Size), int64(pt.Epoch), i)
 	}
 	wg.Wait()
-	return c
+	return c.Load()
 }
 
 // Clone returns a perfect copy of the Points


### PR DESCRIPTION
The roundrobin package was using atomic.AddUint64, which appears to be creating an issue for this user: #667. Per documentation linked below, this function is unsafe on some hardware, and the call/error matches up with what would be expected in that case. The pool now uses an `atomic.Uint64` to count its position, and roundrobin uses the suggested `Uint64.Add` function instead.

There are other parts of the code that also use this, but I don't want to go around changing stuff that we haven't heard is broken, so I'm leaving those instances out of this for now and noting it as a potential area of concern if we see similar reports.