### PR TITLE
feat: [ci] add docker image release on "on tag" workflow & minor fixes

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -34,7 +34,8 @@ jobs:
     steps:
       - name: Get Build Date
         id: builddate
-        run: echo "::set-output name=builddate::$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        run: |
+          echo "builddate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee $GITHUB_OUTPUT
       - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -46,7 +47,7 @@ jobs:
             --label "org.opencontainers.image.revision=${{ github.sha }}" \
             --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
             --label "org.opencontainers.image.created=${{ steps.builddate.outputs.builddate }}" \
-            --platform linux/arm64/v8,linux/amd64 \
+            --platform linux/amd64 \
             -f ./Dockerfile  .
   build:
     runs-on: ubuntu-latest
@@ -86,7 +87,12 @@ jobs:
       - run: sed -i -e '/^.*_gen\.go:.*$/d' .coverprofile
       - run: go build -o /dev/null ./cmd/trickster
       - name: Send coverage
+        if: github.repository_owner == 'trickstercache' # Skip for forked repositories
         uses: shogo82148/actions-goveralls@v1
+        # publishing to coveralls should not fail; and if it does, it should not block the CI process.
+        # Likely coveralls maintenance: https://status.coveralls.io/
+        # TODO: publish PR comment if coveralls publish fails
+        continue-on-error: true
         with:
           path-to-profile: .coverprofile
           flag-name: Go-${{ matrix.go }}
@@ -97,5 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: shogo82148/actions-goveralls@v1
+        if: github.repository_owner == 'trickstercache' # Skip for forked repositories
+        continue-on-error: true
         with:
           parallel-finished: true

--- a/.github/workflows/publish-beta-release.yaml
+++ b/.github/workflows/publish-beta-release.yaml
@@ -7,6 +7,11 @@ name: Publish Trickster Beta Release to Drafts
 
 jobs:
   release:
+    permissions:
+      contents: write
+      packages: write
+      attestations: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     with:
       draft: true

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -3,20 +3,33 @@ on:
     branches:
     - main
   workflow_dispatch:
+  workflow_call:
+    inputs:
+        tag:
+          description: 'Tag to use for the image'
+          required: false
+          type: string
+          default: ''
 name: Publish Latest Trickster Image
 
 jobs:
   publish-image:
     runs-on: ubuntu-latest
     permissions:
-        contents: read
-        packages: write
-        attestations: write
-        id-token: write
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    strategy:
+      matrix:
+        arch:
+        - linux/amd64
+        - linux/arm64/v8
     steps:
       - name: Get Build Date
         id: builddate
-        run: echo "::set-output name=builddate::$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        run: |
+            echo "builddate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee $GITHUB_OUTPUT
       - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -34,19 +47,29 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: build & push image
+      - name: resolve branch name
+        if: inputs.tag == ''
+        id: get-branch
         run: |
           b=$(git branch -r --contains ${{ github.ref }}) && branch=${b##*/}
-          docker buildx build \
-            --label "org.opencontainers.image.revision=${{ github.sha }}" \
-            --label "org.opencontainers.image.source=https://github.com/${{ github.repository }}" \
-            --label "org.opencontainers.image.created=${{ steps.builddate.outputs.builddate }}" \
-            --platform linux/arm64/v8,linux/amd64 \
-            -f ./Dockerfile \
-            --push ${{ github.repository == 'trickstercache/trickster' && format('-t {0}:${branch} -t {0}:{1}', env.DOCKER_HUB_REPO, github.sha) || '' }} \
-            -t ${{ env.GHCR_REPO }}:${branch} \
-            -t ${{ env.GHCR_REPO }}:${{ github.sha }} \
-            .
-        env:
-          DOCKER_HUB_REPO: trickstercache/trickster
-          GHCR_REPO: ghcr.io/${{ github.repository_owner }}/trickster
+          echo "branch=${branch}" | tee $GITHUB_OUTPUT
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          file: ${{ github.workspace }}/Dockerfile
+          context: ${{ github.workspace }}
+          platforms: ${{ matrix.arch}}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.created=${{ steps.builddate.outputs.builddate }}
+          build-args: |
+            GIT_LATEST_COMMIT_ID=${{ github.sha }}
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ inputs.tag || steps.get-branch.outputs.branch }}
+            ${{ inputs.tag == '' && format('ghcr.io/{0}:{1}', github.repository, github.sha) || '' }}
+            ${{ github.repository_owner == 'trickstercache' && format('{0}:{1}', github.repository, (inputs.tag || steps.get-branch.outputs.branch)) || '' }}
+            ${{ (inputs.tag == '' && github.repository_owner == 'trickstercache') && format('{0}:{1}', github.repository, github.sha) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-release-candidate.yaml
+++ b/.github/workflows/publish-release-candidate.yaml
@@ -7,6 +7,11 @@ name: Publish Trickster Release Candidate to Drafts
 
 jobs:
   release:
+    permissions:
+      contents: write
+      packages: write
+      attestations: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     with:
       draft: true

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,12 @@ on:
 
 name: Publish Trickster Release to Drafts
 
+permissions:
+  contents: write
+  packages: write
+  attestations: write
+  id-token: write
+
 env:
   draft: ${{ inputs.draft || true }}
   prerelease: ${{ inputs.prerelease || false }}
@@ -27,6 +33,8 @@ jobs:
   release:
     name: Publish Release ${{ inputs.job-suffix || '' }}
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.baretag.outputs.baretag }}
     steps:
       - name: Get current date
         id: date
@@ -80,3 +88,9 @@ jobs:
           asset_path: ./bin/sha256sum.txt
           asset_name: sha256sum.txt
           asset_content_type: text/plain
+  publish-image:
+    needs:
+      - release
+    uses: ./.github/workflows/publish-image.yaml
+    with:
+      tag: ${{ needs.release.outputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 # This docker file is for local dev, the official Dockerfile is at
 # https://github.com/trickstercache/trickster-docker-images/
-
-FROM golang:1.24 as builder
+ARG BUILDPLATFORM=linux/amd64
+ARG TARGETPLATFORM=linux/amd64
+FROM --platform=${BUILDPLATFORM} golang:1.24 as builder
 ARG GIT_LATEST_COMMIT_ID
 
 COPY . /go/src/github.com/trickstercache/trickster
 WORKDIR /go/src/github.com/trickstercache/trickster
 
-RUN GOOS=linux CGO_ENABLED=0 BUILD_FLAGS=-v make build
+RUN GOOS=linux GOARCH=${TARGETPLATFORM} CGO_ENABLED=0 BUILD_FLAGS=-v make build
 
 FROM alpine as final
 LABEL maintainer "The Trickster Authors <trickster-developers@googlegroups.com>"

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ test-go-mod:
 BUILD_FLAGS ?= -a -v
 .PHONY: build
 build: go-mod-tidy go-mod-vendor
-	CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o ./$(BUILD_SUBDIR)/trickster $(BUILD_FLAGS) $(TRICKSTER_MAIN)/*.go
+	CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) $(BUILD_FLAGS) -o ./$(BUILD_SUBDIR)/trickster  $(TRICKSTER_MAIN)/*.go
 
 rpm: build
 	mkdir -p ./$(BUILD_SUBDIR)/SOURCES
@@ -80,13 +80,7 @@ release: validate-app-version clean go-mod-tidy go-mod-vendor release-artifacts 
 RELEASE_CHECKSUM_FILE=$(BUILD_SUBDIR)/sha256sum.txt
 .PHONY: release-sha256
 release-sha256:
-	@rm -f $(RELEASE_CHECKSUM_FILE) && touch $(RELEASE_CHECKSUM_FILE)
-	@bash -c "pushd $(BUILD_SUBDIR) > /dev/null && sha256sum trickster-$(PROGVER).tar.gz > $$(basename $(RELEASE_CHECKSUM_FILE)) && popd > /dev/null"
-	@RSF="$$(realpath $(RELEASE_CHECKSUM_FILE))" && for file in $(BIN_DIR)/* ; do \
-		if [[ "$$(basename $$file)" == "sha256sum.txt" ]]; then continue; fi ; \
-		bash -c "pushd $$(dirname $$file) > /dev/null && sha256sum $$(basename $$file) >> $${RSF} && popd > /dev/null"; \
-	done
-	@cat $(RELEASE_CHECKSUM_FILE)
+	./hack/release-sha256.sh $(RELEASE_CHECKSUM_FILE) $(BUILD_SUBDIR) $(PROGVER) $(BIN_DIR)
 
 .PHONY: release-artifacts
 release-artifacts: clean
@@ -102,11 +96,11 @@ release-artifacts: clean
 	cp ./LICENSE $(PACKAGE_DIR)
 	cp ./examples/conf/*.yaml $(CONF_DIR)
 
-	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).darwin-amd64  -a -v $(TRICKSTER_MAIN)/*.go
-	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).darwin-arm64  -a -v $(TRICKSTER_MAIN)/*.go
-	GOOS=linux   GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).linux-amd64   -a -v $(TRICKSTER_MAIN)/*.go
-	GOOS=linux   GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).linux-arm64   -a -v $(TRICKSTER_MAIN)/*.go
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).windows-amd64 -a -v $(TRICKSTER_MAIN)/*.go
+	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).darwin-amd64  -v $(TRICKSTER_MAIN)/*.go
+	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).darwin-arm64  -v $(TRICKSTER_MAIN)/*.go
+	GOOS=linux   GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).linux-amd64   -v $(TRICKSTER_MAIN)/*.go
+	GOOS=linux   GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).linux-arm64   -v $(TRICKSTER_MAIN)/*.go
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(PROGVER).windows-amd64 -v $(TRICKSTER_MAIN)/*.go
 
 	cd ./$(BUILD_SUBDIR) && tar cvfz ./trickster-$(PROGVER).tar.gz ./trickster-$(PROGVER)/*
 

--- a/hack/release-sha256.sh
+++ b/hack/release-sha256.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+CHECKSUM_FILE=$1
+BUILD_SUBDIR=$2
+PROGVER=$3
+BIN_DIR=$4
+
+rm ${CHECKSUM_FILE} > /dev/null 2> /dev/null && touch ${CHECKSUM_FILE}
+
+pushd $BUILD_SUBDIR > /dev/null
+sha256sum trickster-$PROGVER.tar.gz > $(basename $CHECKSUM_FILE)
+popd > /dev/null
+
+RSF="$(realpath ${CHECKSUM_FILE})" && for file in ${BIN_DIR}/*; do
+    if [[ "$(basename $file)" == "sha256sum.txt" ]]; then
+        continue
+    fi
+    pushd $(dirname $file) > /dev/null
+    sha256sum "$(basename $file)" >> ${RSF}
+    popd > /dev/null
+done
+
+cat $CHECKSUM_FILE
+


### PR DESCRIPTION
Did a bit of testing on my private fork, this _should_ have a better chance of succeeding.

* Publishes a docker image on tag
* Fixes bug found in initial run of `publish-image` workflow (https://github.com/trickstercache/trickster/actions/runs/14149543077)
  * Refactors docker publishing to use the docker build-push action + use GHA cache
*  Refactors sha256sum generation to fix observed errors (`/bin/sh: 2: [[: not found`)
* Removes force rebuilding of standard library packages in release workflow (`-a`)
* Only builds for one architecture during PR workflows; we aren't doing anything platform specific
* Replaces to-be-deprecated `::set-output` usages
* Allow PR workflow to succeed in forked repositories (skip code coverage publishing)
* Cross compile trickster from local build platform -- speeds up docker build times when going cross-arch
  * Reduces docker build times from 10 minutes to ~3 

Resolves: https://github.com/trickstercache/trickster-docker-images/issues/3
