### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/publish-beta-release.yaml
+++ b/.github/workflows/publish-beta-release.yaml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
         #
       - name: Get bare tag
         id: baretag
-        run: echo "baretag=$(echo ${{ github.ref }} | cut -b 12-)" >> $GITHUB_OUTPUT
+        run: echo "baretag=$(echo ${{ github.ref }} | cut -b 12-)" >> "$GITHUB_OUTPUT"
         #
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/publish-beta-release.yaml
+++ b/.github/workflows/publish-beta-release.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-    - 'v[0-9]+\.[0-9]+\.[0-9]+-beta[0-9]+'
+      - 'v[0-9]+\.[0-9]+\.[0-9]+-beta[0-9]+'
 
 name: Publish Trickster Beta Release to Drafts
 
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         #
       - name: Get bare tag
         id: baretag
-        run: echo "::set-output name=baretag::$(echo ${{ github.ref }} | cut -b 12-)"
+        run: echo "baretag=$(echo ${{ github.ref }} | cut -b 12-)" >> $GITHUB_OUTPUT
         #
       - name: Checkout code
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
       - name: install golang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: "1.19"
       - name: Build project
         run: |
           TAGVER=${{ steps.baretag.outputs.baretag }} make release

--- a/.github/workflows/publish-release-candidate.yaml
+++ b/.github/workflows/publish-release-candidate.yaml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
         #
       - name: Get bare tag
         id: baretag
-        run: echo "baretag=$(echo ${{ github.ref }} | cut -b 12-)" >> $GITHUB_OUTPUT
+        run: echo "baretag=$(echo ${{ github.ref }} | cut -b 12-)" >> "$GITHUB_OUTPUT"
         #
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/publish-release-candidate.yaml
+++ b/.github/workflows/publish-release-candidate.yaml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-    - 'v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+'
+      - 'v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+'
 
 name: Publish Trickster Release Candidate to Drafts
 
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         #
       - name: Get bare tag
         id: baretag
-        run: echo "::set-output name=baretag::$(echo ${{ github.ref }} | cut -b 12-)"
+        run: echo "baretag=$(echo ${{ github.ref }} | cut -b 12-)" >> $GITHUB_OUTPUT
         #
       - name: Checkout code
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
       - name: install golang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: "1.19"
         #
       - name: Build project
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+        run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
         #
       - name: Get bare tag
         id: baretag
-        run: echo "baretag=$(echo ${{ github.ref }} | cut -b 12-)" >> $GITHUB_OUTPUT
+        run: echo "baretag=$(echo ${{ github.ref }} | cut -b 12-)" >> "$GITHUB_OUTPUT"
         #
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,7 +1,7 @@
 on:
   push:
     tags:
-    - 'v[0-9]+\.[0-9]+\.[0-9]+' 
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
 
 name: Publish Trickster Release to Drafts
 
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+        run: echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
         #
       - name: Get bare tag
         id: baretag
-        run: echo "::set-output name=baretag::$(echo ${{ github.ref }} | cut -b 12-)"
+        run: echo "baretag=$(echo ${{ github.ref }} | cut -b 12-)" >> $GITHUB_OUTPUT
         #
       - name: Checkout code
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
       - name: install golang
         uses: actions/setup-go@v2
         with:
-          go-version: '1.19'
+          go-version: "1.19"
         #
       - name: Build project
         run: |


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
