### PR TITLE
fix remaining lint issues

### DIFF
--- a/pkg/backends/clickhouse/clickhouse.go
+++ b/pkg/backends/clickhouse/clickhouse.go
@@ -95,7 +95,8 @@ func (c *Client) ParseTimeRangeQuery(r *http.Request) (*timeseries.TimeRangeQuer
 	trq.TemplateURL = urls.Clone(r.URL)
 
 	if isBody {
-		r = request.SetBody(r, []byte(trq.Statement))
+		// TODO: the return value (a new *http.Request) is not being used
+		request.SetBody(r, []byte(trq.Statement))
 	} else {
 		// Swap in the Tokenized Query in the Url Params
 		qi.Set(upQuery, trq.Statement)

--- a/pkg/backends/clickhouse/model/model.go
+++ b/pkg/backends/clickhouse/model/model.go
@@ -27,10 +27,13 @@ import (
 	"sync"
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/sqlparser"
 )
+
+const formatHeader = "X-Clickhouse-Format"
 
 var marshalers = map[byte]dataset.Marshaler{
 	0: marshalTimeseriesJSON,
@@ -88,26 +91,27 @@ func NewModeler() *timeseries.Modeler {
 }
 
 func marshalTimeseriesJSON(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
-	status int, w io.Writer) error {
-
+	status int) ([]byte, error) {
 	type md struct {
 		name  string
 		typ   string
 		quote bool
 	}
-
 	trq := ds.TimeRangeQuery
 	if trq == nil {
-		return timeseries.ErrNoTimerangeQuery
+		return nil, timeseries.ErrNoTimerangeQuery
 	}
-
-	if rw, ok := w.(http.ResponseWriter); ok {
-		h := rw.Header()
-		h.Set(headers.NameContentType, headers.ValueApplicationJSON+"; charset=UTF-8")
-		h.Set("X-Clickhouse-Format", "JSON")
-		rw.WriteHeader(status)
+	var h map[string]string
+	if rlo != nil {
+		if rlo.VendorData == nil {
+			h = make(map[string]string)
+			rlo.VendorData = h
+		}
+	} else {
+		h = make(map[string]string)
 	}
-
+	h[formatHeader] = "JSON"
+	w := new(bytes.Buffer)
 	w.Write([]byte(`{
 	"meta":
 	[`,
@@ -236,7 +240,7 @@ func marshalTimeseriesJSON(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
 	"rows": `))
 	w.Write([]byte(strconv.FormatInt(j, 10)))
 	w.Write([]byte("\n}\n"))
-	return nil
+	return w.Bytes(), nil
 }
 
 func shouldQuote(in string) bool {
@@ -247,55 +251,98 @@ func shouldQuote(in string) bool {
 }
 
 func marshalTimeseriesCSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
-	status int, w io.Writer) error {
-	return marshalTimeseriesXSV(ds, rlo, status,
-		&tsvWriter{Writer: w, separator: ","})
+	status int) ([]byte, error) {
+	w := new(bytes.Buffer)
+	err := marshalTimeseriesXSV(ds, rlo, &tsvWriter{Writer: w, separator: ","})
+	if err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
 }
 
-func marshalTimeseriesCSVWithNames(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
-	status int, w io.Writer) error {
-	return marshalTimeseriesXSV(ds, rlo, status,
+func marshalTimeseriesCSVWithNames(ds *dataset.DataSet,
+	rlo *timeseries.RequestOptions, status int) ([]byte, error) {
+	w := new(bytes.Buffer)
+	err := marshalTimeseriesXSV(ds, rlo,
 		&tsvWriter{Writer: w, writeNames: true, separator: ","})
+	if err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+func marshalTimeseriesTSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
+	status int) ([]byte, error) {
+	w := new(bytes.Buffer)
+	err := marshalTimeseriesXSV(ds, rlo, &tsvWriter{Writer: w, separator: "\t"})
+	if err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+func marshalTimeseriesTSVWithNames(ds *dataset.DataSet,
+	rlo *timeseries.RequestOptions, status int) ([]byte, error) {
+	w := new(bytes.Buffer)
+	err := marshalTimeseriesXSV(ds, rlo,
+		&tsvWriter{Writer: w, writeNames: true, separator: "\t"})
+	if err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+func marshalTimeseriesTSVWithNamesAndTypes(ds *dataset.DataSet,
+	rlo *timeseries.RequestOptions, status int) ([]byte, error) {
+	w := new(bytes.Buffer)
+	err := marshalTimeseriesXSV(ds, rlo,
+		&tsvWriter{Writer: w, writeNames: true, writeTypes: true, separator: "\t"})
+	if err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
 }
 
 func marshalTimeseriesXSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
-	status int, tw *tsvWriter) error {
+	tw *tsvWriter) error {
 	trq := ds.TimeRangeQuery
 	if trq == nil {
 		return timeseries.ErrNoTimerangeQuery
 	}
 
-	if rw, ok := tw.Writer.(http.ResponseWriter); ok {
-		h := rw.Header()
-
-		if tw.separator == "" {
-			tw.separator = ","
+	var h map[string]string
+	if rlo != nil {
+		if rlo.VendorData == nil {
+			rlo.VendorData = make(map[string]string)
 		}
-
-		var ctPart, fmtPart string
-		switch tw.separator {
-		case "\t":
-			ctPart = "tab"
-			fmtPart = "TSV"
-		default:
-			ctPart = "comma"
-			fmtPart = "CSV"
-			tw.separator = ","
-		}
-
-		h.Set(headers.NameContentType, "text/"+ctPart+"-separated-values; charset=UTF-8")
-		if tw.writeTypes {
-			h.Set("X-Clickhouse-Format", fmtPart+"WithNamesAndTypes")
-		} else if tw.writeNames {
-			h.Set("X-Clickhouse-Format", fmtPart+"WithNames")
-		} else {
-			h.Set("X-Clickhouse-Format", fmtPart)
-		}
-		rw.WriteHeader(status)
+		h = rlo.VendorData
 	}
 
-	if trq == nil || (len(trq.TagFieldDefintions) == 0 &&
-		len(trq.ValueFieldDefinitions) == 0) {
+	if tw.separator == "" {
+		tw.separator = ","
+	}
+
+	var ctPart, fmtPart string
+	switch tw.separator {
+	case "\t":
+		ctPart = "tab"
+		fmtPart = "TSV"
+	default:
+		ctPart = "comma"
+		fmtPart = "CSV"
+		tw.separator = ","
+	}
+	h[headers.NameContentType] = "text/" + ctPart + "-separated-values; charset=UTF-8"
+	if tw.writeTypes {
+		h[formatHeader] = fmtPart + "WithNamesAndTypes"
+	} else if tw.writeNames {
+		h[formatHeader] = fmtPart + "WithNames"
+	} else {
+		h[formatHeader] = fmtPart
+	}
+
+	if len(trq.TagFieldDefintions) == 0 &&
+		len(trq.ValueFieldDefinitions) == 0 {
 		return timeseries.ErrNoTimerangeQuery
 	}
 
@@ -386,40 +433,14 @@ func wrapCSVCell(in, separator string) string {
 	return in
 }
 
-func marshalTimeseriesTSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
-	status int, w io.Writer) error {
-	return marshalTimeseriesXSV(ds, rlo, status,
-		&tsvWriter{Writer: w, separator: "\t"})
-}
-
-func marshalTimeseriesTSVWithNames(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
-	status int, w io.Writer) error {
-	return marshalTimeseriesXSV(ds, rlo, status,
-		&tsvWriter{Writer: w, writeNames: true, separator: "\t"})
-}
-
-func marshalTimeseriesTSVWithNamesAndTypes(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
-	status int, w io.Writer) error {
-	return marshalTimeseriesXSV(ds, rlo, status,
-		&tsvWriter{Writer: w, writeNames: true, writeTypes: true, separator: "\t"})
-}
-
 // MarshalTimeseries converts a Timeseries into a JSON blob
 func MarshalTimeseries(ts timeseries.Timeseries, rlo *timeseries.RequestOptions, status int) ([]byte, error) {
-	buf := bytes.NewBuffer(nil)
-	err := MarshalTimeseriesWriter(ts, rlo, status, buf)
-	return buf.Bytes(), err
-}
-
-// MarshalTimeseriesWriter converts a Timeseries into a JSON blob via an io.Writer
-func MarshalTimeseriesWriter(ts timeseries.Timeseries, rlo *timeseries.RequestOptions,
-	status int, w io.Writer) error {
 	if ts == nil {
-		return timeseries.ErrUnknownFormat
+		return nil, timeseries.ErrUnknownFormat
 	}
 	ds, ok := ts.(*dataset.DataSet)
 	if !ok {
-		return timeseries.ErrUnknownFormat
+		return nil, timeseries.ErrUnknownFormat
 	}
 	var of byte
 	if rlo != nil {
@@ -427,9 +448,36 @@ func MarshalTimeseriesWriter(ts timeseries.Timeseries, rlo *timeseries.RequestOp
 	}
 	marshaler, ok := marshalers[of]
 	if !ok {
-		return timeseries.ErrUnknownFormat
+		return nil, timeseries.ErrUnknownFormat
 	}
-	return marshaler(ds, rlo, status, w)
+	return marshaler(ds, rlo, status)
+}
+
+// MarshalTimeseriesWriter converts a Timeseries into a JSON blob via an io.Writer
+func MarshalTimeseriesWriter(ts timeseries.Timeseries,
+	rlo *timeseries.RequestOptions, status int, w io.Writer) error {
+	b, err := MarshalTimeseries(ts, rlo, status)
+	if err != nil {
+		return err
+	}
+	var of byte
+	if rlo != nil {
+		of = rlo.OutputFormat
+	}
+
+	var h http.Header
+	if rlo != nil && len(rlo.VendorData) > 0 {
+		h = make(http.Header)
+		for k, v := range rlo.VendorData {
+			h.Set(k, v)
+		}
+	}
+	err = response.WriteResponseHeader(w, status, of, h)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
 }
 
 // UnmarshalTimeseries converts a TSV blob into a Timeseries

--- a/pkg/backends/clickhouse/model/model_test.go
+++ b/pkg/backends/clickhouse/model/model_test.go
@@ -17,8 +17,6 @@
 package model
 
 import (
-	"io"
-	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -222,54 +220,42 @@ var testDataset = &dataset.DataSet{
 }
 
 func TestMarshalJSON(t *testing.T) {
-	w := httptest.NewRecorder()
-	marshalTimeseriesJSON(testDataset, &timeseries.RequestOptions{}, 200, w)
-	b, _ := io.ReadAll(w.Result().Body)
+	b, _ := marshalTimeseriesJSON(testDataset, &timeseries.RequestOptions{}, 200)
 	if string(b) != testDataJSON {
 		t.Error()
 	}
 }
 
 func TestMarshalCSV(t *testing.T) {
-	w := httptest.NewRecorder()
-	marshalTimeseriesCSV(testDataset, &timeseries.RequestOptions{OutputFormat: 1}, 200, w)
-	b, _ := io.ReadAll(w.Result().Body)
+	b, _ := marshalTimeseriesCSV(testDataset, &timeseries.RequestOptions{OutputFormat: 1}, 200)
 	if string(b) != testDataCSV {
 		t.Error()
 	}
 }
 
 func TestMarshalCSVWithNames(t *testing.T) {
-	w := httptest.NewRecorder()
-	marshalTimeseriesCSVWithNames(testDataset, &timeseries.RequestOptions{OutputFormat: 2}, 200, w)
-	b, _ := io.ReadAll(w.Result().Body)
+	b, _ := marshalTimeseriesCSVWithNames(testDataset, &timeseries.RequestOptions{OutputFormat: 2}, 200)
 	if string(b) != testDataCSVWithNames {
 		t.Error()
 	}
 }
 
 func TestMarshalTSV(t *testing.T) {
-	w := httptest.NewRecorder()
-	marshalTimeseriesTSV(testDataset, &timeseries.RequestOptions{OutputFormat: 3}, 200, w)
-	b, _ := io.ReadAll(w.Result().Body)
+	b, _ := marshalTimeseriesTSV(testDataset, &timeseries.RequestOptions{OutputFormat: 3}, 200)
 	if string(b) != testDataTSV {
 		t.Error()
 	}
 }
 
 func TestMarshalTSVWithNames(t *testing.T) {
-	w := httptest.NewRecorder()
-	marshalTimeseriesTSVWithNames(testDataset, &timeseries.RequestOptions{OutputFormat: 4}, 200, w)
-	b, _ := io.ReadAll(w.Result().Body)
+	b, _ := marshalTimeseriesTSVWithNames(testDataset, &timeseries.RequestOptions{OutputFormat: 4}, 200)
 	if string(b) != testDataTSVWithNames {
 		t.Error()
 	}
 }
 
 func TestMarshalTSVWithNamesAndTypes(t *testing.T) {
-	w := httptest.NewRecorder()
-	marshalTimeseriesTSVWithNamesAndTypes(testDataset, &timeseries.RequestOptions{OutputFormat: 5}, 200, w)
-	b, _ := io.ReadAll(w.Result().Body)
+	b, _ := marshalTimeseriesTSVWithNamesAndTypes(testDataset, &timeseries.RequestOptions{OutputFormat: 5}, 200)
 	if string(b) != testDataTSVWithNamesAndTypes {
 		t.Error()
 	}

--- a/pkg/backends/clickhouse/url.go
+++ b/pkg/backends/clickhouse/url.go
@@ -45,7 +45,8 @@ func (c *Client) SetExtent(r *http.Request, trq *timeseries.TimeRangeQuery, exte
 
 	sqlQuery := interpolateTimeQuery(trq.Statement, trq.TimestampDefinition.Name, trq.TimestampDefinition.ProviderData1, extent, trq.Step)
 	if isBody {
-		r = request.SetBody(r, []byte(sqlQuery))
+		// TODO: the return value (a new *http.Request) is not being used
+		request.SetBody(r, []byte(sqlQuery))
 	} else {
 		qi.Set(upQuery, sqlQuery)
 		r.URL.RawQuery = qi.Encode()

--- a/pkg/backends/influxdb/model/marshal.go
+++ b/pkg/backends/influxdb/model/marshal.go
@@ -18,40 +18,36 @@ package model
 
 import (
 	"bytes"
-	"fmt"
+	"encoding/json"
 	"io"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/influxdata/influxdb/models"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
 )
 
+const timeColumnName = "time"
+
 var marshalers = map[byte]dataset.Marshaler{
-	0: marshalTimeseriesJSON,
+	0: marshalTimeseriesJSONMinified,
 	1: marshalTimeseriesJSONPretty,
 	2: marshalTimeseriesCSV,
 }
 
 // MarshalTimeseries converts a Timeseries into a JSON blob
-func MarshalTimeseries(ts timeseries.Timeseries, rlo *timeseries.RequestOptions, status int) ([]byte, error) {
-	buf := bytes.NewBuffer(nil)
-	err := MarshalTimeseriesWriter(ts, rlo, status, buf)
-	return buf.Bytes(), err
-}
-
-// MarshalTimeseriesWriter converts a Timeseries into a JSON blob via an io.Writer
-func MarshalTimeseriesWriter(ts timeseries.Timeseries, rlo *timeseries.RequestOptions, status int, w io.Writer) error {
+func MarshalTimeseries(ts timeseries.Timeseries,
+	rlo *timeseries.RequestOptions, status int) ([]byte, error) {
 	if ts == nil {
-		return timeseries.ErrUnknownFormat
+		return nil, timeseries.ErrUnknownFormat
 	}
 	ds, ok := ts.(*dataset.DataSet)
 	if !ok {
-		return timeseries.ErrUnknownFormat
+		return nil, timeseries.ErrUnknownFormat
 	}
 	var of byte
 	if rlo != nil {
@@ -59,9 +55,37 @@ func MarshalTimeseriesWriter(ts timeseries.Timeseries, rlo *timeseries.RequestOp
 	}
 	marshaler, ok := marshalers[of]
 	if !ok {
-		return timeseries.ErrUnknownFormat
+		return nil, timeseries.ErrUnknownFormat
 	}
-	return marshaler(ds, rlo, status, w)
+	return marshaler(ds, rlo, status)
+}
+
+// MarshalTimeseriesWriter writes a Timeseries as a JSON blob to an io.Writer
+func MarshalTimeseriesWriter(ts timeseries.Timeseries,
+	rlo *timeseries.RequestOptions, status int, w io.Writer) error {
+	b, err := MarshalTimeseries(ts, rlo, status)
+	if err != nil {
+		return err
+	}
+	var of byte
+	if rlo != nil {
+		of = rlo.OutputFormat
+	}
+	err = response.WriteResponseHeader(w, status, of, nil)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(b)
+	return err
+}
+
+func formatRFC3339Time(epoch epoch.Epoch, m int64) any {
+	t := time.Unix(0, int64(epoch))
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func formatEpochTime(epoch epoch.Epoch, m int64) any {
+	return int64(epoch) / m
 }
 
 func writeRFC3339Time(w io.Writer, epoch epoch.Epoch, m int64) {
@@ -71,24 +95,6 @@ func writeRFC3339Time(w io.Writer, epoch epoch.Epoch, m int64) {
 
 func writeEpochTime(w io.Writer, epoch epoch.Epoch, m int64) {
 	w.Write([]byte(strconv.FormatInt(int64(epoch)/m, 10)))
-}
-
-func writeValue(w io.Writer, v any, nilVal string) {
-	if v == nil {
-		w.Write([]byte(nilVal))
-	}
-	switch t := v.(type) {
-	case string:
-		w.Write([]byte(`"` + t + `"`))
-	case bool:
-		w.Write([]byte(strconv.FormatBool(t)))
-	case int64:
-		w.Write([]byte(strconv.FormatInt(t, 10)))
-	case int:
-		w.Write([]byte(strconv.Itoa(t)))
-	case float64:
-		w.Write([]byte(strconv.FormatFloat(t, 'f', -1, 64)))
-	}
 }
 
 func writeCSVValue(w io.Writer, v any, nilVal string) {
@@ -114,207 +120,110 @@ func writeCSVValue(w io.Writer, v any, nilVal string) {
 	}
 }
 
-func marshalTimeseriesJSON(ds *dataset.DataSet, rlo *timeseries.RequestOptions, status int, w io.Writer) error {
-	if ds == nil {
-		return nil
-	}
-	if rw, ok := w.(http.ResponseWriter); ok {
-		h := rw.Header()
-		h.Set(headers.NameContentType, headers.ValueApplicationJSON+"; charset=UTF-8")
-		rw.WriteHeader(status)
-	}
-	dw, multiplier := getDateWriter(rlo)
+func marshalTimeseriesJSONMinified(ds *dataset.DataSet,
+	rlo *timeseries.RequestOptions, status int) ([]byte, error) {
+	return marshalTimeseriesJSON(ds, rlo, status, false)
+}
 
-	w.Write([]byte(`{"results":[`))
+func marshalTimeseriesJSONPretty(ds *dataset.DataSet,
+	rlo *timeseries.RequestOptions, status int) ([]byte, error) {
+	return marshalTimeseriesJSON(ds, rlo, status, true)
+}
+
+func toWireFormat(ds *dataset.DataSet,
+	rlo *timeseries.RequestOptions) (*WFDocument, error) {
+	if ds == nil {
+		return nil, nil
+	}
+	df, multiplier := getDateFormatter(rlo)
+	out := &WFDocument{}
 	lr := len(ds.Results)
-	for i := range ds.Results {
-		w.Write([]byte(
-			fmt.Sprintf(`{"statement_id":%d,"series":[`,
-				ds.Results[i].StatementID)))
-		ls := len(ds.Results[i].SeriesList)
-		for si, s := range ds.Results[i].SeriesList {
+	if lr > 0 {
+		out.Results = make([]*WFResult, 0, lr)
+	}
+	for _, dr := range ds.Results {
+		res := &WFResult{
+			StatementID: dr.StatementID,
+		}
+		ls := len(dr.SeriesList)
+		if ls > 0 {
+			res.SeriesList = make([]*models.Row, 0, ls)
+		}
+		for _, s := range dr.SeriesList {
 			if s == nil {
 				continue
 			}
-			if s.Header.Tags == nil {
-				s.Header.Tags = make(dataset.Tags)
+			row := &models.Row{
+				Name: s.Header.Name,
+				Tags: s.Header.Tags,
 			}
-			w.Write([]byte(
-				fmt.Sprintf(`{"name":"%s","tags":%s,`, s.Header.Name,
-					s.Header.Tags.JSON())))
-			fl := len(s.Header.FieldsList)
-			l := fl + 1
-			cols := make([]string, l)
-			var j int
-			for _, f := range s.Header.FieldsList {
-				if j == s.Header.TimestampIndex {
-					cols[j] = "time"
-					j++
+			row.Columns = make([]string, 0, len(s.Header.FieldsList)+1)
+			var tsColumnAdded bool
+			for i, header := range s.Header.FieldsList {
+				if i == s.Header.TimestampIndex {
+					row.Columns = append(row.Columns, timeColumnName)
+					tsColumnAdded = true
 				}
-				cols[j] = f.Name
-				j++
+				row.Columns = append(row.Columns, header.Name)
 			}
-			w.Write([]byte(
-				`"columns":["` + strings.Join(cols, `","`) + `"],"values":[`,
-			))
-			lp := len(s.Points) - 1
-			for j := range s.Points {
-				w.Write([]byte("["))
-				lv := len(s.Points[j].Values)
-				for n, v := range s.Points[j].Values {
+			if !tsColumnAdded {
+				row.Columns = append(row.Columns, timeColumnName)
+				tsColumnAdded = true
+			}
+
+			row.Values = make([][]any, 0, len(s.Points))
+
+			for _, p := range s.Points {
+				if len(p.Values) == 0 {
+					continue
+				}
+				vals := make([]any, 0, len(p.Values))
+				var tsValAdded bool
+				for n, v := range p.Values {
 					if n == s.Header.TimestampIndex {
-						dw(w, s.Points[j].Epoch, multiplier)
-						if n < lv {
-							w.Write([]byte(","))
-						}
-						n++
+						vals = append(vals, df(p.Epoch, multiplier))
+						tsValAdded = true
 					}
-					writeValue(w, v, "null")
-					if n < lv {
-						w.Write([]byte(","))
-					}
+					vals = append(vals, v)
 				}
-				w.Write([]byte("]"))
-				if j < lp {
-					w.Write([]byte(","))
+				if !tsValAdded {
+					vals = append(vals, df(p.Epoch, multiplier))
 				}
+				row.Values = append(row.Values, vals)
 			}
-			w.Write([]byte("]}"))
-			if si < ls-1 {
-				w.Write([]byte(","))
-			}
+			res.SeriesList = append(res.SeriesList, row)
 		}
-		w.Write([]byte("]}"))
-		if i < lr-1 {
-			w.Write([]byte(","))
-		}
+		out.Results = append(out.Results, res)
 	}
-	w.Write([]byte("]}"))
-	return nil
+	return out, nil
 }
 
-func marshalTimeseriesJSONPretty(ds *dataset.DataSet, rlo *timeseries.RequestOptions, status int, w io.Writer) error {
-
+func marshalTimeseriesJSON(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
+	_ int, pretty bool) ([]byte, error) {
 	if ds == nil {
-		return nil
+		return nil, nil
 	}
-	if rw, ok := w.(http.ResponseWriter); ok {
-		h := rw.Header()
-		h.Set(headers.NameContentType, headers.ValueApplicationJSON+"; charset=UTF-8")
-		rw.WriteHeader(status)
+	wfdoc, err := toWireFormat(ds, rlo)
+	if err != nil {
+		return nil, err
 	}
-	dw, multiplier := getDateWriter(rlo)
-
-	w.Write([]byte("{\n    \"results\": [\n"))
-	lr := len(ds.Results)
-	for i := range ds.Results {
-		w.Write([]byte(
-			fmt.Sprintf("        {\n            \"statement_id\": %d,\n            \"series\": [\n",
-				ds.Results[i].StatementID)))
-		ls := len(ds.Results[i].SeriesList)
-		for si, s := range ds.Results[i].SeriesList {
-			if s == nil {
-				continue
-			}
-			if s.Header.Tags == nil {
-				s.Header.Tags = make(dataset.Tags)
-			}
-			w.Write([]byte(
-				"                {\n" +
-					fmt.Sprintf("                    \"name\": \"%s\",\n", s.Header.Name) +
-					"                    \"tags\": {\n"))
-			for j, k := range s.Header.Tags.Keys() {
-				w.Write([]byte(fmt.Sprintf("                        \"%s\": \"%s\"", k, s.Header.Tags[k])))
-				if j < len(s.Header.Tags)-1 {
-					w.Write([]byte(","))
-				}
-				w.Write([]byte("\n"))
-			}
-			w.Write([]byte("                    },\n                    \"columns\": [\n"))
-			for j, v := range s.Header.FieldsList {
-				if j == s.Header.TimestampIndex {
-					w.Write([]byte("                        \"time\""))
-					if j < len(s.Header.FieldsList)-1 {
-						w.Write([]byte(","))
-					}
-					w.Write([]byte("\n"))
-					j++
-				}
-				w.Write([]byte("                        \"" + v.Name + "\""))
-				if j < len(s.Header.FieldsList)-1 {
-					w.Write([]byte(","))
-				}
-				w.Write([]byte("\n"))
-				j++
-			}
-
-			fl := len(s.Header.FieldsList)
-			l := fl + 1
-			cols := make([]string, l)
-			var j int
-			for _, f := range s.Header.FieldsList {
-				if j == s.Header.TimestampIndex {
-					cols[j] = "time"
-					j++
-				}
-				cols[j] = f.Name
-				j++
-			}
-			w.Write([]byte("                    ],\n                    \"values\": [\n"))
-			lp := len(s.Points) - 1
-			for j := range s.Points {
-				w.Write([]byte("                        [\n"))
-				lv := len(s.Points[j].Values) - 1
-				for n, v := range s.Points[j].Values {
-					if n == s.Header.TimestampIndex {
-						w.Write([]byte("                            "))
-						dw(w, s.Points[j].Epoch, multiplier)
-						if n < lv {
-							w.Write([]byte(","))
-						}
-						w.Write([]byte("\n"))
-						n++
-					}
-					w.Write([]byte("                            "))
-					writeValue(w, v, "null")
-					if n < lv {
-						w.Write([]byte(","))
-					}
-					w.Write([]byte("\n"))
-				}
-				w.Write([]byte("                        ]"))
-				if j < lp {
-					w.Write([]byte(","))
-				}
-				w.Write([]byte("\n"))
-			}
-			w.Write([]byte("                    ]\n                }"))
-			if si < ls-1 {
-				w.Write([]byte(","))
-			}
-			w.Write([]byte("\n"))
-		}
-		w.Write([]byte("            ]"))
-		if i < lr-1 {
-			w.Write([]byte(","))
-		}
-		w.Write([]byte("\n"))
+	var b []byte
+	if pretty {
+		b, err = json.MarshalIndent(wfdoc, "", "  ")
+	} else {
+		b, err = json.Marshal(wfdoc)
 	}
-	w.Write([]byte("        }\n    ]\n}\n"))
-	return nil
+	return b, err
 }
 
-func marshalTimeseriesCSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions, status int, w io.Writer) error {
+func marshalTimeseriesCSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
+	status int) ([]byte, error) {
 	var headerWritten bool
 	dw, multiplier := getDateWriter(rlo)
 	if ds == nil {
-		return nil
+		return nil, nil
 	}
-	if rw, ok := w.(http.ResponseWriter); ok {
-		h := rw.Header()
-		h.Set(headers.NameContentType, headers.ValueApplicationCSV+"; charset=UTF-8")
-		rw.WriteHeader(status)
-	}
+	w := new(bytes.Buffer)
 	for _, s := range ds.Results[0].SeriesList {
 		if s == nil {
 			continue
@@ -325,7 +234,7 @@ func marshalTimeseriesCSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions, s
 			var j int
 			for _, f := range s.Header.FieldsList {
 				if j == s.Header.TimestampIndex {
-					cols[j] = "time"
+					cols[j] = timeColumnName
 					j++
 				}
 				cols[j] = f.Name
@@ -353,10 +262,32 @@ func marshalTimeseriesCSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions, s
 			w.Write([]byte("\n"))
 		}
 	}
-	return nil
+	return w.Bytes(), nil
 }
 
+type dateFormatter func(epoch.Epoch, int64) any
 type dateWriter func(io.Writer, epoch.Epoch, int64)
+
+func getDateFormatter(rlo *timeseries.RequestOptions) (dateFormatter, int64) {
+	var df dateFormatter
+	var tf byte
+	var multiplier int64
+	if rlo != nil {
+		tf = rlo.TimeFormat
+	}
+	switch tf {
+	case 0:
+		df = formatRFC3339Time
+	default:
+		if m, ok := epochMultipliers[tf]; ok {
+			multiplier = m
+		} else {
+			multiplier = 1
+		}
+		df = formatEpochTime
+	}
+	return df, multiplier
+}
 
 func getDateWriter(rlo *timeseries.RequestOptions) (dateWriter, int64) {
 	var dw dateWriter

--- a/pkg/backends/influxdb/model/marshal_test.go
+++ b/pkg/backends/influxdb/model/marshal_test.go
@@ -85,12 +85,14 @@ func TestMarshalTimeseries(t *testing.T) {
 }
 
 func TestMarshalTimeseriesJSON(t *testing.T) {
-
-	err := marshalTimeseriesJSON(nil, nil, 200, nil)
+	_, err := marshalTimeseriesJSON(nil, nil, 200, false)
 	if err != nil {
 		t.Error(err)
 	}
-
+	_, err = marshalTimeseriesJSON(nil, nil, 200, true)
+	if err != nil {
+		t.Error(err)
+	}
 }
 
 func TestWriteEpochTime(t *testing.T) {
@@ -109,67 +111,6 @@ func TestWriteEpochTime(t *testing.T) {
 		t.Errorf("expected %s got %s", expected, string(b))
 	}
 
-}
-
-func TestWriteValue(t *testing.T) {
-
-	tests := []struct {
-		val         any
-		nilVal      string
-		expectedErr error
-		expectedVal string
-	}{
-		{ // 0
-			val:         nil,
-			nilVal:      "NULL",
-			expectedErr: nil,
-			expectedVal: "NULL",
-		},
-		{ // 1
-			val:         "trickster",
-			nilVal:      "",
-			expectedErr: nil,
-			expectedVal: `"trickster"`,
-		},
-		{ // 2
-			val:         true,
-			nilVal:      "",
-			expectedErr: nil,
-			expectedVal: `true`,
-		},
-		{ // 3
-			val:         int64(1),
-			nilVal:      "",
-			expectedErr: nil,
-			expectedVal: `1`,
-		},
-		{ // 4
-			val:         1,
-			nilVal:      "",
-			expectedErr: nil,
-			expectedVal: `1`,
-		},
-		{ // 5
-			val:         1.1,
-			nilVal:      "",
-			expectedErr: nil,
-			expectedVal: `1.1`,
-		},
-	}
-
-	for i, test := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			w := httptest.NewRecorder()
-			writeValue(w, test.val, test.nilVal)
-			b, err := io.ReadAll(w.Body)
-			if err != test.expectedErr {
-				t.Errorf("expected %s got %s", test.expectedErr.Error(), err.Error())
-			}
-			if string(b) != test.expectedVal {
-				t.Errorf("expected %s got %s", test.expectedVal, string(b))
-			}
-		})
-	}
 }
 
 func TestWriteCSVValue(t *testing.T) {
@@ -242,7 +183,7 @@ func TestWriteCSVValue(t *testing.T) {
 
 func TestMarshalTimeseriesJSONPretty(t *testing.T) {
 
-	err := marshalTimeseriesJSONPretty(nil, nil, 200, nil)
+	_, err := marshalTimeseriesJSONPretty(nil, nil, 200)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/backends/influxdb/model/model.go
+++ b/pkg/backends/influxdb/model/model.go
@@ -25,15 +25,15 @@ import (
 
 // WFDocument the Wire Format Document for the timeseries
 type WFDocument struct {
-	Results []WFResult `json:"results"`
-	Err     string     `json:"error,omitempty"`
+	Results []*WFResult `json:"results"`
+	Err     string      `json:"error,omitempty"`
 }
 
 // WFResult is the Result section of the WFD
 type WFResult struct {
-	StatementID int          `json:"statement_id"`
-	SeriesList  []models.Row `json:"series,omitempty"`
-	Err         string       `json:"error,omitempty"`
+	StatementID int           `json:"statement_id"`
+	SeriesList  []*models.Row `json:"series,omitempty"`
+	Err         string        `json:"error,omitempty"`
 }
 
 var epochMultipliers = map[byte]int64{

--- a/pkg/backends/influxdb/model/unmarshal.go
+++ b/pkg/backends/influxdb/model/unmarshal.go
@@ -64,8 +64,8 @@ func decodeCSV(reader io.Reader) (*WFDocument, error) {
 		rows = 0
 	}
 	wfd := &WFDocument{
-		Results: []WFResult{
-			{StatementID: 0, SeriesList: make([]models.Row, rows)},
+		Results: []*WFResult{
+			{StatementID: 0, SeriesList: make([]*models.Row, rows)},
 		},
 	}
 	for ri, r := range records {
@@ -75,7 +75,7 @@ func decodeCSV(reader io.Reader) (*WFDocument, error) {
 			continue
 		}
 		// Construct WFD row from record
-		row := models.Row{
+		row := &models.Row{
 			// Name, Tags deliberately left empty, they don't show up here
 			Columns: columns,
 			Values:  [][]interface{}{make([]interface{}, len(r))},

--- a/pkg/proxy/engines/deltaproxycache_test.go
+++ b/pkg/proxy/engines/deltaproxycache_test.go
@@ -231,8 +231,7 @@ func TestDeltaProxyCacheRequestRemoveStale(t *testing.T) {
 
 }
 
-// TODO: Will understand why this test is failing, and if it's due to an application or test defect,
-// Will commit to test issue fix in v1.2.0 or app defect fix in the next release of v1.1.x
+// TODO: Revisit when LRU is re-implemented
 
 // func TestDeltaProxyCacheRequestRemoveStaleLRU(t *testing.T) {
 

--- a/pkg/proxy/engines/key.go
+++ b/pkg/proxy/engines/key.go
@@ -19,6 +19,7 @@ package engines
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"net/url"
 	"sort"
 	"strconv"
@@ -43,13 +44,16 @@ func (pr *proxyRequest) DeriveCacheKey(extra string) string {
 	}
 
 	var qp url.Values
-	r := pr.Request
+	useUR := pr.upstreamRequest != nil
+	var r *http.Request
 
-	if pr.upstreamRequest != nil {
+	if useUR {
 		r = pr.upstreamRequest
 		if r.URL == nil {
 			r.URL = pr.URL
 		}
+	} else {
+		r = pr.Request
 	}
 
 	var b []byte
@@ -115,10 +119,13 @@ func (pr *proxyRequest) DeriveCacheKey(extra string) string {
 					}
 				}
 			}
-			// TODO: this value of r does not appear to be used
 			r = request.SetBody(r, b)
+			if useUR {
+				pr.upstreamRequest = r
+			} else {
+				pr.Request = r
+			}
 		}
-
 		for _, f := range pc.CacheKeyFormFields {
 			if _, ok := pr.Form[f]; ok {
 				if v := pr.FormValue(f); v != "" {

--- a/pkg/proxy/response/response.go
+++ b/pkg/proxy/response/response.go
@@ -15,3 +15,38 @@
  */
 
 package response
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+)
+
+var contentTypeHints = map[byte]string{
+	0: fmt.Sprintf("%s; charset=UTF-8", headers.ValueApplicationJSON),
+	1: fmt.Sprintf("%s; charset=UTF-8", headers.ValueApplicationJSON),
+	2: fmt.Sprintf("%s; charset=UTF-8", headers.ValueApplicationCSV),
+}
+
+func WriteResponseHeader(w io.Writer, statusCode int, contentTypeHint byte,
+	h http.Header) error {
+	if rw, ok := w.(http.ResponseWriter); ok {
+		rwh := rw.Header()
+		if cth, ok := contentTypeHints[contentTypeHint]; ok && cth != "" {
+			rwh.Set(headers.NameContentType, cth)
+		}
+		for k, v := range h {
+			if len(v) == 0 {
+				continue
+			}
+			rwh.Set(k, v[0])
+		}
+		if statusCode == 0 {
+			statusCode = http.StatusOK
+		}
+		rw.WriteHeader(statusCode)
+	}
+	return nil
+}

--- a/pkg/timeseries/dataset/dataset.go
+++ b/pkg/timeseries/dataset/dataset.go
@@ -21,7 +21,6 @@
 package dataset
 
 import (
-	"io"
 	"sort"
 	"sync"
 	"time"
@@ -65,7 +64,7 @@ type DataSet struct {
 }
 
 // Marshaler is a function that serializes the provided DataSet into a byte slice
-type Marshaler func(*DataSet, *timeseries.RequestOptions, int, io.Writer) error
+type Marshaler func(*DataSet, *timeseries.RequestOptions, int) ([]byte, error)
 
 // CroppedClone returns a new, perfect copy of the DataSet, efficiently
 // cropped to the provided Extent. CroppedClone assumes the DataSet is sorted.

--- a/pkg/timeseries/dataset/dataset_test.go
+++ b/pkg/timeseries/dataset/dataset_test.go
@@ -272,7 +272,7 @@ func TestMarshalDataSet(t *testing.T) {
 		t.Error(err)
 	}
 	var ok bool
-	if ds, ok = ts.(*DataSet); !ok {
+	if _, ok = ts.(*DataSet); !ok {
 		t.Error("invalid dataset")
 	}
 }

--- a/pkg/timeseries/request_options.go
+++ b/pkg/timeseries/request_options.go
@@ -33,6 +33,8 @@ type RequestOptions struct {
 	// BaseTimestampFieldName holds the name of the Base Timestamp Field (in case it is aliased with AS) to help
 	// parse WHERE clauses during the initial parsing of a query
 	BaseTimestampFieldName string
+	// VendorData holds data specific to managing data in the underlying TSDB
+	VendorData map[string]string
 }
 
 // ExtractFastForwardDisabled will look for the FastForwardUserDisableFlag in the provided string


### PR DESCRIPTION
This PR makes several updates to correct the remaining linter issues:
* changes `timerseries.Marshaler` function type to return a `[]byte` instead of requiring an `io.Writer`
  * this bifurcates the process of marshaling the payload and writing the http response
* replaces brittle `influxdb.marshalTimeseriesJSON*` funcs with struct tag-based marshaling
  * fixes `marshal.go:248:5: ineffectual assignment to j (ineffassign)`
* removes the `r =` assignment in `r = r.WithContext(...)` whenever `r` is not used following the reassignment
  * TODO's were added to track these, since they suggest a potential underlying defect that requires investigation
  * fixes `SA4006: this value of `r` is never used (staticcheck)`
* Adds a `.WithResource` TracerProviderOption to OTLP Traces whenever Tags are configured
  * fixes `SA4010: this result of append is never used, except maybe in other appends (staticcheck)`
* Removes some function that were not used outside of their own unit tests 