### PR TITLE
feat: [ci] sign docker images

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -63,6 +63,7 @@ jobs:
             type=sha,format=long
       - name: Build and push
         uses: docker/build-push-action@v6
+        id: build-and-push
         with:
           provenance: true
           sbom: true
@@ -77,3 +78,15 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign Images
+        env:
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -54,37 +54,16 @@ jobs:
           TAGVER=${{ steps.baretag.outputs.baretag }} make release
         #
       - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release v${{ steps.baretag.outputs.baretag }} / ${{ steps.date.outputs.date }}
-          draft: ${{ env.draft}}
-          prerelease: ${{ env.prerelease }}
-        #
-      - name: Upload Release Binaries Tarball
-        id: upload-release-asset-bundle
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./bin/trickster-${{ steps.baretag.outputs.baretag }}.tar.gz
-          asset_name: trickster-${{ steps.baretag.outputs.baretag }}.tar.gz
-          asset_content_type: application/gzip
-        #
-      - name: Upload Release sha256sum
-        id: upload-release-asset-sha256
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./bin/sha256sum.txt
-          asset_name: sha256sum.txt
-          asset_content_type: text/plain
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            --generate-notes \
+            --title "Release v${{ steps.baretag.outputs.baretag }} / ${{ steps.date.outputs.date }}" \
+            --draft=${{ env.draft }} \
+            --prerelease=${{ env.prerelease }} \
+            ./bin/trickster-${{ steps.baretag.outputs.baretag }}.tar.gz \
+            ./bin/sha256sum.txt
   publish-image:
     needs:
       - release

--- a/README.md
+++ b/README.md
@@ -81,9 +81,24 @@ Check out our end-to-end [Docker Compose demo composition](./examples/docker-com
 
 ### Docker
 
-Docker images are available on Docker Hub:
+Docker images are available on Docker Hub (docker.io):
+```bash
+$ docker run --name trickster -d -v /path/to/trickster.yaml:/etc/trickster/trickster.yaml -p 0.0.0.0:8480:8480 trickstercache/trickster
+```
+Or via  Github Container Registry (ghcr.io):
+```bash
+    $ docker run --name trickster -d -v /path/to/trickster.yaml:/etc/trickster/trickster.yaml -p 0.0.0.0:8480:8480 ghcr.io/trickstercache/trickster
+```
+#### Verifying Docker Image
 
-    $ docker run --name trickster -d -v /path/to/trickster.yaml:/etc/trickster/trickster.yaml -p 0.0.0.0:8480:8480 trickstercache/trickster
+To verify that the Trickster Docker image is running, first walk through the [cosign quickstart guide](https://docs.sigstore.dev/quickstart/quickstart-cosign/).
+
+To verify a trickster image, you can use the following command:
+
+```bash
+cosign verify ghcr.io/trickstercache/trickster:x.y.z --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/trickstercache/trickster/.github/workflows/publish-image.yaml@refs/tags/vx.y.z
+```
+
 
 See the 'deploy' Directory for more information about using or creating Trickster docker images.
 


### PR DESCRIPTION
Using cosign (with the buit-in github oidc provider + fulcio) to sign images.

https://docs.sigstore.dev/quickstart/quickstart-ci/#signing-and-verifying-a-container-image

```
# verify a test image:
cosign verify ghcr.io/crandles/trickster-dev:4.3.12 --certificate-oidc-issuer=https://token.actions.githubusercontent.com --certificate-identity=https://github.com/crandles/trickster-dev/.github/workflows/publish-image.yaml@refs/tags/v4.3.12
```

---

Additional changes:
- update the release process to remove archived actions