### PR TITLE
remove unneeded nil checks

### DIFF
--- a/pkg/proxy/engines/cache_chunk_test.go
+++ b/pkg/proxy/engines/cache_chunk_test.go
@@ -228,7 +228,7 @@ func TestPartialCacheMissRangeRequestChunks(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if deltas == nil || len(deltas) < 1 {
+	if len(deltas) == 0 {
 		t.Errorf("invalid deltas: %v", deltas)
 	} else if deltas[0].Start != 10 ||
 		deltas[0].End != 20 {

--- a/pkg/proxy/engines/cache_test.go
+++ b/pkg/proxy/engines/cache_test.go
@@ -248,7 +248,7 @@ func TestPartialCacheMissRangeRequest(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if deltas == nil || len(deltas) < 1 {
+	if len(deltas) == 0 {
 		t.Errorf("invalid deltas: %v", deltas)
 	} else if deltas[0].Start != 10 ||
 		deltas[0].End != 20 {

--- a/pkg/proxy/engines/document.go
+++ b/pkg/proxy/engines/document.go
@@ -275,7 +275,7 @@ func (d *HTTPDocument) ParsePartialContentBody(resp *http.Response,
 // the caller must know that document's multipart ranges include full content length before calling this method
 func (d *HTTPDocument) FulfillContentBody() error {
 
-	if d.RangeParts == nil || len(d.RangeParts) == 0 {
+	if len(d.RangeParts) == 0 {
 		d.SetBody(nil)
 		return txe.ErrNoRanges
 	}

--- a/pkg/proxy/engines/proxy_request_test.go
+++ b/pkg/proxy/engines/proxy_request_test.go
@@ -58,7 +58,7 @@ func TestParseRequestRanges(t *testing.T) {
 	}
 	pr.parseRequestRanges()
 
-	if pr.wantedRanges == nil || len(pr.wantedRanges) < 1 {
+	if len(pr.wantedRanges) == 0 {
 		t.Errorf("unexpected range parse: %v", pr.wantedRanges)
 	}
 

--- a/pkg/proxy/headers/headers.go
+++ b/pkg/proxy/headers/headers.go
@@ -162,7 +162,7 @@ func (l Lookup) Clone() Lookup {
 // If a key exists in both maps, the source value wins.
 // If the destination map is nil, the source map will not be merged
 func Merge(dst, src http.Header) {
-	if src == nil || len(src) == 0 || dst == nil {
+	if len(src) == 0 || dst == nil {
 		return
 	}
 	for k, sv := range src {
@@ -175,7 +175,7 @@ func Merge(dst, src http.Header) {
 
 // UpdateHeaders updates the provided headers collection with the provided updates
 func UpdateHeaders(headers http.Header, updates map[string]string) {
-	if headers == nil || updates == nil || len(updates) == 0 {
+	if headers == nil || len(updates) == 0 {
 		return
 	}
 	for k, v := range updates {
@@ -207,7 +207,7 @@ func ExtractHeader(headers http.Header, header string) (string, bool) {
 // String returns the string representation of the headers as if
 // they were transmitted over the wire (Header1: value1\nHeader2: value2\n\n)
 func String(h http.Header) string {
-	if h == nil || len(h) == 0 {
+	if len(h) == 0 {
 		return "\n\n"
 	}
 	sb := strings.Builder{}
@@ -224,7 +224,7 @@ func String(h http.Header) string {
 // LogString returns a compact string representation of the headers suitable for
 // use with logging
 func LogString(h http.Header) string {
-	if h == nil || len(h) == 0 {
+	if len(h) == 0 {
 		return "{}"
 	}
 

--- a/pkg/proxy/headers/headers.go
+++ b/pkg/proxy/headers/headers.go
@@ -162,7 +162,7 @@ func (l Lookup) Clone() Lookup {
 // If a key exists in both maps, the source value wins.
 // If the destination map is nil, the source map will not be merged
 func Merge(dst, src http.Header) {
-	if len(src) == 0 || dst == nil {
+	if len(src) == 0 || len(dst) {
 		return
 	}
 	for k, sv := range src {

--- a/pkg/proxy/params/params.go
+++ b/pkg/proxy/params/params.go
@@ -30,7 +30,7 @@ import (
 
 // UpdateParams updates the provided query parameters collection with the provided updates
 func UpdateParams(params url.Values, updates map[string]string) {
-	if params == nil || updates == nil || len(updates) == 0 {
+	if params == nil || len(updates) == 0 {
 		return
 	}
 	for k, v := range updates {

--- a/pkg/proxy/ranges/byterange/multipart.go
+++ b/pkg/proxy/ranges/byterange/multipart.go
@@ -27,8 +27,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 )
 
 // MultipartByteRange represents one part of a list of multipart byte ranges
@@ -42,7 +42,7 @@ type MultipartByteRanges map[Range]*MultipartByteRange
 
 // Merge merges the source MultipartByteRanges map into the subject map
 func (mbrs MultipartByteRanges) Merge(src MultipartByteRanges) {
-	if src == nil || len(src) == 0 || mbrs == nil {
+	if len(src) == 0 || mbrs == nil {
 		return
 	}
 	for _, v := range src.Ranges() {
@@ -66,7 +66,7 @@ func (mbrs MultipartByteRanges) PackableMultipartByteRanges() map[string]*Multip
 func (mbrs MultipartByteRanges) Body(fullContentLength int64, contentType string) (http.Header, []byte) {
 
 	ranges := mbrs.Ranges()
-	if ranges == nil || len(ranges) == 0 {
+	if len(ranges) == 0 {
 		return nil, []byte{}
 	}
 
@@ -209,7 +209,7 @@ func ParseMultipartRangeResponseBody(body io.Reader,
 func (mbrs MultipartByteRanges) ExtractResponseRange(ranges Ranges, fullContentLength int64,
 	contentType string, body []byte) (http.Header, []byte) {
 
-	if ranges == nil || len(ranges) == 0 {
+	if len(ranges) == 0 {
 		return nil, body
 	}
 

--- a/pkg/proxy/tls/options/options.go
+++ b/pkg/proxy/tls/options/options.go
@@ -80,7 +80,7 @@ func (o *Options) Equal(o2 *Options) bool {
 func (o *Options) Validate() (bool, error) {
 
 	if (o.FullChainCertPath == "" || o.PrivateKeyPath == "") &&
-		(o.CertificateAuthorityPaths == nil || len(o.CertificateAuthorityPaths) == 0) {
+		len(o.CertificateAuthorityPaths) == 0 {
 		return false, nil
 	}
 


### PR DESCRIPTION
this removes duplicative nil checks where the length of the slice or map is also being checked

because unit tests on main currently fail from recent package updates, this PR is expected to fail unit tests too. will address failing tests in a separate PR.