### PR TITLE
Add docker image publishing workflows

### DIFF
--- a/.github/workflows/publish-docker-prerelease.yaml
+++ b/.github/workflows/publish-docker-prerelease.yaml
@@ -1,0 +1,60 @@
+name: Publish docker image on prereleases
+
+on:
+  release:
+    types: [prereleased]
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            tricksterproxy/trickster
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
+          tags: |
+            type=semver,pattern={{version}}
+            type=sha,format=long
+
+      - name: Build Docker Container
+        uses: docker/build-push-action@v5
+        with:
+          platforms: "linux/amd64,linux/arm64"
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-docker-prerelease.yaml
+++ b/.github/workflows/publish-docker-prerelease.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            tricksterproxy/trickster
+            trickstercache/trickster
           flavor: |
             latest=false
             prefix=

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -48,7 +48,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            tricksterproxy/trickster
+            trickstercache/trickster
           flavor: |
             latest=auto
             prefix=

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -1,0 +1,69 @@
+name: Publish docker image on main and releases
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [released]
+  workflow_dispatch:
+  schedule:
+    # Monday at 9am UTC
+    - cron: '0 9 * * 1'
+
+permissions:
+  id-token: write
+  contents: read
+  packages: write
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+            tricksterproxy/trickster
+          flavor: |
+            latest=auto
+            prefix=
+            suffix=
+          tags: |
+            type=raw,value=main,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=long
+
+      - name: Build Docker Container
+        uses: docker/build-push-action@v5
+        with:
+          platforms: "linux/amd64,linux/arm64"
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Sorry for the radio silence on this, I wanted to get to this sooner but I've been extremely busy as of late unfortunately. Eventually carved out time to work on this :smile: Regards https://github.com/trickstercache/trickster/issues/691 FYI @jnichols-git 

These workflows should handle building and pushing images to docker hub and github's container registry, using qemu and docker buildx to build for the arm64 and amd64 platforms. 

We have two files here:

`publish-docker.yaml`:
* This will run when a release is created (which excludes prereleases, like release candidates)
* On a release workflow, it creates some semver docker tags (like `:x.x.x`, `:x.x`, and `:x`), it also updates the `:latest` tag from the latest release code, and creates a `:sha-<commit sha long>` tag
* This will run on merges/pushes to main
* On a main workflow, it refreshes a `:main` tag, and creates a `:sha-<commit sha long>` tag
* It also runs the main workflow on a schedule

`publish-docker-prerelease.yaml`:
* This will run when a prerelease is created (which is a checkbox in the github UI when creating a release, and is typically used for betas or release candidates)
* On a prerelease workflow, it creates a semver docker tags (like `:x.x.x-rc1` for a tagged prerelease like `:x.x.x-rc1`), and creates a `:sha-<commit sha long>` tag

A slight change here that I wanted to specifically call out was that this adds a new kind of tag that I don't think you currently do. And _this_ is the tag that will get rebuilt over time from a fresh alpine base. Which is the `:main` tag. I can also just switch this to be the `:latest` tag, depending on what you want. But `:main` gets refreshed every week. `:latest` will just track the latest released version and will be refreshed every time a release happens. And the semver tags will just be tagged once when a release is cut.

Some important general notes here:
* This begins uploading trickster images to github's container registry, which isn't currently done here. I can strip that out here if you want. I just figure it's valuable to have a second registry and basically free since the workflow should manage tagging/uploading there.
* This relies on a Docker Hub username and access token with read+write privileges in github secrets, which a maintainer here will need to provide.
