### PR TITLE
SQL Parser Performance

### DIFF
--- a/pkg/backends/clickhouse/parsing_test.go
+++ b/pkg/backends/clickhouse/parsing_test.go
@@ -162,49 +162,51 @@ func TestParseErrors(t *testing.T) {
 
 func TestAtWith(t *testing.T) {
 
-	rs := parsing.NewRunState(context.Background())
-	ch := rs.Tokens()
-	ch <- &token.Token{Typ: token.Space, Val: " "}
+	tk := token.Tokens{&token.Token{Typ: token.Space, Val: " "}}
+	rs := parsing.NewRunState(context.Background(), tk)
 	rs.Next()
 	f := atWith(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
 	}
 
-	rs = parsing.NewRunState(context.Background())
-	ch = rs.Tokens()
-	ch <- &token.Token{Typ: lsql.TokenWith, Val: "with"}
+	tk = token.Tokens{&token.Token{Typ: lsql.TokenWith, Val: "with"}}
+	rs = parsing.NewRunState(context.Background(), tk)
 	rs.Next()
 	atWith(nil, nil, rs)
 	if rs.Error() != parsing.ErrUnsupportedParser {
 		t.Error("expected ErrUnsupportedParser")
 	}
 
-	rs = parsing.NewRunState(context.Background())
-	ch = rs.Tokens()
-	ch <- &token.Token{Typ: lsql.TokenWith, Val: "with"}
-	ch <- &token.Token{Typ: lsql.TokenSelect, Val: "select"}
+	tk = token.Tokens{
+		&token.Token{Typ: lsql.TokenWith, Val: "with"},
+		&token.Token{Typ: lsql.TokenSelect, Val: "select"},
+	}
+
+	rs = parsing.NewRunState(context.Background(), tk)
 	rs.Next()
 	f = atWith(parser, parser, rs)
 	if f == nil {
 		t.Error("expected non-nil StateFn")
 	}
 
-	rs = parsing.NewRunState(context.Background())
-	ch = rs.Tokens()
-	ch <- &token.Token{Typ: lsql.TokenWith, Val: "with"}
-	ch <- &token.Token{Typ: token.EOF}
+	tk = token.Tokens{
+		&token.Token{Typ: lsql.TokenWith, Val: "with"},
+		&token.Token{Typ: token.EOF},
+	}
+	rs = parsing.NewRunState(context.Background(), tk)
 	rs.Next()
 	f = atWith(parser, parser, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
 	}
 
-	rs = parsing.NewRunState(context.Background())
-	ch = rs.Tokens()
-	ch <- &token.Token{Typ: lsql.TokenWith, Val: "with"}
-	ch <- &token.Token{Typ: token.Identifier, Val: "x"}
-	ch <- &token.Token{Typ: lsql.TokenSelect, Val: "select"}
+	tk = token.Tokens{
+		&token.Token{Typ: lsql.TokenWith, Val: "with"},
+		&token.Token{Typ: token.Identifier, Val: "x"},
+		&token.Token{Typ: lsql.TokenSelect, Val: "select"},
+	}
+	rs = parsing.NewRunState(context.Background(), tk)
 	rs.Next()
 	f = atWith(parser, parser, rs)
 	if f != nil {
@@ -216,7 +218,7 @@ func TestAtWith(t *testing.T) {
 }
 
 func TestAtPreWhere(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := atPreWhere(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -227,19 +229,22 @@ func TestAtPreWhere(t *testing.T) {
 }
 
 func TestAtFormat(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
-	ch := rs.Tokens()
-	ch <- &token.Token{Typ: lsql.TokenComment}
-	ch <- &token.Token{Typ: token.EOF}
+
+	tk := token.Tokens{
+		&token.Token{Typ: lsql.TokenComment},
+		&token.Token{Typ: token.EOF},
+	}
+	rs := parsing.NewRunState(context.Background(), tk)
 	f := atFormat(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
 	}
 
-	rs = parsing.NewRunState(context.Background())
-	ch = rs.Tokens()
-	ch <- &token.Token{Typ: token.Identifier, Val: "UnsupportedFormat"}
-	ch <- &token.Token{Typ: token.EOF}
+	tk = token.Tokens{
+		&token.Token{Typ: token.Identifier, Val: "UnsupportedFormat"},
+		&token.Token{Typ: token.EOF},
+	}
+	rs = parsing.NewRunState(context.Background(), tk)
 	f = atFormat(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")

--- a/pkg/parsing/lex/lex.go
+++ b/pkg/parsing/lex/lex.go
@@ -27,7 +27,7 @@ const EOF = -1
 
 // Lexer is the Lexer interface
 type Lexer interface {
-	Run(string, chan *token.Token)
+	Run(string) token.Tokens
 }
 
 // Options provides members that alter the behavior of the underlying Lexer

--- a/pkg/parsing/lex/run_state_test.go
+++ b/pkg/parsing/lex/run_state_test.go
@@ -26,7 +26,7 @@ var testRunState = &RunState{
 	Input:        "Test",
 	InputLowered: "test",
 	InputWidth:   4,
-	Tokens:       make(chan *token.Token, 8),
+	Tokens:       make(token.Tokens, 0, 1),
 }
 
 func TestRunState(t *testing.T) {
@@ -88,7 +88,7 @@ func TestScanNumber(t *testing.T) {
 		Input:        "1234",
 		InputLowered: "1234",
 		InputWidth:   4,
-		Tokens:       make(chan *token.Token, 8),
+		Tokens:       make(token.Tokens, 0, 1),
 	}
 	b := tr.ScanNumber()
 	if !b {
@@ -167,7 +167,7 @@ func TestAtTeminator(t *testing.T) {
 		Input:        " ",
 		InputLowered: " ",
 		InputWidth:   1,
-		Tokens:       make(chan *token.Token, 8),
+		Tokens:       make(token.Tokens, 0, 1),
 	}
 	if !tr.AtTerminator() {
 		t.Error("expected true")
@@ -179,7 +179,7 @@ func TestErrorf(t *testing.T) {
 		Input:        " ",
 		InputLowered: " ",
 		InputWidth:   1,
-		Tokens:       make(chan *token.Token, 8),
+		Tokens:       make(token.Tokens, 0, 1),
 	}
 	tk := tr.Errorf("%s", "fail")
 	if tk.Val != "fail" {

--- a/pkg/parsing/lex/sql/sql.go
+++ b/pkg/parsing/lex/sql/sql.go
@@ -94,7 +94,7 @@ func (l *sqllexer) Run(input string, ch chan *token.Token) {
 
 // lexEOLComment scans a // comment that terminates at the end of the line
 // it assumes you have already identified '//' and are positioned on the first slash
-func lexEOLComment(li lex.Lexer, rs *lex.RunState) lex.StateFn {
+func lexEOLComment(_ lex.Lexer, rs *lex.RunState) lex.StateFn {
 	rs.Pos += 2
 	i := strings.Index(rs.InputLowered[rs.Pos:], "\n")
 	if i == -1 {
@@ -112,7 +112,7 @@ func lexEOLComment(li lex.Lexer, rs *lex.RunState) lex.StateFn {
 }
 
 // lexComment scans a comment. The left comment marker is known to be present.
-func lexComment(li lex.Lexer, rs *lex.RunState) lex.StateFn {
+func lexComment(_ lex.Lexer, rs *lex.RunState) lex.StateFn {
 	rs.Pos += len(leftComment)
 	i := strings.Index(rs.InputLowered[rs.Pos:], rightComment)
 	if i < 0 {

--- a/pkg/parsing/lex/sql/sql.go
+++ b/pkg/parsing/lex/sql/sql.go
@@ -77,17 +77,18 @@ func BaseKey() map[string]token.Typ {
 
 // Run runs the lexer against the provided string and returns tokens on the
 // provided channel. Run will end when the state is EOF or Error.
-func (l *sqllexer) Run(input string, ch chan *token.Token) {
+func (l *sqllexer) Run(input string) token.Tokens {
+	li := len(input)
 	rc := &lex.RunState{
 		Input:        input,
 		InputLowered: strings.ToLower(input),
-		InputWidth:   len(input),
-		Tokens:       ch,
+		InputWidth:   li,
+		Tokens:       make(token.Tokens, 0, li/4), // estimated # of tokens
 	}
 	for state := lexText; state != nil; {
 		state = state(l, rc)
 	}
-	close(ch)
+	return rc.Tokens
 }
 
 // state functions

--- a/pkg/parsing/run_state.go
+++ b/pkg/parsing/run_state.go
@@ -145,7 +145,7 @@ func (rs *RunState) IsPeeked() bool {
 	return rs.next != nil
 }
 
-// Next retrieves the next location by peeking and then advancin the state
+// Next retrieves the next location by peeking and then advancing the state
 func (rs *RunState) Next() *token.Token {
 	rs.Peek()
 	rs.prev = rs.curr

--- a/pkg/parsing/run_state_test.go
+++ b/pkg/parsing/run_state_test.go
@@ -25,9 +25,9 @@ import (
 )
 
 func TestNewRunState(t *testing.T) {
-	rs := NewRunState(context.Background())
+	rs := NewRunState(context.Background(), nil)
 	if rs == nil {
-		t.Error("expected non-nil error")
+		t.Error("expected non-nil run state")
 	}
 }
 
@@ -38,7 +38,7 @@ func testStateFn(p1, p2 Parser, rs *RunState) StateFn {
 func TestRunState(t *testing.T) {
 	v := "trickster"
 	ctx := context.Background()
-	rs := NewRunState(context.Background()).WithContext(ctx)
+	rs := NewRunState(context.Background(), nil).WithContext(ctx)
 	rs.SetResultsCollection("test", v)
 	v2, _ := rs.GetResultsCollection("test")
 	if v3, ok := v2.(string); !ok || v3 != v {
@@ -82,14 +82,16 @@ func TestRunState(t *testing.T) {
 	}
 
 	tk := &token.Token{Typ: token.EOF}
-	ch := rs.Tokens()
-	ch <- tk
+	tokens := token.Tokens{tk}
+	rs = NewRunState(context.Background(), tokens).WithContext(ctx)
 	rs.Peek()
-	if rs.Next() != tk {
-		t.Error("next mismatch")
+	tk2 := rs.Next()
+	if tk2 != tk {
+		t.Error("next mismatch", tk2)
 	}
-	if rs.Peek() != tk {
-		t.Error("peek mismatch")
+	tk2 = rs.Peek()
+	if tk2 != tk {
+		t.Error("peek mismatch", tk2)
 	}
 
 	StateUnexpectedToken(nil, nil, rs)

--- a/pkg/parsing/sql/select.go
+++ b/pkg/parsing/sql/select.go
@@ -111,7 +111,7 @@ func GetField(
 func (p *Parser) GetFieldList(rs *parsing.RunState, allowedToken token.Typ, disAllowedTokenErr error,
 	isDelim, isBreakable, isContinuable token.TypeCheckFunc,
 	isolateDelimiter bool) []token.Tokens {
-	if rs.Current().Typ != allowedToken {
+	if rs.Current() == nil || rs.Current().Typ != allowedToken {
 		rs.WithError(disAllowedTokenErr)
 		return nil
 	}
@@ -158,7 +158,7 @@ func DefaultIsBreakable(t token.Typ) bool {
 
 // IsWhereBreakable returns true if the token is a loop-breakable token (EOF or Error), or
 // a primary keyword excluding BETWEEN.
-//  These indicate the parser should break any loops and start a new token collection
+// These indicate the parser should break any loops and start a new token collection
 func IsWhereBreakable(t token.Typ) bool {
 	return lsql.IsNonVerbPrimaryKeyword(t) && t != lsql.TokenBetween
 }

--- a/pkg/parsing/sql/select_test.go
+++ b/pkg/parsing/sql/select_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestSelectTokens(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	ts := SelectTokens(rs)
 	if ts != nil {
 		t.Error("expected nil tokens list")
@@ -82,10 +82,8 @@ func TestHasLimitClause(t *testing.T) {
 
 func TestGetFieldList(t *testing.T) {
 	p := New(nil).(*Parser)
-	rs := parsing.NewRunState(context.Background())
-	ch := rs.Tokens()
-	ch <- &token.Token{Typ: token.Space, Pos: 0, Val: " "}
-	rs.Next()
+	tokens := token.Tokens{&token.Token{Typ: token.Space, Pos: 0, Val: " "}}
+	rs := parsing.NewRunState(context.Background(), tokens)
 	p.GetFieldList(rs, token.Bool, parsing.ErrUnexpectedToken, nil, nil, nil, false)
 	if rs.Error() != parsing.ErrUnexpectedToken {
 		t.Error("expected ErrUnexpectedToken")
@@ -93,7 +91,7 @@ func TestGetFieldList(t *testing.T) {
 }
 
 func TestAtSelect(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := AtSelect(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -103,9 +101,8 @@ func TestAtSelect(t *testing.T) {
 	}
 
 	p := New(nil)
-	rs = parsing.NewRunState(context.Background())
-	ch := rs.Tokens()
-	ch <- &token.Token{Typ: token.Space, Pos: 0, Val: " "}
+	tokens := token.Tokens{&token.Token{Typ: token.Space, Pos: 0, Val: " "}}
+	rs = parsing.NewRunState(context.Background(), tokens)
 	rs.Next()
 	f = AtSelect(p, p, rs)
 	if f != nil {
@@ -115,11 +112,13 @@ func TestAtSelect(t *testing.T) {
 		t.Error("expected ErrNotAtSelect")
 	}
 
-	rs = parsing.NewRunState(context.Background())
-	ch = rs.Tokens()
-	ch <- &token.Token{Typ: lsql.TokenSelect, Pos: 0, Val: "SELECT"}
-	ch <- &token.Token{Typ: token.Identifier, Pos: 7, Val: "x"}
-	ch <- &token.Token{Typ: token.EOF, Pos: 8, Val: ""}
+	tokens = token.Tokens{
+		&token.Token{Typ: lsql.TokenSelect, Pos: 0, Val: "SELECT"},
+		&token.Token{Typ: token.Identifier, Pos: 7, Val: "x"},
+		&token.Token{Typ: token.EOF, Pos: 8, Val: ""},
+	}
+
+	rs = parsing.NewRunState(context.Background(), tokens)
 	rs.Next()
 	f = AtSelect(p, p, rs)
 	if f != nil {
@@ -131,7 +130,7 @@ func TestAtSelect(t *testing.T) {
 }
 
 func TestAtFrom(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := AtFrom(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -142,7 +141,7 @@ func TestAtFrom(t *testing.T) {
 }
 
 func TestAtWhere(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := AtWhere(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -153,7 +152,7 @@ func TestAtWhere(t *testing.T) {
 }
 
 func TestAtGroupBy(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := AtGroupBy(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -163,9 +162,10 @@ func TestAtGroupBy(t *testing.T) {
 	}
 
 	p := New(nil)
-	rs = parsing.NewRunState(context.Background())
-	ch := rs.Tokens()
-	ch <- &token.Token{Typ: token.Space, Pos: 0, Val: " "}
+	tokens := token.Tokens{
+		&token.Token{Typ: token.Space, Pos: 0, Val: " "},
+	}
+	rs = parsing.NewRunState(context.Background(), tokens)
 	rs.Next()
 	f = AtGroupBy(p, p, rs)
 	if f != nil {
@@ -177,7 +177,7 @@ func TestAtGroupBy(t *testing.T) {
 }
 
 func TestAtHaving(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := AtHaving(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -188,7 +188,7 @@ func TestAtHaving(t *testing.T) {
 }
 
 func TestAtOrderBy(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := AtOrderBy(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -199,7 +199,7 @@ func TestAtOrderBy(t *testing.T) {
 }
 
 func TestAtLimit(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := AtLimit(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -210,7 +210,7 @@ func TestAtLimit(t *testing.T) {
 }
 
 func TestAtIntoOutfile(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := AtIntoOutfile(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -221,7 +221,7 @@ func TestAtIntoOutfile(t *testing.T) {
 }
 
 func TestAtUnion(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	f := AtUnion(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")

--- a/pkg/parsing/sql/sql.go
+++ b/pkg/parsing/sql/sql.go
@@ -19,7 +19,6 @@
 // support for specific SELECT statements
 //
 // NOTE: While Trickster does not proved a true, full AST; we would love to and welcome all contributions
-//
 package sql
 
 import (
@@ -36,11 +35,6 @@ var ErrUnsupportedVerb = errors.New("unsupported verb")
 
 // ErrUnsupportedClause represents an error of type "unsupported clause"
 var ErrUnsupportedClause = errors.New("unsupported clause")
-
-// // Parser defines the SQL Parser Interface
-// type Parser interface {
-// 	Run(parsing.Parser, string, context.Context) error
-// }
 
 // Parser represents the base SQLParser struct that conforms to the Parser interface
 type Parser struct {

--- a/pkg/parsing/sql/sql.go
+++ b/pkg/parsing/sql/sql.go
@@ -117,8 +117,8 @@ func (sp *Parser) Run(ctx context.Context, p parsing.Parser,
 	if lexer == nil {
 		return nil, parsing.ErrNoLexer
 	}
-	rs := parsing.NewRunState(ctx)
-	go lexer.Run(query, rs.Tokens())
+	tokens := lexer.Run(query)
+	rs := parsing.NewRunState(ctx, tokens)
 	for state := sp.options.EntryFunc(); state != nil; {
 		state = state(p, sp, rs)
 	}

--- a/pkg/parsing/sql/sql_test.go
+++ b/pkg/parsing/sql/sql_test.go
@@ -76,13 +76,13 @@ func TestParser(t *testing.T) {
 
 	_, err = sp.Run(context.Background(), sp, tq01+"\n UNION something else")
 	if err != parsing.ErrUnsupportedKeyword {
-		t.Error("expected error for UnsupportedKeyword", err)
+		t.Error("expected error for UnsupportedKeyword got", err)
 	}
 
 }
 
 func TestUnsupportedVerb(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	UnsupportedVerb(nil, nil, rs)
 	if rs.Error() != ErrUnsupportedVerb {
 		t.Error("expected err for UnsupportedVerb")
@@ -90,7 +90,7 @@ func TestUnsupportedVerb(t *testing.T) {
 }
 
 func TestUnsupportedClause(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	UnsupportedClause(nil, nil, rs)
 	if rs.Error() != ErrUnsupportedClause {
 		t.Error("expected err for UnsupportedClause")
@@ -98,7 +98,7 @@ func TestUnsupportedClause(t *testing.T) {
 }
 
 func TestFindVerbUnsupportedParser(t *testing.T) {
-	rs := parsing.NewRunState(context.Background())
+	rs := parsing.NewRunState(context.Background(), nil)
 	FindVerb(nil, nil, rs)
 	if rs.Error() != parsing.ErrUnsupportedParser {
 		t.Error("expected err for UnsupportedParser")

--- a/pkg/parsing/token/token.go
+++ b/pkg/parsing/token/token.go
@@ -38,10 +38,9 @@ const (
 
 // Token represents a token or text string returned from the scanner.
 type Token struct {
-	Typ  Typ       // The type of this Token.
-	Pos  int       // The starting position, in bytes, of this Token in the input string.
-	Val  string    // The value of this Token.
-	dict TypLookup // to get the token Typ as a string for String() calls
+	Typ Typ    // The type of this Token.
+	Pos int    // The starting position, in bytes, of this Token in the input string.
+	Val string // The value of this Token.
 }
 
 // Lookup represents a map of Strings to Token Reference

--- a/pkg/parsing/token/token.go
+++ b/pkg/parsing/token/token.go
@@ -105,3 +105,18 @@ func (t Tokens) Values() []string {
 	}
 	return s
 }
+
+// Compress returns a new Tokens slice with nil values removed
+func (t Tokens) Compress() Tokens {
+	if len(t) == 0 {
+		return t
+	}
+	out := make(Tokens, 0, len(t))
+	for _, tk := range t {
+		if tk == nil {
+			continue
+		}
+		out = append(out, tk)
+	}
+	return out
+}

--- a/pkg/parsing/token/token_test.go
+++ b/pkg/parsing/token/token_test.go
@@ -106,3 +106,30 @@ func TestValues(t *testing.T) {
 		t.Error("values mismatch")
 	}
 }
+
+func TestCompress(t *testing.T) {
+	tk := Tokens{}
+	tk = tk.Compress()
+	if len(tk) != 0 {
+		t.Error("expedted enmpty tokens slice")
+	}
+
+	tk = Tokens{
+		nil,
+		nil,
+	}
+	tk = tk.Compress()
+	if len(tk) != 0 {
+		t.Error("expedted enmpty tokens slice")
+	}
+
+	tk = Tokens{
+		nil,
+		&Token{},
+		nil,
+	}
+	tk = tk.Compress()
+	if len(tk) != 1 {
+		t.Error("expedted 1 element in tokens slice")
+	}
+}

--- a/pkg/parsing/token/token_test.go
+++ b/pkg/parsing/token/token_test.go
@@ -111,7 +111,7 @@ func TestCompress(t *testing.T) {
 	tk := Tokens{}
 	tk = tk.Compress()
 	if len(tk) != 0 {
-		t.Error("expedted enmpty tokens slice")
+		t.Error("expected empty tokens slice")
 	}
 
 	tk = Tokens{
@@ -120,7 +120,7 @@ func TestCompress(t *testing.T) {
 	}
 	tk = tk.Compress()
 	if len(tk) != 0 {
-		t.Error("expedted enmpty tokens slice")
+		t.Error("expected empty tokens slice")
 	}
 
 	tk = Tokens{
@@ -130,6 +130,6 @@ func TestCompress(t *testing.T) {
 	}
 	tk = tk.Compress()
 	if len(tk) != 1 {
-		t.Error("expedted 1 element in tokens slice")
+		t.Error("expected 1 element in tokens slice")
 	}
 }

--- a/pkg/timeseries/sqlparser/sqlparser_test.go
+++ b/pkg/timeseries/sqlparser/sqlparser_test.go
@@ -65,9 +65,10 @@ func TestParseComment(t *testing.T) {
 	trq := &timeseries.TimeRangeQuery{Statement: "trickster"}
 	ro := &timeseries.RequestOptions{TimeFormat: 42}
 	rc := NewRunContext(trq, ro)
-	rs := parsing.NewRunState(rc)
-	ch := rs.Tokens()
-	ch <- &token.Token{Typ: lsql.TokenComment, Val: ":)"}
+	tk := token.Tokens{
+		&token.Token{Typ: lsql.TokenComment, Val: ":)"},
+	}
+	rs := parsing.NewRunState(rc, tk)
 	rs.Next()
 	ParseFVComment(nil, nil, rs)
 	if rs.Current().Typ != lsql.TokenComment {


### PR DESCRIPTION
This patch improves the SQL Lexer/Parser performance by refactoring from the previous scheme of concurrent lexing/parsing via channels to a lex-then-parse scheme that is more performant due to a 100% removal of channels in the request path.