### PR TITLE
feat: [redis/config] allow referencing redis password via env variable

### DIFF
--- a/pkg/cache/redis/cluster.go
+++ b/pkg/cache/redis/cluster.go
@@ -31,7 +31,7 @@ func (c *Cache) clusterOpts() (*redis.ClusterOptions, error) {
 	}
 
 	if c.Config.Redis.Password != "" {
-		o.Password = c.Config.Redis.Password
+		o.Password = string(c.Config.Redis.Password)
 	}
 
 	if c.Config.Redis.MaxRetries != 0 {

--- a/pkg/cache/redis/options/options.go
+++ b/pkg/cache/redis/options/options.go
@@ -16,6 +16,8 @@
 
 package options
 
+import "github.com/trickstercache/trickster/v2/pkg/config/types"
+
 // Options is a collection of Configurations for Connecting to Redis
 type Options struct {
 	// ClientType defines the type of Redis Client ("standard", "cluster", "sentinel")
@@ -27,7 +29,7 @@ type Options struct {
 	// Endpoints represents FQDN:port or IP:Port collection of a Redis Cluster or Sentinel Nodes
 	Endpoints []string `yaml:"endpoints,omitempty"`
 	// Password can be set when using password protected redis instance.
-	Password string `yaml:"password,omitempty"`
+	Password types.EnvString `yaml:"password,omitempty"`
 	// SentinelMaster should be set when using Redis Sentinel to indicate the Master Node
 	SentinelMaster string `yaml:"sentinel_master,omitempty"`
 	// DB is the Database to be selected after connecting to the server.

--- a/pkg/cache/redis/sentinel.go
+++ b/pkg/cache/redis/sentinel.go
@@ -36,7 +36,7 @@ func (c *Cache) sentinelOpts() (*redis.FailoverOptions, error) {
 	}
 
 	if c.Config.Redis.Password != "" {
-		o.Password = c.Config.Redis.Password
+		o.Password = string(c.Config.Redis.Password)
 	}
 
 	if c.Config.Redis.DB != 0 {

--- a/pkg/cache/redis/standard.go
+++ b/pkg/cache/redis/standard.go
@@ -37,7 +37,7 @@ func (c *Cache) clientOpts() (*redis.Options, error) {
 	}
 
 	if c.Config.Redis.Password != "" {
-		o.Password = c.Config.Redis.Password
+		o.Password = string(c.Config.Redis.Password)
 	}
 
 	if c.Config.Redis.DB != 0 {

--- a/pkg/config/types/doc.go
+++ b/pkg/config/types/doc.go
@@ -1,0 +1,5 @@
+package types
+
+// The `pkg/config/types` package contains common types used by the Trickster configuration files.
+// These types are defined in the `types` package to allow for easy import and avoid circular dependencies.
+// The `types` package should not import any other config or options-related packages.

--- a/pkg/config/types/envstring.go
+++ b/pkg/config/types/envstring.go
@@ -1,0 +1,25 @@
+package types
+
+import (
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+// EnvString is a string that should automatically have any environment variable references
+// expanded as it is decoded from YAML. For example, if the YAML contains
+//
+//	foo: ${BAR}
+//
+// then the value of foo will be the value of the BAR environment variable.
+type EnvString string
+
+func (s *EnvString) Unmarshal(data []byte) error {
+	if err := yaml.Unmarshal(data, s); err != nil {
+		return err
+	}
+	if len(*s) != 0 {
+		*s = EnvString(os.ExpandEnv(string(*s)))
+	}
+	return nil
+}

--- a/pkg/config/types/envstring_test.go
+++ b/pkg/config/types/envstring_test.go
@@ -1,0 +1,26 @@
+package types
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvString(t *testing.T) {
+	os.Setenv("FOO", "bar")
+	os.Setenv("BAR", "baz")
+	example := EnvString("")
+	// expect bar
+	err := example.Unmarshal([]byte("${FOO}"))
+	require.NoError(t, err)
+	require.Equal(t, "bar", string(example))
+	// expect baz
+	err = example.Unmarshal([]byte("${BAR}"))
+	require.NoError(t, err)
+	require.Equal(t, "baz", string(example))
+	// expect both
+	err = example.Unmarshal([]byte("${FOO}${BAR}"))
+	require.NoError(t, err)
+	require.Equal(t, "barbaz", string(example))
+}


### PR DESCRIPTION
* Adds a new package `pkg/config/types` for common custom types used across the config / options structs
* Adds a new type `type EnvString` that automatically expands environment variable references as it is decoded from a config file
* Updates the redis password to use the new `EnvString` type

example:
```yaml
caches:
  default:
    redis:
      password: "${MY_REDIS_PW}"
```