### PR TITLE
fix cache chunk panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/trickstercache/trickster/v2
 
 go 1.24
 
-toolchain go1.24.0
+toolchain go1.24.1
 
 require (
 	github.com/alicebob/miniredis v2.5.0+incompatible

--- a/pkg/observability/logging/logging.go
+++ b/pkg/observability/logging/logging.go
@@ -336,8 +336,12 @@ func (l *logger) log(logLevel level.Level, event string, detail Pairs) {
 	if ld > 0 {
 		sortedKeys := make([]string, ld)
 		for k, v := range detail {
-			if s, ok := v.(string); ok && strings.Contains(s, " ") {
-				v = `"` + s + `"`
+			if s, ok := v.(string); ok {
+				v = quoteAsNeeded(s)
+			} else if stringer, ok := v.(fmt.Stringer); ok {
+				v = quoteAsNeeded(stringer.String())
+			} else if err, ok := v.(error); ok {
+				v = quoteAsNeeded(err.Error())
 			}
 			sortedKeys[i] = fmt.Sprintf("%s=%v", k, v)
 			i++

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -181,15 +181,23 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 						(qr.err == nil || qr.err == cache.ErrKNF) {
 						return
 					}
-					if c.Configuration().Provider != "memory" {
-						qr.d.timeseries, qr.err = unmarshal(qr.d.Body, nil)
-					}
-					if qr.err == nil && qr.d != nil && qr.d.timeseries != nil {
-						ress[outIdx] = qr.d.timeseries
-					} else {
+					if qr.err != nil {
 						logger.Error("dpc query cache chunk failed",
 							logging.Pairs{"error": qr.err, "chunkIdx": outIdx,
 								"key": subkey, "cacheQueryStatus": qr.lookupStatus})
+						return
+					}
+					if c.Configuration().Provider != "memory" {
+						qr.d.timeseries, qr.err = unmarshal(qr.d.Body, nil)
+						if qr.err != nil {
+							logger.Error("dpc query cache chunk failed",
+								logging.Pairs{"error": qr.err, "chunkIdx": outIdx,
+									"key": subkey, "cacheQueryStatus": qr.lookupStatus})
+							return
+						}
+					}
+					if qr.d.timeseries != nil {
+						ress[outIdx] = qr.d.timeseries
 					}
 				}(resi)
 				resi++

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -29,6 +29,8 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/cache/status"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	tspan "github.com/trickstercache/trickster/v2/pkg/observability/tracing/span"
 	tc "github.com/trickstercache/trickster/v2/pkg/proxy/context"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
@@ -179,6 +181,9 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 					}
 					if qr.err == nil {
 						ress[outIdx] = qr.d.timeseries
+					} else {
+						logger.Error("dpc query cache chunk failed",
+							logging.Pairs{"detail": qr.err, "chunkIdx": outIdx})
 					}
 				}(resi)
 				resi++

--- a/pkg/timeseries/dataset/dataset_test.go
+++ b/pkg/timeseries/dataset/dataset_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
 )
@@ -42,7 +43,7 @@ func testDataSet() *DataSet {
 
 func genTestDataSet(seriesCount int, resultsCount int) *DataSet {
 	if resultsCount <= 0 {
-		fmt.Println("resultsCount must be greater than 0")
+		logger.Error("resultsCount must be greater than 0", nil)
 		resultsCount = 1
 	}
 	results := make([]*Result, 0, resultsCount)

--- a/pkg/timeseries/timeseries.go
+++ b/pkg/timeseries/timeseries.go
@@ -80,3 +80,36 @@ type Timeseries interface {
 	// SetTimeRangeQuery sets the TimeRangeQuery associated with the Timeseries
 	SetTimeRangeQuery(*TimeRangeQuery)
 }
+
+type TimeseriesList []Timeseries
+
+// Compress removes nil entries from t
+func (t TimeseriesList) Compress() TimeseriesList {
+	if len(t) == 0 {
+		return TimeseriesList{}
+	}
+	out := make(TimeseriesList, len(t))
+	var j int
+	for _, ts := range t {
+		if ts == nil {
+			continue
+		}
+		out[j] = ts
+		j++
+	}
+	return out[:j]
+}
+
+// Merge combines all Timesseries in t into a single Timeseries
+func (t TimeseriesList) Merge() Timeseries {
+	cts := t.Compress()
+	if len(cts) == 0 {
+		return nil
+	}
+	if len(cts) == 1 {
+		return cts[0]
+	}
+	out := cts[0].Clone()
+	out.Merge(true, cts[1:]...)
+	return out
+}


### PR DESCRIPTION
fixes #756

The main cause of this is that the chunking aggregator was susceptible to a nil pointer panic if the first index of the cache chunk lookup in the results slice was a cache miss (meaning the chunk data is nil). This change ensures that nil chunk results (at any indexes) are removed from the results slice before performing the chunk aggregation.

This also properly logs errors in the partial cache chunk queries and properly handles cache miss and non-memory unmarshaling based on the lookup result.

This also bumps the go.mod toolchain to `go1.24.1` and fixes a logger issue where objects of type `error` or that conform to `fmt.Stringer` were not properly enclosing their stringified output in quotes when required.