### PR TITLE
feat: [release] inject trickster application version from tag at release time

### DIFF
--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -24,14 +24,15 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 )
 
+// application variables set at build time via go build's -ldflags
 var (
 	applicationGitCommitID string
 	applicationBuildTime   string
+	applicationVersion     string
 )
 
 const (
-	applicationName    = "trickster"
-	applicationVersion = "2.0.0-beta2"
+	applicationName = "trickster"
 )
 
 func main() {

--- a/hack/release-sha256.sh
+++ b/hack/release-sha256.sh
@@ -2,13 +2,13 @@
 
 CHECKSUM_FILE=$1
 BUILD_SUBDIR=$2
-PROGVER=$3
+TAGVER=$3
 BIN_DIR=$4
 
 rm ${CHECKSUM_FILE} > /dev/null 2> /dev/null && touch ${CHECKSUM_FILE}
 
 pushd $BUILD_SUBDIR > /dev/null
-sha256sum trickster-$PROGVER.tar.gz > $(basename $CHECKSUM_FILE)
+sha256sum trickster-${TAGVER}.tar.gz > $(basename $CHECKSUM_FILE)
 popd > /dev/null
 
 RSF="$(realpath ${CHECKSUM_FILE})" && for file in ${BIN_DIR}/*; do


### PR DESCRIPTION
Inject application version via ldflags instead of hard-coding in main.go

```
./bin/trickster -version
Trickster version: v0.0.0-beta1-11-g3b4851b9-dirty (darwin/arm64), buildInfo: 2025-03-31T03:48:03+0000 3b4851b92cfb2dee6e5538b1915c1da0235da98d, goVersion: go1.24.1, copyright: © 2018 The Trickster Authors
```