### PR TITLE
ci: use reviewdog with golangci-lint to limit feedback to changed files

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           go-version: stable
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: reviewdog/action-golangci-lint@v2
         with:
-          version: v1.64
-          args: --timeout 5m
+          go_version: go.mod
+          golangci_lint_flags: "--config=.golangci.yml --timeout 5m"
   build:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Upgrade the CI lint to use reviewdog, which should limit feedback to just what is changed in the PR.