### PR TITLE
refactor: use more stdlib & optimize dataset/points.Size

### DIFF
--- a/pkg/proxy/tls/options/options.go
+++ b/pkg/proxy/tls/options/options.go
@@ -19,8 +19,6 @@ package options
 import (
 	"os"
 	"slices"
-
-	strutil "github.com/trickstercache/trickster/v2/pkg/util/strings"
 )
 
 // Options is a collection of TLS-related client and server configurations
@@ -71,7 +69,7 @@ func (o *Options) Equal(o2 *Options) bool {
 	return o.FullChainCertPath == o2.FullChainCertPath &&
 		o.PrivateKeyPath == o2.PrivateKeyPath &&
 		o.InsecureSkipVerify == o2.InsecureSkipVerify &&
-		strutil.Equal(o.CertificateAuthorityPaths, o2.CertificateAuthorityPaths) &&
+		slices.Equal(o.CertificateAuthorityPaths, o2.CertificateAuthorityPaths) &&
 		o.ClientCertPath == o2.ClientCertPath &&
 		o.ClientKeyPath == o2.ClientKeyPath
 }

--- a/pkg/router/lm/lm.go
+++ b/pkg/router/lm/lm.go
@@ -19,7 +19,6 @@ package lm
 
 import (
 	"net/http"
-	"slices"
 	"sort"
 	"strings"
 
@@ -161,7 +160,6 @@ func (rt *lmRouter) sort() {
 		}
 		prs := prefixRouteSets(hrc.PrefixMatchRoutes)
 		sort.Sort(prs)
-		slices.Reverse(prs)
 		hrc.PrefixMatchRoutes = route.PrefixRouteSets(prs)
 	}
 }
@@ -238,5 +236,5 @@ func (prs prefixRouteSets) Swap(i, j int) {
 }
 
 func (prs prefixRouteSets) Less(i, j int) bool {
-	return prs[i].PathLen < prs[j].PathLen
+	return prs[i].PathLen > prs[j].PathLen
 }

--- a/pkg/router/lm/lm_test.go
+++ b/pkg/router/lm/lm_test.go
@@ -21,7 +21,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/trickstercache/trickster/v2/pkg/errors"
+	"github.com/trickstercache/trickster/v2/pkg/router/route"
 	"github.com/trickstercache/trickster/v2/pkg/testutil/writer"
 )
 
@@ -231,4 +233,31 @@ func verifyTestResponse2(h http.Handler, w *writer.TestResponseWriter,
 
 func verifyBadRequest(w *writer.TestResponseWriter) bool {
 	return w.StatusCode == http.StatusBadRequest
+}
+
+func Test_lmRouter(t *testing.T) {
+	l := lmRouter{
+		routes: map[string]*route.HostRouteSet{
+			"foo": {
+				PrefixMatchRoutes: []*route.PrefixRouteSet{
+					{Path: "/baz", PathLen: 3},
+					{Path: "/quxx", PathLen: 4},
+					{Path: "/ab", PathLen: 2},
+				},
+			},
+		},
+	}
+	// sort the routes (by path length)
+	l.sort()
+	route := l.routes["foo"]
+	require.Equal(t, 3, len(route.PrefixMatchRoutes))
+	prefixes := route.PrefixMatchRoutes
+	// check the order of sorted routes
+	require.Equal(t, "/quxx", prefixes[0].Path)
+	require.Equal(t, 4, prefixes[0].PathLen)
+	require.Equal(t, "/baz", prefixes[1].Path)
+	require.Equal(t, 3, prefixes[1].PathLen)
+	require.Equal(t, "/ab", prefixes[2].Path)
+	require.Equal(t, 2, prefixes[2].PathLen)
+
 }

--- a/pkg/timeseries/dataset/point.go
+++ b/pkg/timeseries/dataset/point.go
@@ -19,17 +19,14 @@
 package dataset
 
 import (
-	"sync"
-	"sync/atomic"
-
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/epoch"
 )
 
 // Point represents a timeseries data point
 type Point struct {
-	Epoch  epoch.Epoch   `msg:"epoch"`
-	Size   int           `msg:"size"`
-	Values []interface{} `msg:"values"`
+	Epoch  epoch.Epoch `msg:"epoch"`
+	Size   int         `msg:"size"`
+	Values []any       `msg:"values"`
 }
 
 // Points is a slice of type *Point
@@ -42,7 +39,7 @@ func (p *Point) Clone() Point {
 		Size:  p.Size,
 	}
 	if p.Values != nil {
-		clone.Values = make([]interface{}, len(p.Values))
+		clone.Values = make([]any, len(p.Values))
 		copy(clone.Values, p.Values)
 	}
 	return clone
@@ -50,18 +47,11 @@ func (p *Point) Clone() Point {
 
 // Size returns the memory utilization of the Points in bytes
 func (p Points) Size() int64 {
-	var c atomic.Int64
-	c.Store(16)
-	var wg sync.WaitGroup
-	for i, pt := range p {
-		wg.Add(1)
-		go func(s, e int64, j int) {
-			c.Add(s)
-			wg.Done()
-		}(int64(pt.Size), int64(pt.Epoch), i)
+	var c int64 = 16
+	for _, pt := range p {
+		c += int64(pt.Size)
 	}
-	wg.Wait()
-	return c.Load()
+	return c
 }
 
 // Clone returns a perfect copy of the Points

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -38,8 +38,7 @@ func Substring(s string, i int, length int) string {
 func Unique(in []string) []string {
 	out := slices.Clone(in)
 	slices.Sort(out)
-	out = slices.Compact(out)
-	return out
+	return slices.Compact(out)
 }
 
 // ErrKeyNotInMap represents an error for key not found in map

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -20,6 +20,7 @@ package strings
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -33,62 +34,17 @@ func Substring(s string, i int, length int) string {
 	return s[i : i+length]
 }
 
-// IndexInSlice returns the index of a string element in a given slice
-func IndexInSlice(arr []string, val string) int {
-	for i, v := range arr {
-		if v == val {
-			return i
-		}
-	}
-	return -1
-}
-
-// CloneBoolMap returns an exact copy of a map consisting string key and bool value
-func CloneBoolMap(in map[string]bool) map[string]bool {
-	if in == nil {
-		return nil
-	}
-	out := make(map[string]bool)
-	for k, v := range in {
-		out[k] = v
-	}
-	return out
-}
-
 // Equal returns true if the slices contain identical values in the identical order
 func Equal(s1, s2 []string) bool {
-	if s1 == nil && s2 == nil {
-		return true
-	}
-	if s1 == nil || s2 == nil || len(s1) != len(s2) {
-		return false
-	}
-	for i, v := range s1 {
-		if v != s2[i] {
-			return false
-		}
-	}
-	return true
+	return slices.Equal(s1, s2)
 }
 
 // Unique returns a uniqueified version of the list
 func Unique(in []string) []string {
-	l := len(in)
-	if l == 0 {
-		return in
-	}
-	m := make(map[string]interface{})
-	out := make([]string, l)
-	var k int
-	for _, v := range in {
-		if _, ok := m[v]; ok {
-			continue
-		}
-		out[k] = v
-		k++
-		m[v] = nil
-	}
-	return out[:k]
+	out := slices.Clone(in)
+	slices.Sort(out)
+	out = slices.Compact(out)
+	return out
 }
 
 // ErrKeyNotInMap represents an error for key not found in map
@@ -97,8 +53,8 @@ var ErrKeyNotInMap = errors.New("key not found in map")
 // StringMap represents a map[string]string
 type StringMap map[string]string
 
-// Lookup represents a map[string]interface{} with assumed nil values
-type Lookup map[string]interface{}
+// Lookup represents a map[string]any with assumed nil values
+type Lookup map[string]any
 
 func (m StringMap) String() string {
 	delimiter := ""

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -34,11 +34,6 @@ func Substring(s string, i int, length int) string {
 	return s[i : i+length]
 }
 
-// Equal returns true if the slices contain identical values in the identical order
-func Equal(s1, s2 []string) bool {
-	return slices.Equal(s1, s2)
-}
-
 // Unique returns a uniqueified version of the list
 func Unique(in []string) []string {
 	out := slices.Clone(in)

--- a/pkg/util/strings/strings_test.go
+++ b/pkg/util/strings/strings_test.go
@@ -34,22 +34,6 @@ func TestSubstring(t *testing.T) {
 	}
 }
 
-func TestIndexOfString(t *testing.T) {
-
-	arr := []string{"string0", "string1", "string2"}
-
-	i := IndexInSlice(arr, "string0")
-	if i != 0 {
-		t.Errorf(`expected 0. got %d`, i)
-	}
-
-	i = IndexInSlice(arr, "string3")
-	if i != -1 {
-		t.Errorf(`expected -1. got %d`, i)
-	}
-
-}
-
 func TestEqual(t *testing.T) {
 
 	l1 := []string{"test1", "test2"}
@@ -74,6 +58,14 @@ func TestEqual(t *testing.T) {
 	}
 }
 
+func BenchmarkEqual(b *testing.B) {
+	l1 := []string{"test1", "test2"}
+	l2 := []string{"test1", "test2"}
+	for i := 0; i < b.N; i++ {
+		Equal(l1, l2)
+	}
+}
+
 func TestStringMap(t *testing.T) {
 
 	sm := StringMap(map[string]string{"test": "value"})
@@ -82,29 +74,6 @@ func TestStringMap(t *testing.T) {
 
 	if s != expected {
 		t.Errorf("expected %s got %s", expected, s)
-	}
-
-}
-
-func TestCloneBoolMap(t *testing.T) {
-
-	m1 := CloneBoolMap(nil)
-	if m1 != nil {
-		t.Error("expected nil map")
-	}
-
-	const expected = true
-
-	m := map[string]bool{"test": expected}
-	m2 := CloneBoolMap(m)
-
-	v, ok := m2["test"]
-	if !ok {
-		t.Errorf("expected true got %t", ok)
-	}
-
-	if v != expected {
-		t.Errorf("expected %t got %t", expected, v)
 	}
 
 }
@@ -120,6 +89,13 @@ func TestUnique(t *testing.T) {
 	empty := Unique(nil)
 	if len(empty) != 0 {
 		t.Error("expected empty list")
+	}
+}
+
+func BenchmarkUnique(b *testing.B) {
+	initial := []string{"test", "test", "test1", "test2", "test2", "test", "test3"}
+	for i := 0; i < b.N; i++ {
+		Unique(initial)
 	}
 }
 

--- a/pkg/util/strings/strings_test.go
+++ b/pkg/util/strings/strings_test.go
@@ -34,38 +34,6 @@ func TestSubstring(t *testing.T) {
 	}
 }
 
-func TestEqual(t *testing.T) {
-
-	l1 := []string{"test1", "test2"}
-	l2 := []string{"test1", "test2"}
-	l3 := []string{"test3", "test4"}
-	l4 := []string{}
-
-	if !Equal(l1, l2) {
-		t.Error("expected true got false")
-	}
-
-	if Equal(l1, l3) {
-		t.Error("expected false got true")
-	}
-
-	if Equal(l1, l4) {
-		t.Error("expected false got true")
-	}
-
-	if !Equal(nil, nil) {
-		t.Error("expected true got false")
-	}
-}
-
-func BenchmarkEqual(b *testing.B) {
-	l1 := []string{"test1", "test2"}
-	l2 := []string{"test1", "test2"}
-	for i := 0; i < b.N; i++ {
-		Equal(l1, l2)
-	}
-}
-
 func TestStringMap(t *testing.T) {
 
 	sm := StringMap(map[string]string{"test": "value"})


### PR DESCRIPTION
* Removes unused code
* Replaces custom string/slice functions with stdlib
* Removes extra `slices.reverse` call in `pkg/router/lm`
* Optimize point size calculation

---
Equal -- ~no change
Unique --  20% improvement

```
BenchmarkEqual-12     	245202459	         4.393 ns/op
BenchmarkUnique-12    	14429709	        88.49 ns/op
```

vs (main):

```
BenchmarkEqual-12     	263193535	         4.449 ns/op
BenchmarkUnique-12    	10249306	       112.2 ns/op
```
---
Points.Size -- looks like a big improvement -- I'm not sure if the goroutine was helping here

```
BenchmarkPointsSize-12    	     100	       654.5 ns/op
```

vs (main):

```
BenchmarkPointsSize-12    	     100	    291119 ns/op
```

