### PR TITLE
fix: [pkg/proxy/listener] [pkg/timeseries/dataset] fix data races

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -56,13 +56,20 @@ jobs:
         run: |
           go mod download
       - run: go mod vendor
-      - run: go test -v -coverprofile=profile.cov ./...
-      - run: sed -i -e '/^.*_gen\.go:.*$/d' profile.cov
+      - name: Run tests
+        run: make test
+      - name: Run tests (with race detection enabled)
+        run: |
+          echo "::group::Race Detection Tests"
+          make data-race-test
+          echo "::endgroup::"
+          make data-race-test-inspect
+      - run: sed -i -e '/^.*_gen\.go:.*$/d' .coverprofile
       - run: go build -o /dev/null ./cmd/trickster
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1
         with:
-          path-to-profile: profile.cov
+          path-to-profile: .coverprofile
           flag-name: Go-${{ matrix.go }}
           parallel: true
   finish:

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,11 @@ cacheKey.expiration
 #Goland IDE
 .idea/
 
+# coverage profiles
+*.cov
+
 #log testing
-out.log
+*.log
 
 tags
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # This docker file is for local dev, the official Dockerfile is at
 # https://github.com/trickstercache/trickster-docker-images/
 
-FROM golang:1.20 as builder
+FROM golang:1.24 as builder
 COPY . /go/src/github.com/trickstercache/trickster
 WORKDIR /go/src/github.com/trickstercache/trickster
 
 RUN GOOS=linux CGO_ENABLED=0 make build
 
-FROM alpine
+FROM alpine as final
 LABEL maintainer "The Trickster Authors <trickster-developers@googlegroups.com>"
 
 COPY --from=builder /go/src/github.com/trickstercache/trickster/bin/trickster /usr/local/bin/trickster

--- a/hack/inspect-race-output.sh
+++ b/hack/inspect-race-output.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+LOGFILE=$1
+if [ ! -f $LOGFILE ]; then
+    echo "Logfile $LOGFILE does not exist, please check path"
+    exit 1
+fi
+
+results=$(cat ${LOGFILE} | grep -IE '^      .*trickster.*\.go:([0-9]+) \+0x[\w0-9]*' | sed -n 's/.*trickster\/\(.*\):.*/\1/p' | sort | uniq)
+totalRaces=$(cat ${LOGFILE} | grep -IE 'DATA RACE' | wc -l | awk '$1=$1')
+if [ -z "$results" ]; then
+    echo "No races detected"
+else
+    echo "${totalRaces} race(s) detected across the following files:"
+    echo "$results"
+    # TODO: Uncomment this to trigger failure once we resolve existing race conditions
+    # exit 2
+fi

--- a/pkg/timeseries/dataset/dataset.go
+++ b/pkg/timeseries/dataset/dataset.go
@@ -419,8 +419,9 @@ func (ds *DataSet) DefaultRangeCropper(e timeseries.Extent) {
 		if len(ds.Results[i].SeriesList) == 0 {
 			continue
 		}
-		sl := make([]*Series, 0, len(ds.Results[i].SeriesList))
-		for _, s := range ds.Results[i].SeriesList {
+		var m sync.Mutex
+		sl := make([]*Series, len(ds.Results[i].SeriesList))
+		for j, s := range ds.Results[i].SeriesList {
 			if s == nil || len(s.Points) == 0 {
 				continue
 			}
@@ -442,8 +443,10 @@ func (ds *DataSet) DefaultRangeCropper(e timeseries.Extent) {
 					s2.Points = s2.Points.CloneRange(start, end)
 					s2.PointSize = s2.Points.Size()
 				}
+				m.Lock()
+				sl[j] = s2
+				m.Unlock()
 				wg.Done()
-				sl = append(sl, s2)
 			}(s)
 		}
 		wg.Wait()


### PR DESCRIPTION
* Adds race detection test to CI workflow (but does not fail the CI job)
---
* Fixes a race condition provoked by test code in the `pkg/proxy/listener` package accessing the listener's inner map


<details>
<summary> Race Condition </summary>

```
WARNING: DATA RACE
Read at 0x00c000456660 by goroutine 50:
  runtime.mapdelete_faststr()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/internal/runtime/maps/runtime_faststr_swiss.go:396 +0x8c
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:69 +0x308
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c000456660 by goroutine 51:
  runtime.mapaccess2()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/internal/runtime/maps/runtime_swiss.go:117 +0x2dc
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:197 +0x824
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func2()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:63 +0x19c

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 51 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:57 +0x2d4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00046e0e8 by goroutine 50:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:69 +0x310
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c00046e0e8 by goroutine 51:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:197 +0x830
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func2()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:63 +0x19c

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 51 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:57 +0x2d4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00042efc0 by goroutine 50:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:70 +0x324
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c00042efc0 by goroutine 51:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:173 +0x188
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func2()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:63 +0x19c

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 51 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:57 +0x2d4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c0004567e0 by goroutine 50:
  golang.org/x/net/netutil.(*limitListener).Close()
      /Users/c/code/oss/trickster/vendor/golang.org/x/net/netutil/listen.go:72 +0x2c
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:70 +0x338
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c0004567e0 by goroutine 51:
  golang.org/x/net/netutil.LimitListener()
      /Users/c/code/oss/trickster/vendor/golang.org/x/net/netutil/listen.go:17 +0x1e4
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.NewListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:140 +0x1a0
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:184 +0x4a8
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func2()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:63 +0x19c

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 51 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:57 +0x2d4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00042aa38 by goroutine 50:
  crypto/tls.(*listener).Close()
      <autogenerated>:1 +0x34
  golang.org/x/net/netutil.(*limitListener).Close()
      /Users/c/code/oss/trickster/vendor/golang.org/x/net/netutil/listen.go:72 +0x40
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:70 +0x338
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c00042aa38 by goroutine 51:
  crypto/tls.NewListener()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/crypto/tls/tls.go:80 +0x12c
  crypto/tls.Listen()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/crypto/tls/tls.go:99 +0x1a4
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.NewListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:130 +0xd8
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:184 +0x4a8
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func2()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:63 +0x19c

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 51 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:57 +0x2d4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00042f000 by goroutine 50:
  net.(*TCPListener).ok()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/tcpsock_posix.go:156 +0x2c
  net.(*TCPListener).Close()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/tcpsock.go:390 +0x38
  crypto/tls.(*listener).Close()
      <autogenerated>:1 +0x48
  golang.org/x/net/netutil.(*limitListener).Close()
      /Users/c/code/oss/trickster/vendor/golang.org/x/net/netutil/listen.go:72 +0x40
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:70 +0x338
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c00042f000 by goroutine 51:
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/tcpsock_posix.go:193 +0xec
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/tcpsock_posix.go:179 +0x3c0
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/dial.go:821 +0x3a8
  net.Listen()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/dial.go:898 +0x68
  crypto/tls.Listen()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/crypto/tls/tls.go:95 +0x10c
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.NewListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:130 +0xd8
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:184 +0x4a8
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func2()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:63 +0x19c

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 51 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:57 +0x2d4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
time=2025-03-18T12:57:11.903374Z app=trickster level=error event="https listener stopping" detail=accept tcp [::]:62014: use of closed network connection listenerName=httpListener
==================
WARNING: DATA RACE
Read at 0x00c0006827d0 by goroutine 50:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:72 +0x34c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c0006827d0 by goroutine 51:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func2()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:63 +0x1ac

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 51 (finished) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:57 +0x2d4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
time=2025-03-18T12:57:12.004187Z app=trickster level=info event="http listener starting" address= listenerName=httpListener2 port=0
==================
WARNING: DATA RACE
Read at 0x00c000456660 by goroutine 50:
  runtime.mapdelete_faststr()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/internal/runtime/maps/runtime_faststr_swiss.go:396 +0x8c
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:83 +0x4b0
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c000456660 by goroutine 54:
  runtime.mapaccess2()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/internal/runtime/maps/runtime_swiss.go:117 +0x2dc
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:197 +0x824
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListenerRouter()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:254 +0x110
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func3()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:78 +0xa4

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 54 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:77 +0x47c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00046e100 by goroutine 50:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:83 +0x4b8
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c00046e100 by goroutine 54:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:197 +0x830
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListenerRouter()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:254 +0x110
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func3()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:78 +0xa4

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 54 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:77 +0x47c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00042f080 by goroutine 50:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:84 +0x4cc
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c00042f080 by goroutine 54:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:173 +0x188
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListenerRouter()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:254 +0x110
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func3()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:78 +0xa4

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 54 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:77 +0x47c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c000456a50 by goroutine 50:
  golang.org/x/net/netutil.(*limitListener).Close()
      /Users/c/code/oss/trickster/vendor/golang.org/x/net/netutil/listen.go:72 +0x2c
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:84 +0x4e0
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c000456a50 by goroutine 54:
  golang.org/x/net/netutil.LimitListener()
      /Users/c/code/oss/trickster/vendor/golang.org/x/net/netutil/listen.go:17 +0x1e4
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.NewListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:140 +0x1a0
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:184 +0x4a8
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListenerRouter()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:254 +0x110
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func3()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:78 +0xa4

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 54 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:77 +0x47c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00042f0c0 by goroutine 50:
  net.(*TCPListener).ok()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/tcpsock_posix.go:156 +0x2c
  net.(*TCPListener).Close()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/tcpsock.go:390 +0x38
  golang.org/x/net/netutil.(*limitListener).Close()
      /Users/c/code/oss/trickster/vendor/golang.org/x/net/netutil/listen.go:72 +0x40
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:84 +0x4e0
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c00042f0c0 by goroutine 54:
  net.(*sysListener).listenTCPProto()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/tcpsock_posix.go:193 +0xec
  net.(*sysListener).listenTCP()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/tcpsock_posix.go:179 +0x3c0
  net.(*ListenConfig).Listen()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/dial.go:821 +0x3a8
  net.Listen()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/net/dial.go:898 +0x68
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.NewListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:132 +0x178
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListener()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:184 +0x4a8
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.(*ListenerGroup).StartListenerRouter()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener.go:254 +0x110
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func3()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:78 +0xa4

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 54 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:77 +0x47c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
time=2025-03-18T12:57:12.306307Z app=trickster level=error event="http listener stopping" detail=accept tcp [::]:62015: use of closed network connection listenerName=httpListener2
==================
WARNING: DATA RACE
Read at 0x00c0006827d0 by goroutine 50:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:86 +0x4f4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c0006827d0 by goroutine 54:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners.func3()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:78 +0xb4

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:67 +0x110

Goroutine 54 (finished) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/listener.TestListeners()
      /Users/c/code/oss/trickster/pkg/proxy/listener/listener_test.go:77 +0x47c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
```
</details>


-----

* Fix data race in `pkg/timeseries/dataset`
  * aggregate timeseries results via channel instead of appending same slice via multiple goroutines

<details>
<summary> Race Condition </summary>

```
WARNING: DATA RACE
Read at 0x00c00009a5d0 by goroutine 92:
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:450 +0x8cc
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).CropToRange()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:366 +0x150
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.TestCropToRange()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset_test.go:336 +0x218
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c00009a5d0 by goroutine 99:
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper.func1()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:446 +0x504
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper.gowrap1()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:447 +0x44

Goroutine 92 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:243 +0x110

Goroutine 99 (finished) created at:
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:428 +0xb48
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).CropToRange()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:366 +0x150
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.TestCropToRange()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset_test.go:336 +0x218
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c000166480 by goroutine 104:
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper.func1()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:446 +0x468
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper.gowrap1()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:447 +0x44

Previous write at 0x00c000166480 by goroutine 105:
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper.func1()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:446 +0x504
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper.gowrap1()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:447 +0x44

Goroutine 104 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:428 +0xb48
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).CropToRange()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:366 +0x150
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.TestCropToRange()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset_test.go:336 +0x218
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Goroutine 105 (finished) created at:
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).DefaultRangeCropper()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:428 +0xb48
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.(*DataSet).CropToRange()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset.go:366 +0x150
  github.com/trickstercache/trickster/v2/pkg/timeseries/dataset.TestCropToRange()
      /Users/c/code/oss/trickster/pkg/timeseries/dataset/dataset_test.go:336 +0x218
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
```
</details>