### PR TITLE
Clickhouse multi-line query fix

### DIFF
--- a/pkg/backends/clickhouse/handler_query.go
+++ b/pkg/backends/clickhouse/handler_query.go
@@ -41,7 +41,6 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		var body []byte
 		if sqlQuery != "" {
-			body = make([]byte, 0, len(sqlQuery)+len(b))
 			body = append([]byte(sqlQuery), b...)
 			q.Del(upQuery)
 			r.URL.RawQuery = q.Encode()

--- a/pkg/backends/clickhouse/handler_query.go
+++ b/pkg/backends/clickhouse/handler_query.go
@@ -52,7 +52,9 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 		r = request.SetBody(r, body)
 	}
 	sqlQuery = strings.ToLower(sqlQuery)
-	if (!strings.HasPrefix(sqlQuery, "select ")) && (!(strings.Index(sqlQuery, " select ") > 0)) {
+	if !(strings.HasPrefix(sqlQuery, "select ") ||
+		strings.HasPrefix(sqlQuery, "select\n") ||
+		strings.Contains(sqlQuery, " select ")) {
 		c.ProxyHandler(w, r)
 		return
 	}


### PR DESCRIPTION
#696 was describing an issue with multi-line queries in ClickHouse, where if a query started with `SELECT` immediately followed by a newline, it would not get cached. The parser previously only looked for `SELECT ` or ` SELECT ` (including spaces), so this adds `SELECT\n` to the list. Also removed a `make` call that was unused.