### PR TITLE
feat: [docker] use distroless as final stage

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -59,6 +59,10 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.created=${{ steps.builddate.outputs.builddate }}
+            org.opencontainers.image.title="Trickster"
+            org.opencontainers.image.description="an HTTP Reverse Proxy Cache and time series dashboard accelerator"
+            org.opencontainers.image.documentation="https://github.com/${{ github.repository }}/tree/main/docs"
+
           build-args: |
             GIT_LATEST_COMMIT_ID=${{ github.sha }}
           tags: |

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ TRICKSTER      := $(FIRST_GOPATH)/bin/trickster
 BUILD_TIME     := $(shell date -u +%FT%T%z)
 GIT_LATEST_COMMIT_ID     ?= $(shell git rev-parse HEAD)
 IMAGE_TAG      ?= latest
-IMAGE_ARCH     ?= amd64
-GOARCH         ?= amd64
+IMAGE_ARCH     ?= $(shell $(GO) env GOARCH)
+GOARCH         ?= $(shell $(GO) env GOARCH)
 TAGVER         ?= $(shell git describe --tags --dirty --always)
 LDFLAGS         =-ldflags "-extldflags '-static' -w -s -X main.applicationBuildTime=$(BUILD_TIME) -X main.applicationGitCommitID=$(GIT_LATEST_COMMIT_ID) -X main.applicationVersion=$(TAGVER)"
 BUILD_SUBDIR   := bin
@@ -128,7 +128,7 @@ docker:
 		--build-arg GOARCH=$(GOARCH) \
 		-f ./Dockerfile \
 		-t trickster:$(TAGVER) \
-		--platform linux/amd64 \
+		--platform linux/$(IMAGE_ARCH) \
 		.
 
 .PHONY: docker-release


### PR DESCRIPTION
Use the debian distroless image as the final stage.

```
docker image ls | grep trick
trickster           2.0.0-betaN                                159e48c7475d   4 minutes ago       27.7MB
```

Seems to work from what I can tell, but would welcome extra testing.