### PR TITLE
refactor: minor improvements

### DIFF
--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -88,5 +88,5 @@ func IsVirtual(provider string) bool {
 // UsesCache returns true if the backend uses a cache
 // (anything except Virtuals and ReverseProxy)
 func UsesCache(provider string) bool {
-	return !(IsVirtual(provider)) && !(provider == "rp") && !(provider == "reverseproxy")
+	return !IsVirtual(provider) && provider != "rp" && provider != "reverseproxy"
 }

--- a/pkg/backends/clickhouse/handler_query.go
+++ b/pkg/backends/clickhouse/handler_query.go
@@ -51,9 +51,9 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 		r = request.SetBody(r, body)
 	}
 	sqlQuery = strings.ToLower(sqlQuery)
-	if !(strings.HasPrefix(sqlQuery, "select ") ||
-		strings.HasPrefix(sqlQuery, "select\n") ||
-		strings.Contains(sqlQuery, " select ")) {
+	if !strings.HasPrefix(sqlQuery, "select ") &&
+		!strings.HasPrefix(sqlQuery, "select\n") &&
+		!strings.Contains(sqlQuery, " select ") {
 		c.ProxyHandler(w, r)
 		return
 	}

--- a/pkg/backends/clickhouse/parsing.go
+++ b/pkg/backends/clickhouse/parsing.go
@@ -586,12 +586,12 @@ func parseWhereTokens(results map[string]interface{},
 				}
 				_, j, _ := SolveMathExpression(fieldParts[i:], ts, withVars)
 				if atLowerBound {
-					//e.Start = time.Unix(v, 0)
+					// e.Start = time.Unix(v, 0)
 					e.Start, _, _ = lsql.TokenToTime(t)
 					tsr1 = t.Val
 					atLowerBound = false
 				} else {
-					//e.End = time.Unix(v, 0)
+					// e.End = time.Unix(v, 0)
 					e.End, _, _ = lsql.TokenToTime(t)
 					tsr2 = t.Val
 				}
@@ -643,16 +643,16 @@ func parseWhereTokens(results map[string]interface{},
 		r2 = trq.Statement[s2:e2]
 	}
 	if r1 != "" {
-		trq.Statement = strings.Replace(trq.Statement, r1, tkRange, -1)
+		trq.Statement = strings.ReplaceAll(trq.Statement, r1, tkRange)
 	}
 	if r2 != "" {
-		trq.Statement = strings.Replace(trq.Statement, r2, "", -1)
+		trq.Statement = strings.ReplaceAll(trq.Statement, r2, "")
 	}
 	if tsr1 != "" {
-		trq.Statement = strings.Replace(trq.Statement, tsr1, tkTS1, -1)
+		trq.Statement = strings.ReplaceAll(trq.Statement, tsr1, tkTS1)
 	}
 	if tsr2 != "" {
-		trq.Statement = strings.Replace(trq.Statement, tsr2, tkTS2, -1)
+		trq.Statement = strings.ReplaceAll(trq.Statement, tsr2, tkTS2)
 	}
 	return nil, nil
 }

--- a/pkg/backends/healthcheck/target.go
+++ b/pkg/backends/healthcheck/target.go
@@ -158,7 +158,7 @@ func (t *target) isGoodBody(r io.ReadCloser) bool {
 		t.status.detail = "error reading response body from target"
 		return false
 	}
-	if !(string(x) == t.eb) {
+	if string(x) != t.eb {
 		t.status.detail = fmt.Sprintf("required response body mismatch expected [%s] got [%s]", t.eb, string(x))
 		return false
 	}
@@ -252,7 +252,7 @@ func (t *target) demandProbe(w http.ResponseWriter) {
 				h.Set(k, sh.Get(k))
 			}
 		}
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("error performing health check: " + err.Error()))
 		return
 	}

--- a/pkg/backends/influxdb/model/marshal.go
+++ b/pkg/backends/influxdb/model/marshal.go
@@ -104,7 +104,7 @@ func writeCSVValue(w io.Writer, v any, nilVal string) {
 	switch t := v.(type) {
 	case string:
 		if strings.Contains(t, `"`) {
-			t = `"` + strings.Replace(t, `"`, `\"`, -1) + `"`
+			t = `"` + strings.ReplaceAll(t, `"`, `\"`) + `"`
 		} else if strings.Contains(t, " ") || strings.Contains(t, ",") {
 			t = `"` + t + `"`
 		}

--- a/pkg/backends/influxdb/model/unmarshal.go
+++ b/pkg/backends/influxdb/model/unmarshal.go
@@ -59,7 +59,7 @@ func decodeCSV(reader io.Reader) (*WFDocument, error) {
 		return nil, err
 	}
 	var columns []string
-	var rows int = len(records) - 1
+	rows := len(records) - 1
 	if len(records) == 0 {
 		rows = 0
 	}
@@ -112,14 +112,6 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 			return nil, err
 		}
 	}
-	//wfd := &WFDocument{}
-	//d := json.NewDecoder(reader)
-	//err := d.Decode(wfd)
-	/*
-		if err != nil {
-			return nil, err
-		}
-	*/
 	ds := &dataset.DataSet{
 		Error:          wfd.Err,
 		TimeRangeQuery: trq,

--- a/pkg/backends/irondb/handler_caql.go
+++ b/pkg/backends/irondb/handler_caql.go
@@ -76,7 +76,7 @@ func (c *Client) caqlHandlerParseTimeRangeQuery(
 
 	qp := r.URL.Query()
 	var err error
-	p := ""
+	var p string
 
 	if p = qp.Get(upQuery); p == "" {
 		if p = qp.Get(upCAQLQuery); p == "" {

--- a/pkg/backends/irondb/handler_fetch.go
+++ b/pkg/backends/irondb/handler_fetch.go
@@ -25,11 +25,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/engines"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/urls"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
-	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
 )
 
 // FetchHandler handles requests for numeric timeseries data with specified

--- a/pkg/backends/irondb/handler_histogram.go
+++ b/pkg/backends/irondb/handler_histogram.go
@@ -26,12 +26,12 @@ import (
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/irondb/common"
+	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/engines"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/urls"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
-	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
 )
 
 // HistogramHandler handles requests for historgam timeseries data and processes

--- a/pkg/backends/irondb/handler_raw.go
+++ b/pkg/backends/irondb/handler_raw.go
@@ -53,7 +53,7 @@ func (c *Client) rawHandlerParseTimeRangeQuery(
 
 	qp := r.URL.Query()
 	var err error
-	p := ""
+	var p string
 	if p = qp.Get(upStart); p == "" {
 		return nil, errors.MissingURLParam(upStart)
 	}

--- a/pkg/backends/irondb/handler_rollup.go
+++ b/pkg/backends/irondb/handler_rollup.go
@@ -75,7 +75,7 @@ func (c *Client) rollupHandlerParseTimeRangeQuery(
 
 	qp := r.URL.Query()
 	var err error
-	p := ""
+	var p string
 	if p = qp.Get(upStart); p == "" {
 		return nil, errors.MissingURLParam(upStart)
 	}

--- a/pkg/backends/irondb/handler_text.go
+++ b/pkg/backends/irondb/handler_text.go
@@ -24,11 +24,11 @@ import (
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/irondb/common"
+	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/engines"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/urls"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
-	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
 )
 
 // TextHandler handles requests for text timeseries data and processes them

--- a/pkg/backends/irondb/handler_text_test.go
+++ b/pkg/backends/irondb/handler_text_test.go
@@ -25,8 +25,8 @@ import (
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
-	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	tu "github.com/trickstercache/trickster/v2/pkg/testutil"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
 func TestTextHandler(t *testing.T) {

--- a/pkg/backends/irondb/health.go
+++ b/pkg/backends/irondb/health.go
@@ -28,6 +28,6 @@ func (c *Client) DefaultHealthCheckConfig() *ho.Options {
 	o.Host = u.Host
 	o.Path = u.Path
 	// TODO: Provide health check query
-	//o.Query = url.Values{"query": {healthQuery}}.Encode()
+	// o.Query = url.Values{"query": {healthQuery}}.Encode()
 	return o
 }

--- a/pkg/backends/irondb/model/model.go
+++ b/pkg/backends/irondb/model/model.go
@@ -399,7 +399,7 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 // UnmarshalTimeseries converts a JSON blob into a Timeseries value.
 func UnmarshalTimeseries(data []byte, trq *timeseries.TimeRangeQuery) (timeseries.Timeseries,
 	error) {
-	if strings.Contains(strings.Replace(string(data), " ", "", -1),
+	if strings.Contains(strings.ReplaceAll(string(data), " ", ""),
 		`"version":"DF4"`) {
 		se := &DF4SeriesEnvelope{timeRangeQuery: trq}
 		if trq != nil {

--- a/pkg/backends/irondb/model/model_df4.go
+++ b/pkg/backends/irondb/model/model_df4.go
@@ -324,8 +324,8 @@ func (se *DF4SeriesEnvelope) CropToSize(sz int, t time.Time,
 		newData = append(newData, data[rc:])
 	}
 
-	se.Head.Start += int64(rc) * se.Head.Period
-	se.Head.Count -= int64(rc)
+	se.Head.Start += rc * se.Head.Period
+	se.Head.Count -= rc
 	se.Data = newData
 	se.ExtentList = timeseries.ExtentList{timeseries.Extent{
 		Start: time.Unix(se.Head.Start, 0),

--- a/pkg/backends/options/errors.go
+++ b/pkg/backends/options/errors.go
@@ -41,10 +41,9 @@ type ErrMissingProvider struct {
 
 // NewErrMissingProvider returns a new missing provider error
 func NewErrMissingProvider(backendName string) error {
-	var e *ErrMissingProvider = &ErrMissingProvider{
+	return &ErrMissingProvider{
 		error: fmt.Errorf(`missing provider for backend "%s"`, backendName),
 	}
-	return e
 }
 
 // ErrMissingOriginURL is an error type for missing origin URL
@@ -54,10 +53,9 @@ type ErrMissingOriginURL struct {
 
 // NewErrMissingOriginURL returns a new missing origin URL error
 func NewErrMissingOriginURL(backendName string) error {
-	var e *ErrMissingOriginURL = &ErrMissingOriginURL{
+	return &ErrMissingOriginURL{
 		error: fmt.Errorf(`missing origin-url for backend "%s"`, backendName),
 	}
-	return e
 }
 
 // ErrInvalidNegativeCacheName is an error type for invalid negative cache name
@@ -67,10 +65,9 @@ type ErrInvalidNegativeCacheName struct {
 
 // NewErrInvalidNegativeCacheName returns a new invalid negative cache name error
 func NewErrInvalidNegativeCacheName(cacheName string) error {
-	var e *ErrInvalidNegativeCacheName = &ErrInvalidNegativeCacheName{
+	return &ErrInvalidNegativeCacheName{
 		error: fmt.Errorf(`invalid negative cache name: %s`, cacheName),
 	}
-	return e
 }
 
 // ErrInvalidRuleName is an error type for invalid rule name
@@ -80,11 +77,10 @@ type ErrInvalidRuleName struct {
 
 // NewErrInvalidRuleName returns a new invalid rule name error
 func NewErrInvalidRuleName(ruleName, backendName string) error {
-	var e *ErrInvalidRuleName = &ErrInvalidRuleName{
+	return &ErrInvalidRuleName{
 		error: fmt.Errorf(`invalid rule name "%s" provided in backend options "%s"`,
 			ruleName, backendName),
 	}
-	return e
 }
 
 // ErrInvalidALBOptions is an error type for invalid ALB Options
@@ -94,11 +90,10 @@ type ErrInvalidALBOptions struct {
 
 // NewErrInvalidALBOptions returns a new invalid ALB Options error
 func NewErrInvalidALBOptions(albName, backendName string) error {
-	var e *ErrInvalidALBOptions = &ErrInvalidALBOptions{
+	return &ErrInvalidALBOptions{
 		error: fmt.Errorf("invalid backend name [%s] provided in pool for alb [%s]",
 			backendName, albName),
 	}
-	return e
 }
 
 // ErrInvalidCacheName is an error type for invalid cache name
@@ -108,11 +103,10 @@ type ErrInvalidCacheName struct {
 
 // NewErrInvalidCacheName returns a new invalid cache name error
 func NewErrInvalidCacheName(cacheName, backendName string) error {
-	var e *ErrInvalidCacheName = &ErrInvalidCacheName{
+	return &ErrInvalidCacheName{
 		error: fmt.Errorf(`invalid cache name "%s" provided in backend options "%s"`,
 			cacheName, backendName),
 	}
-	return e
 }
 
 // ErrInvalidBackendName is an error type for invalid backend name
@@ -122,10 +116,9 @@ type ErrInvalidBackendName struct {
 
 // NewErrInvalidBackendName returns a new invalid backend name error
 func NewErrInvalidBackendName(backendName string) error {
-	var e *ErrInvalidBackendName = &ErrInvalidBackendName{
+	return &ErrInvalidBackendName{
 		error: fmt.Errorf(`invalid backend name: %s`, backendName),
 	}
-	return e
 }
 
 // ErrInvalidRewriterName is an error type for invalid rewriter name
@@ -135,9 +128,8 @@ type ErrInvalidRewriterName struct {
 
 // NewErrInvalidRewriterName returns a new missing invalid rewriter name error
 func NewErrInvalidRewriterName(rewriterName, backendName string) error {
-	var e *ErrInvalidRewriterName = &ErrInvalidRewriterName{
+	return &ErrInvalidRewriterName{
 		error: fmt.Errorf(`invalid rewriter name "%s" provided in backend options "%s"`,
 			rewriterName, backendName),
 	}
-	return e
 }

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -76,7 +76,7 @@ type Options struct {
 	// timestamps worth of data to store in cache for each query
 	TimeseriesRetentionFactor int `yaml:"timeseries_retention_factor,omitempty"`
 	// TimeseriesEvictionMethodName specifies which methodology ("oldest", "lru") is used to identify
-	//timeseries to evict from a full cache object
+	// timeseries to evict from a full cache object
 	TimeseriesEvictionMethodName string `yaml:"timeseries_eviction_method,omitempty"`
 	// BackfillToleranceMS prevents values with timestamps newer than the provided number of
 	// milliseconds from being cached. this allows propagation of upstream backfill operations

--- a/pkg/backends/prometheus/model/alerts.go
+++ b/pkg/backends/prometheus/model/alerts.go
@@ -148,7 +148,6 @@ func MergeAndWriteAlerts(w http.ResponseWriter, r *http.Request, rgs merge.Respo
 		}
 	}
 
-	statusCode := 0
 	if a == nil || len(responses) == 0 {
 		if bestResp != nil {
 			h := w.Header()
@@ -163,23 +162,23 @@ func MergeAndWriteAlerts(w http.ResponseWriter, r *http.Request, rgs merge.Respo
 	}
 
 	sort.Ints(responses)
-	statusCode = responses[0]
+	statusCode := responses[0]
 	a.StartMarshal(w, statusCode)
 
 	var sep string
 	w.Write([]byte(`,"data":{"alerts":[`))
 	if a.Data != nil && len(a.Data.Alerts) > 0 {
 		for _, alert := range a.Data.Alerts {
-			w.Write([]byte(
-				fmt.Sprintf(`{"state":"%s","labels":%s,"annotations":%s`,
-					alert.State, dataset.Tags(alert.Labels).JSON(),
-					dataset.Tags(alert.Annotations).JSON()),
-			))
+			fmt.Fprintf(w,
+				`{"state":"%s","labels":%s,"annotations":%s`,
+				alert.State, dataset.Tags(alert.Labels).JSON(),
+				dataset.Tags(alert.Annotations).JSON(),
+			)
 			if alert.Value != "" {
-				w.Write([]byte(fmt.Sprintf(`,"value":"%s"`, alert.Value)))
+				fmt.Fprintf(w, `,"value":"%s"`, alert.Value)
 			}
 			if alert.ActiveAt != "" {
-				w.Write([]byte(fmt.Sprintf(`,"activeAt":"%s"`, alert.ActiveAt)))
+				fmt.Fprintf(w, `,"activeAt":"%s"`, alert.ActiveAt)
 			}
 			w.Write([]byte("}" + sep))
 			sep = ","

--- a/pkg/backends/prometheus/model/labels.go
+++ b/pkg/backends/prometheus/model/labels.go
@@ -96,7 +96,6 @@ func MergeAndWriteLabelData(w http.ResponseWriter, r *http.Request, rgs merge.Re
 		}
 	}
 
-	statusCode := 0
 	if ld == nil || len(responses) == 0 {
 		if bestResp != nil {
 			h := w.Header()
@@ -111,12 +110,12 @@ func MergeAndWriteLabelData(w http.ResponseWriter, r *http.Request, rgs merge.Re
 	}
 
 	sort.Ints(responses)
-	statusCode = responses[0]
+	statusCode := responses[0]
 	ld.StartMarshal(w, statusCode)
 
 	if len(ld.Data) > 0 {
 		sort.Strings(ld.Data)
-		w.Write([]byte(fmt.Sprintf(`,"data":["%s"]`, strings.Join(ld.Data, `","`))))
+		fmt.Fprintf(w, `,"data":["%s"]`, strings.Join(ld.Data, `","`))
 	}
 	w.Write([]byte("}"))
 }

--- a/pkg/backends/prometheus/model/model.go
+++ b/pkg/backends/prometheus/model/model.go
@@ -48,19 +48,18 @@ func (e *Envelope) StartMarshal(w io.Writer, httpStatus int) {
 		h.Set(headers.NameContentType, headers.ValueApplicationJSON+"; charset=UTF-8")
 		rw.WriteHeader(httpStatus)
 	}
-	w.Write([]byte(fmt.Sprintf(`{"status":"%s"`, e.Status)))
+	fmt.Fprintf(w, `{"status":"%s"`, e.Status)
 
 	if e.Error != "" {
-		w.Write([]byte(fmt.Sprintf(`,"error":"%s"`, e.Error)))
+		fmt.Fprintf(w, `,"error":"%s"`, e.Error)
 	}
 
 	if e.ErrorType != "" {
-		w.Write([]byte(fmt.Sprintf(`,"errorType":"%s"`, e.ErrorType)))
+		fmt.Fprintf(w, `,"errorType":"%s"`, e.ErrorType)
 	}
 
 	if len(e.Warnings) > 0 {
-		w.Write([]byte(fmt.Sprintf(`,"warnings":["%s"]`, strings.Join(e.Warnings, `","`))))
-
+		fmt.Fprintf(w, `,"warnings":["%s"]`, strings.Join(e.Warnings, `","`))
 	}
 }
 

--- a/pkg/backends/prometheus/model/series.go
+++ b/pkg/backends/prometheus/model/series.go
@@ -104,7 +104,6 @@ func MergeAndWriteSeries(w http.ResponseWriter, r *http.Request, rgs merge.Respo
 		}
 	}
 
-	statusCode := 0
 	if s == nil || len(responses) == 0 {
 		if bestResp != nil {
 			h := w.Header()
@@ -119,15 +118,15 @@ func MergeAndWriteSeries(w http.ResponseWriter, r *http.Request, rgs merge.Respo
 	}
 
 	sort.Ints(responses)
-	statusCode = responses[0]
+	statusCode := responses[0]
 	s.StartMarshal(w, statusCode)
 
 	var sep string
 	if len(s.Data) > 0 {
 		w.Write([]byte(`,"data":[`))
 		for _, series := range s.Data {
-			w.Write([]byte(fmt.Sprintf(`%s{"__name__":"%s","instance":"%s","job":"%s"}`,
-				sep, series.Name, series.Instance, series.Job)))
+			fmt.Fprintf(w, `%s{"__name__":"%s","instance":"%s","job":"%s"}`,
+				sep, series.Name, series.Instance, series.Job)
 			sep = ","
 		}
 		w.Write([]byte("]"))

--- a/pkg/backends/prometheus/model/timeseries.go
+++ b/pkg/backends/prometheus/model/timeseries.go
@@ -204,7 +204,7 @@ func MarshalTSOrVectorWriter(ts timeseries.Timeseries, rlo *timeseries.RequestOp
 		resultType = "vector"
 	}
 
-	w.Write([]byte(fmt.Sprintf(`,"data":{"resultType":"%s","result":[`, resultType)))
+	fmt.Fprintf(w, `,"data":{"resultType":"%s","result":[`, resultType)
 
 	seriesSep := ""
 	for _, s := range ds.Results[0].SeriesList {
@@ -214,16 +214,16 @@ func MarshalTSOrVectorWriter(ts timeseries.Timeseries, rlo *timeseries.RequestOp
 		w.Write([]byte(seriesSep + `{"metric":{`))
 		sep := ""
 		for _, k := range s.Header.Tags.Keys() {
-			w.Write([]byte(fmt.Sprintf(`%s"%s":"%s"`, sep, k, s.Header.Tags[k])))
+			fmt.Fprintf(w, `%s"%s":"%s"`, sep, k, s.Header.Tags[k])
 			sep = ","
 		}
 		if isVector {
 			w.Write([]byte(`},"value":[`))
 			if len(s.Points) > 0 {
-				w.Write([]byte(fmt.Sprintf(`%s,"%s"`,
+				fmt.Fprintf(w, `%s,"%s"`,
 					strconv.FormatFloat(float64(s.Points[0].Epoch)/1000000000, 'f', -1, 64),
-					s.Points[0].Values[0]),
-				))
+					s.Points[0].Values[0],
+				)
 			}
 			w.Write([]byte("]}"))
 		} else {
@@ -231,11 +231,11 @@ func MarshalTSOrVectorWriter(ts timeseries.Timeseries, rlo *timeseries.RequestOp
 			sep = ""
 			sort.Sort(s.Points)
 			for _, p := range s.Points {
-				w.Write([]byte(fmt.Sprintf(`%s[%s,"%s"]`,
+				fmt.Fprintf(w, `%s[%s,"%s"]`,
 					sep,
 					strconv.FormatFloat(float64(p.Epoch)/1000000000, 'f', -1, 64),
-					p.Values[0]),
-				))
+					p.Values[0],
+				)
 				sep = ","
 			}
 			w.Write([]byte("]}"))

--- a/pkg/backends/rule/operations.go
+++ b/pkg/backends/rule/operations.go
@@ -21,9 +21,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/trickstercache/trickster/v2/pkg/encoding/base64"
 	"github.com/trickstercache/trickster/v2/pkg/checksum/md5"
 	"github.com/trickstercache/trickster/v2/pkg/checksum/sha1"
+	"github.com/trickstercache/trickster/v2/pkg/encoding/base64"
 )
 
 type operation string

--- a/pkg/backends/rule/rule.go
+++ b/pkg/backends/rule/rule.go
@@ -78,7 +78,7 @@ func (r *rule) EvaluateOpArg(hr *http.Request) (http.Handler, *http.Request, err
 		r.ingressReqRewriter.Execute(hr)
 	}
 
-	var h http.Handler = r.defaultRouter
+	h := r.defaultRouter
 	res := r.operationFunc(r.extractionFunc(hr, r.extractionArg),
 		r.operationArg, r.negateOpResult)
 	var nonDefault bool
@@ -134,7 +134,7 @@ func (r *rule) EvaluateCaseArg(hr *http.Request) (http.Handler, *http.Request, e
 		r.ingressReqRewriter.Execute(hr)
 	}
 
-	var h http.Handler = r.defaultRouter
+	h := r.defaultRouter
 	var nonDefault bool
 
 	for _, c := range r.caseList {

--- a/pkg/cache/options/defaults/defaults_unix.go
+++ b/pkg/cache/options/defaults/defaults_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/cache/options/defaults/defaults_windows.go
+++ b/pkg/cache/options/defaults/defaults_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/pkg/config/defaults_unix.go
+++ b/pkg/config/defaults_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/pkg/config/defaults_windows.go
+++ b/pkg/config/defaults_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 /*

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -95,7 +95,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 
 	applyLoggingConfig(newConf, si.Config)
 
-	//Register Tracing Configurations
+	// Register Tracing Configurations
 	tracers, err := tr.RegisterAll(newConf, false)
 	if err != nil {
 		handleStartupIssue("tracing registration failed",
@@ -142,8 +142,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	alb.StartALBPools(backends, si.HealthChecker.Statuses())
 	routing.RegisterDefaultBackendRoutes(r, backends, tracers)
 	routing.RegisterHealthHandler(mr, newConf.Main.HealthHandlerPath, si.HealthChecker)
-	applyListenerConfigs(newConf, si.Config, r, http.HandlerFunc(rh), mr,
-		tracers, backends, errorFunc)
+	applyListenerConfigs(newConf, si.Config, r, rh, mr, tracers, backends, errorFunc)
 
 	metrics.LastReloadSuccessfulTimestamp.Set(float64(time.Now().Unix()))
 	metrics.LastReloadSuccessful.Set(1)
@@ -222,7 +221,8 @@ func applyCachingConfig(si *instance.ServerInstance,
 			// is the only change. In this case, we'll apply the new index configuration,
 			// then add the old cache with the new index config to the new cache map
 			if ocfg.ProviderID == v.ProviderID &&
-				ocfg.ProviderID == providers.Memory {
+				v.ProviderID == providers.Memory {
+				// Note: this is only necessary for the memory cache as all other providers will be closed and reopened with the newest config
 				if v.Index != nil {
 					mc := w.(*memory.Cache)
 					mc.Index.UpdateOptions(v.Index)

--- a/pkg/encoding/handler/writer_test.go
+++ b/pkg/encoding/handler/writer_test.go
@@ -17,6 +17,7 @@
 package handler
 
 import (
+	"net/http"
 	"net/http/httptest"
 	"testing"
 
@@ -40,7 +41,7 @@ func TestWrite(t *testing.T) {
 	ew := &responseEncoder{ResponseWriter: w}
 	ew.writeFunc = ew.writeDirect
 
-	ew.WriteHeader(200)
+	ew.WriteHeader(http.StatusOK)
 	ew.prepared = false
 
 	i, err := ew.Write([]byte("trickster"))

--- a/pkg/parsing/lex/run_state.go
+++ b/pkg/parsing/lex/run_state.go
@@ -38,7 +38,7 @@ type RunState struct {
 
 // Next returns the next rune in the input.
 func (rs *RunState) Next() rune {
-	if int(rs.Pos) >= rs.InputWidth {
+	if rs.Pos >= rs.InputWidth {
 		rs.Width = 0
 		return EOF
 	}

--- a/pkg/parsing/parsing.go
+++ b/pkg/parsing/parsing.go
@@ -84,7 +84,7 @@ var ErrNoLexer = errors.New("no lexer provided")
 // ErrUnsupportedParser means the passed parser does not support the function being called
 var ErrUnsupportedParser = errors.New("this state function is not supported by this parser")
 
-//ErrUnexpectedToken is returned when the next token provided to the parser does not have a
+// ErrUnexpectedToken is returned when the next token provided to the parser does not have a
 // value in the current DecisionSet
 var ErrUnexpectedToken = errors.New("unexpected token")
 

--- a/pkg/parsing/run_state.go
+++ b/pkg/parsing/run_state.go
@@ -101,7 +101,7 @@ func (rs *RunState) GetReturnFunc(f StateFn, ds DecisionSet, exitOnEOF bool) Sta
 	} else if ds != nil && rs.curr != nil {
 		if f1, ok := ds[rs.curr.Typ]; ok {
 			if rs.lastkw != nil && rs.curr.Typ > token.CustomKeyword &&
-				!(rs.curr.Typ > rs.lastkw.Typ) {
+				rs.curr.Typ <= rs.lastkw.Typ {
 				rs.WithError(ErrInvalidKeywordOrder)
 				return nil
 			}

--- a/pkg/proxy/engines/caching_policy.go
+++ b/pkg/proxy/engines/caching_policy.go
@@ -131,7 +131,7 @@ func (cp *CachingPolicy) Merge(src *CachingPolicy) {
 
 // TTL returns a TTL based on the subject caching policy and the provided multiplier and max values
 func (cp *CachingPolicy) TTL(multiplier float64, max time.Duration) time.Duration {
-	var ttl time.Duration = time.Duration(cp.FreshnessLifetime) * time.Second
+	ttl := time.Duration(cp.FreshnessLifetime) * time.Second
 	if cp.CanRevalidate {
 		ttl *= time.Duration(multiplier)
 	}
@@ -272,7 +272,7 @@ var supportedCCD = map[string]bool{
 }
 
 func (cp *CachingPolicy) parseCacheControlDirectives(directives string) {
-	dl := strings.Split(strings.Replace(strings.ToLower(directives), " ", "", -1), ",")
+	dl := strings.Split(strings.ReplaceAll(strings.ToLower(directives), " ", ""), ",")
 	var noCache bool
 	var hasSharedMaxAge bool
 	var foundFreshnessDirective bool

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -457,7 +457,7 @@ checkCache:
 		rts.Merge(false, ffts)
 	}
 	rts.SetExtents(nil) // so they are not included in the client response json
-	//rts.SetTimeRangeQuery(&timeseries.TimeRangeQuery{})
+	// rts.SetTimeRangeQuery(&timeseries.TimeRangeQuery{})
 	rh := doc.SafeHeaderClone()
 	sc := doc.StatusCode
 
@@ -628,7 +628,7 @@ func fetchExtents(el timeseries.ExtentList, rsc *request.Resources, h http.Heade
 				headers.Merge(h, resp.Header)
 				mts = append(mts, nts)
 				appendLock.Unlock()
-			} else if resp.StatusCode != 200 {
+			} else if resp.StatusCode != http.StatusOK {
 				err = tpe.ErrUnexpectedUpstreamResponse
 				var b []byte
 				var s string

--- a/pkg/proxy/engines/document.go
+++ b/pkg/proxy/engines/document.go
@@ -123,7 +123,7 @@ func (d *HTTPDocument) GetByterangeChunk(chunkRange byterange.Range, chunkSize i
 			dd.Ranges[ddri] = r
 			ddri++
 		}
-		ddbi = ddbi - chunkRange.Start
+		ddbi -= chunkRange.Start
 		dd.Body = dd.Body[:ddbi]
 		dd.Ranges = dd.Ranges[:ddri]
 		sort.Sort(dd.Ranges)

--- a/pkg/proxy/engines/httpproxy_test.go
+++ b/pkg/proxy/engines/httpproxy_test.go
@@ -131,7 +131,7 @@ func TestProxyRequestBadGateway(t *testing.T) {
 func TestClockOffsetWarning(t *testing.T) {
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add(headers.NameDate, time.Now().Add(-1*time.Hour).Format(http.TimeFormat))
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 	}
 	s := httptest.NewServer(http.HandlerFunc(handler))
 

--- a/pkg/proxy/engines/progressive_collapse_forwarder.go
+++ b/pkg/proxy/engines/progressive_collapse_forwarder.go
@@ -100,10 +100,8 @@ func (pcf *progressiveCollapseForwarder) AddClient(w io.Writer) error {
 	pcf.clientCond.L.Unlock()
 	var readIndex uint64
 	var err error
-	remaining := 0
-	n := 0
+	var n, remaining int
 	buf := make([]byte, HTTPBlockSize)
-
 	for {
 		n, err = pcf.IndexRead(readIndex, buf)
 		if n > 0 {

--- a/pkg/proxy/handlers/health/health.go
+++ b/pkg/proxy/handlers/health/health.go
@@ -66,7 +66,7 @@ func StatusHandler(hc healthcheck.HealthChecker) http.Handler {
 		}
 		hd.mtx.RUnlock()
 		w.Header().Set(headers.NameContentType, ct)
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(body))
 	})
 }
@@ -138,7 +138,7 @@ func udpateStatusText(hc healthcheck.HealthChecker, hd *healthDetail) {
 				json.WriteString(",")
 			}
 			d := cleanupDescription(st[k].Description())
-			tw.Write([]byte(fmt.Sprintf("%s\t%s\t%s\n", k, d, statusToString(1))))
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", k, d, statusToString(1))
 			json.WriteString(fmt.Sprintf(`{"name":"%s","provider":"%s"}`, k, d))
 		}
 		json.WriteString(`]`)
@@ -155,9 +155,9 @@ func udpateStatusText(hc healthcheck.HealthChecker, hd *healthDetail) {
 			v := st[k]
 			d := cleanupDescription(st[k].Description())
 			fs := v.FailingSince().Truncate(time.Second).UTC().String()[:20] + "UTC"
-			tw.Write([]byte(fmt.Sprintf("%s\t%s\t%s %s\n", k, d, statusToString(-1), fs)))
+			fmt.Fprintf(tw, "%s\t%s\t%s %s\n", k, d, statusToString(-1), fs)
 			json.WriteString(fmt.Sprintf(`{"name":"%s","provider":"%s","downSince":"%s","detail":"%s"}`,
-				k, d, fs, strings.Replace(v.Detail(), `"`, `'`, -1)))
+				k, d, fs, strings.ReplaceAll(v.Detail(), `"`, `'`)))
 		}
 		json.WriteString(`]`)
 		tw.Write([]byte("\t\t\t\n"))
@@ -171,7 +171,7 @@ func udpateStatusText(hc healthcheck.HealthChecker, hd *healthDetail) {
 				json.WriteString(",")
 			}
 			d := cleanupDescription(st[k].Description())
-			tw.Write([]byte(fmt.Sprintf("%s\t%s\t%s\n", k, d, statusToString(0))))
+			fmt.Fprintf(tw, "%s\t%s\t%s\n", k, d, statusToString(0))
 			json.WriteString(fmt.Sprintf(`{"name":"%s","provider":"%s"}`, k, d))
 		}
 		json.WriteString(`]`)
@@ -200,5 +200,5 @@ func statusToString(i int) string {
 }
 
 func cleanupDescription(in string) string {
-	return strings.Replace(in, "reverseproxycache", "rpc", -1)
+	return strings.ReplaceAll(in, "reverseproxycache", "rpc")
 }

--- a/pkg/proxy/headers/forwarding.go
+++ b/pkg/proxy/headers/forwarding.go
@@ -247,7 +247,7 @@ func HopsFromHeader(h http.Header) Hops {
 func parseForwardHeaders(h http.Header) Hops {
 	fh := h.Get(NameForwarded)
 	if fh != "" {
-		fwds := strings.Split(strings.Replace(fh, " ", "", -1), ",")
+		fwds := strings.Split(strings.ReplaceAll(fh, " ", ""), ",")
 		var k int
 		hops := make(Hops, len(fwds))
 		for _, f := range fwds {
@@ -306,7 +306,7 @@ func formatForwardedAddress(input string) string {
 func parseXForwardHeaders(h http.Header) Hops {
 	xff := h.Get(NameXForwardedFor)
 	if xff != "" {
-		fwds := strings.Split(strings.Replace(xff, " ", "", -1), ",")
+		fwds := strings.Split(strings.ReplaceAll(xff, " ", ""), ",")
 		hops := make(Hops, len(fwds))
 		for i, f := range fwds {
 			hop := &Hop{RemoteAddr: f}

--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -208,7 +208,10 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 			logger.ErrorSynchronous(
 				"https listener stopping", logging.Pairs{"listenerName": listenerName, "detail": err})
 			if l.exitOnError {
-				os.Exit(1)
+				defer func() {
+					os.Exit(1) // exit via defer to allow prior defers to run
+				}()
+				return nil
 			}
 		}
 		return err
@@ -223,7 +226,9 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 		logger.ErrorSynchronous("http listener stopping",
 			logging.Pairs{"listenerName": listenerName, "detail": err})
 		if l.exitOnError {
-			os.Exit(1)
+			defer func() {
+				os.Exit(1) // exit via defer to allow prior defers to run
+			}()
 		}
 	}
 	return err

--- a/pkg/proxy/listener/listener_test.go
+++ b/pkg/proxy/listener/listener_test.go
@@ -178,7 +178,7 @@ func TestNewListenerTLS(t *testing.T) {
 func TestListenerConnectionLimitWorks(t *testing.T) {
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
 	handler := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		fmt.Fprint(w, "hello!")
 	}
 	es := httptest.NewServer(http.HandlerFunc(handler))

--- a/pkg/proxy/ranges/byterange/range.go
+++ b/pkg/proxy/ranges/byterange/range.go
@@ -292,7 +292,7 @@ func ParseRangeHeader(input string) Ranges {
 		input == byteRequestRangePrefix {
 		return nil
 	}
-	input = strings.Replace(input, " ", "", -1)[6:]
+	input = strings.ReplaceAll(input, " ", "")[6:]
 	parts := strings.Split(input, ",")
 	ranges := make(Ranges, len(parts))
 

--- a/pkg/router/lm/lm.go
+++ b/pkg/router/lm/lm.go
@@ -192,7 +192,7 @@ func (rt *lmRouter) matchByHost(method, host, path string) http.Handler {
 			}
 			return r.Handler
 		}
-		if !(rt.matchScheme&router.MatchPathPrefix == router.MatchPathPrefix) {
+		if rt.matchScheme&router.MatchPathPrefix != router.MatchPathPrefix {
 			return nil
 		}
 		lp := len(path)
@@ -221,7 +221,7 @@ func MethodNotAllowed(w http.ResponseWriter, r *http.Request) {
 }
 
 var methodNotAllowedHandler = http.HandlerFunc(MethodNotAllowed)
-var notFoundHandler = http.HandlerFunc(http.NotFound)
+var notFoundHandler = http.NotFoundHandler()
 
 // prefixRouteSets allows the route.PrefixRouteSets to be sorted by path from
 // longest-to-shortest using sort.Interface

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -198,14 +198,14 @@ func registerBackendRoutes(r router.Router, metricsRouter router.Router,
 		// now we'll go ahead and register the health handler
 		if h, ok := client.Handlers()["health"]; ok && o.Name != "" && metricsRouter != nil && (o.HealthCheck == nil ||
 			o.HealthCheck.Verb != "x") {
-			hp := strings.Replace(conf.Main.HealthHandlerPath+"/"+o.Name, "//", "/", -1)
+			hp := strings.ReplaceAll(conf.Main.HealthHandlerPath+"/"+o.Name, "//", "/")
 			logger.Debug("registering health handler path",
 				logging.Pairs{"path": hp, "backendName": o.Name,
 					"upstreamPath": o.HealthCheck.Path,
 					"upstreamVerb": o.HealthCheck.Verb})
 			metricsRouter.RegisterRoute(hp, nil, nil, false,
-				http.Handler(middleware.WithResourcesContext(client, o, nil,
-					nil, nil, h)))
+				middleware.WithResourcesContext(client, o, nil,
+					nil, nil, h))
 		}
 	}
 	return nil

--- a/pkg/testutil/healthcheck/healthcheck.go
+++ b/pkg/testutil/healthcheck/healthcheck.go
@@ -19,6 +19,6 @@ package healthcheck
 import "net/http"
 
 func DemandProbe(w http.ResponseWriter) {
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("{}"))
 }

--- a/pkg/testutil/testing.go
+++ b/pkg/testutil/testing.go
@@ -46,8 +46,16 @@ import (
 	"github.com/trickstercache/mockster/pkg/testutil"
 )
 
-// Epoch2020 is the epoch value representing 1 January 2020 00:00:00 UTC
-const Epoch2020 int64 = 1577836800
+const (
+	// Epoch2020 is the epoch value representing 1 January 2020 00:00:00 UTC
+	Epoch2020 int64 = 1577836800
+
+	// Provider Names
+	PrometheusBackendProvider = "prometheus"
+	PromSimBackendProvider    = "promsim"
+	RangeSimBackendProvider   = "rangesim"
+	RPCBackendProvider        = "rpc"
+)
 
 // Time2020 is the Time.Time representing 1 January 2020 00:00:00 UTC
 var Time2020 = time.Unix(Epoch2020, 0)
@@ -98,13 +106,14 @@ func NewTestInstance(
 	isBasicTestServer := false
 
 	var ts *httptest.Server
-	if backendProvider == "promsim" {
+	switch backendProvider {
+	case PromSimBackendProvider:
 		ts = testutil.NewTestServer()
-		backendProvider = "prometheus"
-	} else if backendProvider == "rangesim" {
+		backendProvider = PrometheusBackendProvider
+	case RangeSimBackendProvider:
 		ts = testutil.NewTestServer()
-		backendProvider = "rpc"
-	} else {
+		backendProvider = RPCBackendProvider
+	default:
 		isBasicTestServer = true
 		ts = NewTestServer(respCode, respBody, respHeaders)
 	}
@@ -131,7 +140,7 @@ func NewTestInstance(
 	}
 
 	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", ts.URL+urlPath, nil)
+	r := httptest.NewRequest(http.MethodGet, ts.URL+urlPath, nil)
 
 	o := conf.Backends["default"]
 	p := NewTestPathConfig(o, defaultPathConfigs, urlPath)
@@ -203,7 +212,7 @@ func BasicHTTPHandler(w http.ResponseWriter, r *http.Request) {
 	h.Set("Test-Header", "Trickster")
 	h.Set(th.NameLastModified, "Wed, 01 Jan 2020 00:00:00 UTC")
 	h.Set(th.NameTricksterResult, "engine=none")
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("{}"))
 }
 

--- a/pkg/testutil/timeseries/model/model.go
+++ b/pkg/testutil/timeseries/model/model.go
@@ -172,18 +172,18 @@ func MarshalTimeseriesWriter(ts timeseries.Timeseries, rlo *timeseries.RequestOp
 		w.Write([]byte(seriesSep + `{"metric":{`))
 		sep := ""
 		for _, k := range s.Header.Tags.Keys() {
-			w.Write([]byte(fmt.Sprintf(`%s"%s":"%s"`, sep, k, s.Header.Tags[k])))
+			fmt.Fprintf(w, `%s"%s":"%s"`, sep, k, s.Header.Tags[k])
 			sep = ","
 		}
 		w.Write([]byte(`},"values":[`))
 		sep = ""
 		sort.Sort(s.Points)
 		for _, p := range s.Points {
-			w.Write([]byte(fmt.Sprintf(`%s[%s,"%s"]`,
+			fmt.Fprintf(w, `%s[%s,"%s"]`,
 				sep,
 				strconv.FormatFloat(float64(p.Epoch)/1000000000, 'f', -1, 64),
-				p.Values[0]),
-			))
+				p.Values[0],
+			)
 			sep = ","
 		}
 		w.Write([]byte("]}"))

--- a/pkg/timeseries/dataset/dataset.go
+++ b/pkg/timeseries/dataset/dataset.go
@@ -496,7 +496,7 @@ func (ds *DataSet) Size() int64 {
 		(len(ds.ExtentList) * 72) +
 		len(ds.Error))
 	for i := range ds.Results {
-		c += int64(ds.Results[i].Size())
+		c += ds.Results[i].Size()
 	}
 	return c
 }

--- a/pkg/timeseries/dataset/series.go
+++ b/pkg/timeseries/dataset/series.go
@@ -50,7 +50,7 @@ type SeriesLookupKey struct {
 
 // Size returns the memory utilization of the Series in bytes
 func (s Series) Size() int64 {
-	return int64(16 + s.PointSize + int64(s.Header.Size))
+	return 16 + s.PointSize + int64(s.Header.Size)
 }
 
 // Clone returns a perfect, new copy of the Series

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -182,7 +182,7 @@ func (el ExtentList) spliceByTimeAligned(step, maxRange, spliceStep time.Duratio
 		// if the size of the extent is smaller than the max splice size, and
 		// the extent doesn't cross spliceSteps, pass through and continue
 		if e.End.Sub(e.Start) <= maxRange &&
-			e.End.Truncate(spliceStep) == e.Start.Truncate(spliceStep) {
+			e.End.Truncate(spliceStep).Equal(e.Start.Truncate(spliceStep)) {
 			out = append(out, e)
 			continue
 		}
@@ -209,7 +209,7 @@ func (el ExtentList) spliceByTimeAligned(step, maxRange, spliceStep time.Duratio
 		//
 		// this re-checks if e is shallower than maxRange, since it might've just been reduced
 		if e.End.Sub(e.Start) <= maxRange &&
-			e.End.Truncate(spliceStep) == e.Start.Truncate(spliceStep) {
+			e.End.Truncate(spliceStep).Equal(e.Start.Truncate(spliceStep)) {
 			out = append(out, e)
 			continue
 		}

--- a/pkg/timeseries/sqlparser/sqlparser.go
+++ b/pkg/timeseries/sqlparser/sqlparser.go
@@ -108,6 +108,7 @@ func ParseEpoch(input string) (epoch.Epoch, byte, error) {
 			return million * epoch.Epoch(i), 1, nil
 		}
 	}
+
 	if (li == 10 || li == 19) && (input[4] == '-' && input[7] == '-') {
 		var typ byte = 3
 		year, err := strconv.Atoi(input[0:4])
@@ -122,23 +123,23 @@ func ParseEpoch(input string) (epoch.Epoch, byte, error) {
 		if err != nil {
 			return 0, 0, err
 		}
-		var hour, min, sec int
+		var hour, minute, second int
 		if (li == 19) && (input[13] == ':' && input[16] == ':') {
 			typ = 2
 			hour, err = strconv.Atoi(input[11:13])
 			if err != nil {
 				return 0, 0, err
 			}
-			min, err = strconv.Atoi(input[14:16])
+			minute, err = strconv.Atoi(input[14:16])
 			if err != nil {
 				return 0, 0, err
 			}
-			sec, err = strconv.Atoi(input[17:19])
+			second, err = strconv.Atoi(input[17:19])
 			if err != nil {
 				return 0, 0, err
 			}
 		}
-		t := time.Date(year, time.Month(month), day, hour, min, sec, 0, time.UTC)
+		t := time.Date(year, time.Month(month), day, hour, minute, second, 0, time.UTC)
 		return epoch.Epoch(t.UnixNano()), typ, nil
 	}
 	return ts, 0, timeseries.ErrInvalidTimeFormat

--- a/pkg/timeseries/timerangequery.go
+++ b/pkg/timeseries/timerangequery.go
@@ -99,7 +99,7 @@ func (trq *TimeRangeQuery) NormalizeExtent() {
 
 func (trq *TimeRangeQuery) String() string {
 	return fmt.Sprintf(`{ "statement": "%s", "step": "%s", "extent": "%s", "tsd": "%s", "td": %s, "vd": %s }`,
-		strings.Replace(trq.Statement, `"`, `\"`, -1), trq.Step.String(),
+		strings.ReplaceAll(trq.Statement, `"`, `\"`), trq.Step.String(),
 		trq.Extent.String(), trq.TimestampDefinition.String(),
 		FieldDefinitions(trq.TagFieldDefintions).String(), FieldDefinitions(trq.ValueFieldDefinitions))
 }

--- a/pkg/util/strings/strings.go
+++ b/pkg/util/strings/strings.go
@@ -55,7 +55,7 @@ func (m StringMap) String() string {
 	sb := &strings.Builder{}
 	sb.WriteString("{")
 	for k, v := range m {
-		sb.WriteString(fmt.Sprintf(`%s"%s":"%s"`, delimiter, k, v))
+		fmt.Fprintf(sb, `%s"%s":"%s"`, delimiter, k, v)
 		delimiter = ", "
 	}
 	sb.WriteString("}")

--- a/pkg/util/timeconv/timeconv.go
+++ b/pkg/util/timeconv/timeconv.go
@@ -143,8 +143,8 @@ func ParseDuration(s string) (time.Duration, error) {
 	if len(s) <= 1 {
 		return 0, ErrInvalidDurationFormat(0, "value of at least length 2", s)
 	}
-	var d time.Duration = 0
-	var currentMult int64 = 0
+	var d time.Duration
+	var currentMult int64
 	for i := 0; i < len(s); {
 		if currentMult == 0 {
 			v, is, inc := isIntAtPos(s, i)


### PR DESCRIPTION
This PR addresses a number of warnings found by upgrading golangci-lint to v2 and turning on more linters.

I'm still working through a few errors, but will save those and the golangci-lint updates for another PR.

---

Summary of changes:

- various logic simplifications
- usage of strings.ReplaceAll
- reduced assignments where possible
- use `fmt.Fprintf` vs `w.Write([]byte(fmt.Sprintf(...`
- use more (stdlib and custom) constants