### PR TITLE
feat: [docker] add sbom attestation and provenance to image publishing workflow

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -10,7 +10,11 @@ on:
           required: false
           type: string
           default: ''
-name: Publish Latest Trickster Image
+name: Publish Trickster Image
+
+env:
+  oci_metadata: |
+    org.opencontainers.image.description="Open Source HTTP Reverse Proxy Cache and Time Series Dashboard Accelerator"
 
 jobs:
   publish-image:
@@ -21,10 +25,6 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - name: Get Build Date
-        id: builddate
-        run: |
-            echo "builddate=$(date -u +%Y-%m-%dT%H:%M:%SZ)" | tee $GITHUB_OUTPUT
       - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -42,33 +42,38 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: resolve branch name
-        if: inputs.tag == ''
-        id: get-branch
-        run: |
-          b=$(git branch -r --contains ${{ github.ref }}) && branch=${b##*/}
-          echo "branch=${branch}" | tee $GITHUB_OUTPUT
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # Create an image for ghcr.io/github_owner/repo_name and docker.io/github_owner/repo_name
+          images: |
+            ghcr.io/${{ github.repository }}
+            ${{ github.repository_owner == 'trickstercache' && github.repository || ''}}
+          annotations: ${{ env.oci_metadata }}
+          labels:  ${{ env.oci_metadata }}
+          flavor: |
+            latest=${{ github.ref_name == 'main' &&  'auto' || 'false' }}
+          tags: |
+            type=semver,pattern={{major}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,format=long
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
+          provenance: true
+          sbom: true
           push: true
           file: ${{ github.workspace }}/Dockerfile
           context: ${{ github.workspace }}
           platforms: linux/amd64,linux/arm64/v8
-          labels: |
-            org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.created=${{ steps.builddate.outputs.builddate }}
-            org.opencontainers.image.title="Trickster"
-            org.opencontainers.image.description="an HTTP Reverse Proxy Cache and time series dashboard accelerator"
-            org.opencontainers.image.documentation="https://github.com/${{ github.repository }}/tree/main/docs"
-
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_LATEST_COMMIT_ID=${{ github.sha }}
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ inputs.tag || steps.get-branch.outputs.branch }}
-            ${{ inputs.tag == '' && format('ghcr.io/{0}:{1}', github.repository, github.sha) || '' }}
-            ${{ github.repository_owner == 'trickstercache' && format('{0}:{1}', github.repository, (inputs.tag || steps.get-branch.outputs.branch)) || '' }}
-            ${{ (inputs.tag == '' && github.repository_owner == 'trickstercache') && format('{0}:{1}', github.repository, github.sha) || '' }}
+          tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,12 +19,6 @@ on:
 
 name: Publish Trickster Release to Drafts
 
-permissions:
-  contents: write
-  packages: write
-  attestations: write
-  id-token: write
-
 env:
   draft: ${{ inputs.draft || true }}
   prerelease: ${{ inputs.prerelease || false }}
@@ -32,6 +26,9 @@ env:
 jobs:
   release:
     name: Publish Release ${{ inputs.job-suffix || '' }}
+    permissions:
+      contents: write
+      id-token: write
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.baretag.outputs.baretag }}
@@ -92,5 +89,10 @@ jobs:
     needs:
       - release
     uses: ./.github/workflows/publish-image.yaml
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     with:
       tag: ${{ needs.release.outputs.tag }}


### PR DESCRIPTION
* Adds sbom & provenance attestation to the images publish workflow.
* Fixes minor permissions bug in workflow.
* Simplifies image versioning

---

branch + sha tags:
![Screenshot 2025-04-02 at 9 02 40 AM](https://github.com/user-attachments/assets/5adfdc96-90fc-49a1-b9cf-6390dc2c2946)

version tags:
![Screenshot 2025-04-02 at 9 04 17 AM](https://github.com/user-attachments/assets/0fcf92c2-1a95-4162-922b-16ad0543c06f)

rc/beta:
![Screenshot 2025-04-02 at 9 03 52 AM](https://github.com/user-attachments/assets/3a73d9cd-ff41-40c5-860d-83ebf568dbc4)

---

FYI, I verified the beta/release workflows work as expected.

Occasionally the create-release action hangs on an error; but I'm not sure why.

- https://github.com/trickstercache/trickster/blob/f405c963c65452ee1c6131e1d61c8df3c32854f2/.github/workflows/publish-release.yml#L61
- https://github.com/actions/create-release/issues/103