### PR TITLE
fix: [pkg/proxy/engines] fix data race in time range query normalization

### DIFF
--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -92,7 +92,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 
 	pr := newProxyRequest(r, w)
 	rlo.FastForwardDisable = o.FastForwardDisable || rlo.FastForwardDisable
-	trq.NormalizeExtent()
+	trq = trq.NormalizeExtent()
 	now := time.Now()
 	bt := trq.GetBackfillTolerance(o.BackfillTolerance, o.BackfillTolerancePoints)
 	bfs := now.Add(-bt).Truncate(trq.Step) // start of the backfill tolerance window
@@ -118,7 +118,7 @@ func DeltaProxyCacheRequest(w http.ResponseWriter, r *http.Request, modeler *tim
 		Extent: timeseries.Extent{Start: time.Unix(0, 0), End: now},
 		Step:   trq.Step,
 	}
-	normalizedNow.NormalizeExtent()
+	normalizedNow = normalizedNow.NormalizeExtent()
 
 	var cts timeseries.Timeseries
 	var doc *HTTPDocument

--- a/pkg/timeseries/extent_list_test.go
+++ b/pkg/timeseries/extent_list_test.go
@@ -944,7 +944,7 @@ func TestCalculateDeltas(t *testing.T) {
 
 			trq := TimeRangeQuery{Statement: "up", Extent: Extent{Start: time.Unix(test.start, 0),
 				End: time.Unix(test.end, 0)}, Step: time.Duration(test.stepSecs) * time.Second}
-			trq.NormalizeExtent()
+			trq = *trq.NormalizeExtent()
 			d := ExtentList(test.have).CalculateDeltas(trq.Extent, trq.Step)
 
 			if len(d) != len(test.expected) {

--- a/pkg/timeseries/timerangequery.go
+++ b/pkg/timeseries/timerangequery.go
@@ -87,14 +87,16 @@ func (trq *TimeRangeQuery) Clone() *TimeRangeQuery {
 }
 
 // NormalizeExtent adjusts the Start and End of a TimeRangeQuery's Extent to align against normalized boundaries.
-func (trq *TimeRangeQuery) NormalizeExtent() {
+func (trq *TimeRangeQuery) NormalizeExtent() *TimeRangeQuery {
+	t := trq.Clone()
 	if trq.Step > 0 {
 		if !trq.IsOffset && trq.Extent.End.After(time.Now()) {
-			trq.Extent.End = time.Now()
+			t.Extent.End = time.Now()
 		}
-		trq.Extent.Start = trq.Extent.Start.Truncate(trq.Step)
-		trq.Extent.End = trq.Extent.End.Truncate(trq.Step)
+		t.Extent.Start = trq.Extent.Start.Truncate(trq.Step)
+		t.Extent.End = trq.Extent.End.Truncate(trq.Step)
 	}
+	return t
 }
 
 func (trq *TimeRangeQuery) String() string {

--- a/pkg/timeseries/timerangequery_test.go
+++ b/pkg/timeseries/timerangequery_test.go
@@ -60,7 +60,7 @@ func TestNormalizeExtent(t *testing.T) {
 			trq := TimeRangeQuery{Statement: "up", Extent: Extent{Start: time.Unix(test.start, 0),
 				End: time.Unix(test.end, 0)}, Step: time.Duration(test.stepSecs) * time.Second}
 
-			trq.NormalizeExtent()
+			trq = *trq.NormalizeExtent()
 
 			if trq.Extent.Start.Unix() != test.rangeStart {
 				t.Errorf("Mismatch in rangeStart: expected=%d actual=%d", test.rangeStart, trq.Extent.Start.Unix())


### PR DESCRIPTION
Attempted fix for #765.

Having trouble reproducing the race, so still WIP.