### PR TITLE
feat: [config] allow referencing header values from environment variables

### DIFF
--- a/docs/alb.md
+++ b/docs/alb.md
@@ -58,7 +58,7 @@ backends:
     path_routing_disabled: true # disables frontend request routing via /node02 path
     origin_url: http://node-02.example.com # make unsecured requests
     request_headers: # this backend might use basic auth headers
-      Authoriziation: "basic jdoe:*****"
+      Authoriziation: "basic jdoe:${NODE_02_AUTH_TOKEN}"
 
   # Trickster 2.0 ALB backend configuration, using above backends as pool members
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -20,6 +20,20 @@ When a `-config` parameter is not provided, Trickster will check for the presenc
 
 Refer to [examples/conf/example.full.yaml](../examples/conf/example.full.yaml) for full documentation on format of a configuration file.
 
+### Configuring Secrets or Sensitive Information
+
+Trickster supports Environment variable substitution in its configuration file where sensitive information is expected.
+- Supported via the following fields:
+  - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].response_headers`
+
+Usage `${ENV_VAR_NAME}`, example:
+```yaml
+caches:
+  default:
+    redis:
+      password: "${MY_REDIS_PW}"
+```
+
 ## Environment Variables
 
 Trickster will then check for and evaluate the following Environment Variables:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -24,7 +24,7 @@ Refer to [examples/conf/example.full.yaml](../examples/conf/example.full.yaml) f
 
 Trickster supports Environment variable substitution in its configuration file where sensitive information is expected.
 - Supported via the following fields:
-  - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].response_headers`
+  - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].request_params`, `backends[*].paths[*].response_headers`
 
 Usage `${ENV_VAR_NAME}`, example:
 ```yaml

--- a/docs/new-changed-2.0.md
+++ b/docs/new-changed-2.0.md
@@ -44,6 +44,10 @@
 - We've switched from Regular Expression matches for SQL-based Time Series Backends to an extensible lexer/parser solution
   - ClickHouse backend providers now use the new SQL Parser
 - We now support [Simiulated Latency](./simulated-latency.md) if you want to use Trickster for that purpose in a test harness.
+- We now support Environment variable substitution in configuration files where sensitive information is expected.
+  - Supported via the following fields:
+    - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].response_headers`
+  - Usage: `password: ${MY_SECRET_VAR}`
 
 ## Still to Come
 

--- a/docs/new-changed-2.0.md
+++ b/docs/new-changed-2.0.md
@@ -46,7 +46,7 @@
 - We now support [Simiulated Latency](./simulated-latency.md) if you want to use Trickster for that purpose in a test harness.
 - We now support Environment variable substitution in configuration files where sensitive information is expected.
   - Supported via the following fields:
-    - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].response_headers`
+    - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].request_params`, `backends[*].paths[*].response_headers`
   - Usage: `password: ${MY_SECRET_VAR}`
 
 ## Still to Come

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -67,6 +67,23 @@ To Set a header or parameter means to insert if non-existent, or fully replace i
 
 As an example, if the client request provides a `Cache-Control: no-store` header, a Path Config with a header 'set' directive for `'Cache-Control' = 'no-transform'` will replace the `no-store` entirely with a `no-transform`; client requests that have no `Cache-Control` header that are routed through this Path will have the Trickster-configured header injected outright. The same logic applies to query parameters.
 
+##### Environment Variable Substitution
+
+The `request_headers` and `response_headers` sections support environment variable substitution. This means you can use environment variables in your header or query parameter values. Example:
+
+```yaml
+backends:
+  default:
+    // ...
+    paths:
+      root:
+        // ...
+        request_headers:
+          'X-Auth-Token': '${AUTH_TOKEN}'
+        response_headers:
+          'X-Auth-Token': '${AUTH_TOKEN}'
+```
+
 #### Appending
 
 Appending a means inserting the header or parameter if it doesn't exist, or appending the configured value(s) into a pre-existing header with the given name. To indicate an append behavior (as opposed to set), prefix the header or parameter name with a '+' in the Path Config.

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -69,19 +69,21 @@ As an example, if the client request provides a `Cache-Control: no-store` header
 
 ##### Environment Variable Substitution
 
-The `request_headers` and `response_headers` sections support environment variable substitution. This means you can use environment variables in your header or query parameter values. Example:
+The `request_headers`, `request_params` and `response_headers` sections support environment variable substitution. This means you can use environment variables in your header or query parameter values. Example:
 
 ```yaml
 backends:
   default:
-    // ...
+    # ...
     paths:
       root:
-        // ...
+        # ...
+        request_params:
+          'token': '${REQUEST_PARAM_TOKEN}'
         request_headers:
-          'X-Auth-Token': '${AUTH_TOKEN}'
+          'X-Auth-Token': '${REQUEST_HEADER_TOKEN}'
         response_headers:
-          'X-Auth-Token': '${AUTH_TOKEN}'
+          'X-Auth-Token': '${RESPONSE_HEADER_TOKEN}'
 ```
 
 #### Appending
@@ -141,9 +143,10 @@ backends:
         methods: [ '*' ] # All HTTP methods applicable to this config
         match_type: prefix # matches any path under '/'
         handler: proxy # proxy only, no caching (this is the default)
-        # modify the query params en route to the origin; this adds authToken=secret_string
+        # modify the query params en route to the origin; this adds authToken=${ROOT_REQUEST_AUTH_TOKEN}
+        # (sourced from the environment variable ROOT_REQUEST_AUTH_TOKEN)
         request_params:
-          authToken: secret string
+          authToken: ${ROOT_REQUEST_AUTH_TOKEN}
         # When a user requests a path matching this route, Trickster will
         # inject these headers into the request before contacting the Origin
         request_headers:

--- a/pkg/backends/healthcheck/options/options.go
+++ b/pkg/backends/healthcheck/options/options.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/util/yamlx"
 )
@@ -59,7 +60,7 @@ type Options struct {
 	// Query provides the HTTP query parameters to use when making an upstream health check
 	Query string `yaml:"query,omitempty"`
 	// Headers provides the HTTP Headers to apply when making an upstream health check
-	Headers map[string]string `yaml:"headers,omitempty"`
+	Headers types.EnvStringMap `yaml:"headers,omitempty"`
 	// Body provides a body to apply when making an upstream health check request
 	Body string `yaml:"body,omitempty"`
 	// TimeoutMS is the amount of time a health check probe should wait for a response
@@ -109,7 +110,7 @@ func (o *Options) Clone() *Options {
 	c.IntervalMS = o.IntervalMS
 	c.ExpectedBody = o.ExpectedBody
 	if o.Headers != nil {
-		c.Headers = headers.Lookup(o.Headers).Clone()
+		c.Headers = types.EnvStringMap(headers.Lookup(o.Headers).Clone())
 	}
 	if o.ExpectedHeaders != nil {
 		c.ExpectedHeaders = headers.Lookup(o.ExpectedHeaders).Clone()

--- a/pkg/config/types/envstring.go
+++ b/pkg/config/types/envstring.go
@@ -23,3 +23,17 @@ func (s *EnvString) Unmarshal(data []byte) error {
 	}
 	return nil
 }
+
+// EnvStringMap is a map of strings that should automatically expand environment variables
+// as it is decoded from YAML (like EnvString).
+type EnvStringMap map[string]string
+
+func (s *EnvStringMap) Unmarshal(data []byte) error {
+	if err := yaml.Unmarshal(data, s); err != nil {
+		return err
+	}
+	for k, v := range *s {
+		(*s)[k] = os.ExpandEnv(v)
+	}
+	return nil
+}

--- a/pkg/config/types/envstring_test.go
+++ b/pkg/config/types/envstring_test.go
@@ -24,3 +24,22 @@ func TestEnvString(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "barbaz", string(example))
 }
+
+func TestEnvStringMap(t *testing.T) {
+	os.Setenv("FIZZ", "buzz")
+	os.Setenv("BIZZ", "quux")
+	example := EnvStringMap{}
+	// expect fizz
+	err := example.Unmarshal([]byte(`abc: "${FIZZ}"`))
+	require.NoError(t, err)
+	require.Equal(t, "buzz", example["abc"])
+	// expect bizz
+	err = example.Unmarshal([]byte(`def: "${BIZZ}"`))
+	require.NoError(t, err)
+	require.Equal(t, "quux", example["def"])
+	// expect both
+	err = example.Unmarshal([]byte(`abc: "${FIZZ}"` + "\n" + `def: "${BIZZ}"`))
+	require.NoError(t, err)
+	require.Equal(t, "buzz", example["abc"])
+	require.Equal(t, "quux", example["def"])
+}

--- a/pkg/proxy/headers/sensitive.go
+++ b/pkg/proxy/headers/sensitive.go
@@ -24,10 +24,10 @@ var sensitiveCredentials = map[string]interface{}{NameAuthorization: nil}
 
 // HideAuthorizationCredentials replaces any sensitive HTTP header values with 5
 // asterisks sensitive headers are defined in the sensitiveCredentials map
-func HideAuthorizationCredentials(headers Lookup) {
+func HideAuthorizationCredentials[m ~map[K]V, K ~string, V ~string](headers m) {
 	// strip Authorization Headers
 	for k := range headers {
-		if _, ok := sensitiveCredentials[k]; ok {
+		if _, ok := sensitiveCredentials[string(k)]; ok {
 			headers[k] = "*****"
 		}
 	}

--- a/pkg/proxy/paths/options/options.go
+++ b/pkg/proxy/paths/options/options.go
@@ -53,8 +53,8 @@ type Options struct {
 	CacheKeyFormFields []string `yaml:"cache_key_form_fields,omitempty"`
 	// RequestHeaders is a map of headers that will be added to requests to the upstream Origin for this path
 	RequestHeaders types.EnvStringMap `yaml:"request_headers,omitempty"`
-	// RequestParams is a map of headers that will be added to requests to the upstream Origin for this path
-	RequestParams map[string]string `yaml:"request_params,omitempty"`
+	// RequestParams is a map of parameters that will be added to requests to the upstream Origin for this path
+	RequestParams types.EnvStringMap `yaml:"request_params,omitempty"`
 	// ResponseHeaders is a map of http headers that will be added to responses to the downstream client
 	ResponseHeaders types.EnvStringMap `yaml:"response_headers,omitempty"`
 	// ResponseCode sets a custom response code to be sent to downstream clients for this path.

--- a/pkg/proxy/paths/options/options.go
+++ b/pkg/proxy/paths/options/options.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/cache/key"
+	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/forwarding"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
@@ -51,11 +52,11 @@ type Options struct {
 	// in the hash for each request's cache key
 	CacheKeyFormFields []string `yaml:"cache_key_form_fields,omitempty"`
 	// RequestHeaders is a map of headers that will be added to requests to the upstream Origin for this path
-	RequestHeaders map[string]string `yaml:"request_headers,omitempty"`
+	RequestHeaders types.EnvStringMap `yaml:"request_headers,omitempty"`
 	// RequestParams is a map of headers that will be added to requests to the upstream Origin for this path
 	RequestParams map[string]string `yaml:"request_params,omitempty"`
 	// ResponseHeaders is a map of http headers that will be added to responses to the downstream client
-	ResponseHeaders map[string]string `yaml:"response_headers,omitempty"`
+	ResponseHeaders types.EnvStringMap `yaml:"response_headers,omitempty"`
 	// ResponseCode sets a custom response code to be sent to downstream clients for this path.
 	ResponseCode int `yaml:"response_code,omitempty"`
 	// ResponseBody sets a custom response body to be sent to the donstream client for this path.


### PR DESCRIPTION
Following #769, adds environment substitution support to the backend and health-check header values.

Adds new type, `type EnvStringMap map[string]string` to handle substitution into a map of values; this type is chosen so that it is more easily retrofit into the current `map[string]string` usage.