### PR TITLE
Clickhouse fix

### DIFF
--- a/pkg/backends/clickhouse/handler_query.go
+++ b/pkg/backends/clickhouse/handler_query.go
@@ -41,7 +41,6 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		var body []byte
 		if sqlQuery != "" {
-			body = make([]byte, 0, len(sqlQuery)+len(b))
 			body = append([]byte(sqlQuery), b...)
 			q.Del(upQuery)
 			r.URL.RawQuery = q.Encode()

--- a/pkg/backends/clickhouse/handler_query.go
+++ b/pkg/backends/clickhouse/handler_query.go
@@ -52,7 +52,9 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 		r = request.SetBody(r, body)
 	}
 	sqlQuery = strings.ToLower(sqlQuery)
-	if (!strings.HasPrefix(sqlQuery, "select ")) && (!(strings.Index(sqlQuery, " select ") > 0)) {
+	if !(strings.HasPrefix(sqlQuery, "select ") ||
+		strings.HasPrefix(sqlQuery, "select\n") ||
+		strings.Contains(sqlQuery, " select ")) {
 		c.ProxyHandler(w, r)
 		return
 	}

--- a/pkg/proxy/engines/objectproxycache_chunk_test.go
+++ b/pkg/proxy/engines/objectproxycache_chunk_test.go
@@ -729,6 +729,9 @@ func TestObjectProxyCacheRequestNegativeCacheChunks(t *testing.T) {
 	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(cfg, pc, rsc.CacheConfig,
 		rsc.CacheClient, rsc.BackendClient, nil, rsc.Logger)))
 
+	// Remove negative cache for first request
+	delete(cfg.NegativeCache, 404)
+
 	_, e := testFetchOPC(r, http.StatusNotFound, "test", map[string]string{"status": "kmiss"})
 	for _, err = range e {
 		t.Error(err)

--- a/pkg/proxy/engines/objectproxycache_test.go
+++ b/pkg/proxy/engines/objectproxycache_test.go
@@ -798,6 +798,9 @@ func TestObjectProxyCacheRequestNegativeCache(t *testing.T) {
 	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(cfg, pc, rsc.CacheConfig,
 		rsc.CacheClient, rsc.BackendClient, nil, rsc.Logger)))
 
+	// Remove negative cache for first request
+	delete(cfg.NegativeCache, 404)
+
 	_, e := testFetchOPC(r, http.StatusNotFound, "test", map[string]string{"status": "kmiss"})
 	for _, err = range e {
 		t.Error(err)


### PR DESCRIPTION
Issue 696 was describing an issue with multi-line queries in ClickHouse, where if a query started with SELECT immediately followed by a newline, it would not get cached. The parser previously only looked for SELECT or SELECT (including spaces), so this adds SELECT\n to the list. Also removed a make call that was unused.