### PR TITLE
fix: [pkg/proxy] fix deadlock from double lock / missing  unlock

### DIFF
--- a/pkg/proxy/engines/httpproxy.go
+++ b/pkg/proxy/engines/httpproxy.go
@@ -114,7 +114,7 @@ func DoProxy(w io.Writer, r *http.Request, closeResponse bool) *http.Response {
 			resp = pcf.GetResp()
 			pr.mapLock.Lock()
 			writer := PrepareResponseWriter(w, resp.StatusCode, resp.Header)
-			pr.mapLock.Lock()
+			pr.mapLock.Unlock()
 			pcf.AddClient(writer)
 		}
 	}


### PR DESCRIPTION
Looks like we are calling `mapLock.Lock()` twice here, and not unlocking. This looks like a mistake.

No coverage here, but I'll address that separately.

FYI, I spot checked other locks and didn't see this elsewhere.