### PR TITLE
fix: [pkg/proxy] fix data races

### DIFF
--- a/hack/inspect-race-output.sh
+++ b/hack/inspect-race-output.sh
@@ -13,6 +13,5 @@ if [ -z "$results" ]; then
 else
     echo "${totalRaces} race(s) detected across the following files:"
     echo "$results"
-    # TODO: Uncomment this to trigger failure once we resolve existing race conditions
-    # exit 2
+    exit 2
 fi

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -405,7 +405,10 @@ func WriteCache(ctx context.Context, c cache.Cache, key string, d *HTTPDocument,
 	}
 
 	if c.Configuration().UseCacheChunking {
-		if trq := rsc.TimeRangeQuery; trq != nil {
+		rsc.Lock()
+		trq := rsc.TimeRangeQuery
+		rsc.Unlock()
+		if trq != nil {
 			// Do timeseries chunking
 			meta := d.GetMeta()
 			// Determine chunk extent and number of chunks

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -71,8 +71,10 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 	client := rsc.BackendClient.(backends.TimeseriesBackend)
 
 	trq, rlo, canOPC, err := client.ParseTimeRangeQuery(r)
+	rsc.Lock()
 	rsc.TimeRangeQuery = trq
 	rsc.TSReqestOptions = rlo
+	rsc.Unlock()
 	if err != nil {
 		if canOPC {
 			rsc.Logger.Debug("could not parse time range query, using object proxy cache",

--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -680,15 +680,13 @@ func (pr *proxyRequest) reconstituteResponses() {
 				r := pr.originRequests[j]
 				resp := pr.originResponses[j]
 
+				// only set the upstream response
+				appendLock.Lock()
 				if pr.upstreamResponse == nil {
-					// only set the upstream response
-					appendLock.Lock()
-					if pr.upstreamResponse == nil {
-						pr.upstreamRequest = r
-						pr.upstreamResponse = resp
-					}
-					appendLock.Unlock()
+					pr.upstreamRequest = r
+					pr.upstreamResponse = resp
 				}
+				appendLock.Unlock()
 
 				if resp.StatusCode == http.StatusPartialContent {
 					b, _ := io.ReadAll(resp.Body)

--- a/pkg/proxy/request/resources.go
+++ b/pkg/proxy/request/resources.go
@@ -18,6 +18,7 @@ package request
 
 import (
 	"net/http"
+	"sync"
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
@@ -34,6 +35,7 @@ import (
 // Resources is a collection of resources a Trickster request would need to fulfill the client request
 // This is stored in the client request's context for use by request handers.
 type Resources struct {
+	sync.Mutex
 	BackendOptions    *bo.Options
 	PathConfig        *po.Options
 	CacheConfig       *co.Options


### PR DESCRIPTION
Fixing data races in `pkg/proxy`. (In conjunction with #743, this should bring us to zero races)

---

*  concurrent adds to a sync.waitgroup
   * Fix: replaced with `sync.Cond` + int

<details>
  <summary>Race Condition</summary>

```
WARNING: DATA RACE
Write at 0x00c000868028 by goroutine 10389:
  runtime.racewrite()
      <autogenerated>:1 +0x10
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.(*progressiveCollapseForwarder).WaitAllComplete()
      /Users/c/code/oss/trickster/pkg/proxy/engines/progressive_collapse_forwarder.go:147 +0x3c
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.TestPCFWaits.func2()
      /Users/c/code/oss/trickster/pkg/proxy/engines/progressive_collapse_forwarder_test.go:164 +0x44

Previous read at 0x00c000868028 by goroutine 10388:
  runtime.raceread()
      <autogenerated>:1 +0x10
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.(*progressiveCollapseForwarder).AddClient()
      /Users/c/code/oss/trickster/pkg/proxy/engines/progressive_collapse_forwarder.go:96 +0x4c
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.TestPCFWaits.gowrap1()
      /Users/c/code/oss/trickster/pkg/proxy/engines/progressive_collapse_forwarder_test.go:161 +0x60

Goroutine 10389 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.TestPCFWaits()
      /Users/c/code/oss/trickster/pkg/proxy/engines/progressive_collapse_forwarder_test.go:163 +0x420
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Goroutine 10388 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.TestPCFWaits()
      /Users/c/code/oss/trickster/pkg/proxy/engines/progressive_collapse_forwarder_test.go:161 +0x37c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
```
</details> 

---

* concurrent read and write to byte slice
  * fix: guard byte slice with mutex

<details>
  <summary>Race Condition</summary>

```
WARNING: DATA RACE
Read at 0x00c0007224b0 by goroutine 9354:
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.(*progressiveCollapseForwarder).IndexRead()
      /Users/c/code/oss/trickster/pkg/proxy/engines/progressive_collapse_forwarder.go:201 +0x130
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.(*progressiveCollapseForwarder).AddClient()
      /Users/c/code/oss/trickster/pkg/proxy/engines/progressive_collapse_forwarder.go:104 +0x8c
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.handlePCF()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache.go:340 +0x7c8
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.handleCacheKeyMiss()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache.go:268 +0x168
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.fetchViaObjectProxyCache()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache.go:436 +0x970
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.ObjectProxyCacheRequest()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache.go:470 +0x58
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.testFetchOPC()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache_test.go:1124 +0x138
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.TestObjectProxyCacheRequestWithPCFChunks()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache_chunk_test.go:497 +0x3ac
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous write at 0x00c0007224b0 by goroutine 9362:
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.(*progressiveCollapseForwarder).Write()
      /Users/c/code/oss/trickster/pkg/proxy/engines/progressive_collapse_forwarder.go:170 +0x1bc
  io.(*multiWriter).Write()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/io/multi.go:85 +0xa8
  io.copyBuffer()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/io/io.go:431 +0x258
  io.Copy()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/io/io.go:388 +0x460
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.handlePCF.func1()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache.go:335 +0x94

Goroutine 9354 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:389 +0x110

Goroutine 9362 (running) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.handlePCF()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache.go:329 +0x79c
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.handleCacheKeyMiss()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache.go:268 +0x168
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.fetchViaObjectProxyCache()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache.go:436 +0x970
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.ObjectProxyCacheRequest()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache.go:470 +0x58
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.testFetchOPC()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache_test.go:1124 +0x138
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.TestObjectProxyCacheRequestWithPCFChunks()
      /Users/c/code/oss/trickster/pkg/proxy/engines/objectproxycache_chunk_test.go:497 +0x3ac
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
```
</details> 

---

* multiple go routines modifying `Resources` struct (time range query field)
  * Fix: added mutex to `Resources` struct and lock/unlock before accessing fields

<details>
  <summary>Race Condition</summary>

```
WARNING: DATA RACE
Write at 0x00c0005c5088 by goroutine 1077:
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.DeltaProxyCacheRequest()
      /Users/c/code/oss/trickster/pkg/proxy/engines/deltaproxycache.go:74 +0x434
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.(*TestClient).QueryRangeHandler()
      /Users/c/code/oss/trickster/pkg/proxy/engines/client_test.go:378 +0x1ec
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.TestDeltaProxyCacheRequestPartialHitChunks()
      /Users/c/code/oss/trickster/pkg/proxy/engines/deltaproxycache_chunk_test.go:388 +0xfb8
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40

Previous read at 0x00c0005c5088 by goroutine 1161:
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.WriteCache()
      /Users/c/code/oss/trickster/pkg/proxy/engines/cache.go:408 +0x450
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.DeltaProxyCacheRequest.func2()
      /Users/c/code/oss/trickster/pkg/proxy/engines/deltaproxycache.go:419 +0x3cc

Goroutine 1077 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x684
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2279 +0x7c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.runTests()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2277 +0x77c
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:2142 +0xb68
  main.main()
      _testmain.go:389 +0x110

Goroutine 1161 (finished) created at:
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.DeltaProxyCacheRequest()
      /Users/c/code/oss/trickster/pkg/proxy/engines/deltaproxycache.go:405 +0x4188
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.(*TestClient).QueryRangeHandler()
      /Users/c/code/oss/trickster/pkg/proxy/engines/client_test.go:378 +0x1ec
  github.com/trickstercache/trickster/v2/pkg/proxy/engines.TestDeltaProxyCacheRequestPartialHitChunks()
      /Users/c/code/oss/trickster/pkg/proxy/engines/deltaproxycache_chunk_test.go:349 +0x658
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1792 +0x180
  testing.(*T).Run.gowrap1()
      /opt/homebrew/Cellar/go/1.24.1/libexec/src/testing/testing.go:1851 +0x40
```
</details>