### PR TITLE
chore: use strings.Replacer

### DIFF
--- a/pkg/backends/clickhouse/url.go
+++ b/pkg/backends/clickhouse/url.go
@@ -68,8 +68,10 @@ func interpolateTimeQuery(template string, tsFieldName string, timeFormat int, e
 	}
 
 	rangeCondition := fmt.Sprintf("%s BETWEEN %d AND %d", tsFieldName, start, end)
-	x := strings.Replace(strings.Replace(strings.Replace(strings.Replace(template,
-		tkRange, rangeCondition, -1), tkTS1, strconv.FormatInt(start, 10), -1), tkTS2,
-		strconv.FormatInt(end, 10), -1), "<$FORMAT$>", "TSVWithNamesAndTypes", -1)
-	return x
+	return strings.NewReplacer(
+		tkRange, rangeCondition,
+		tkTS1, strconv.FormatInt(start, 10),
+		tkTS2, strconv.FormatInt(end, 10),
+		tkFormat, "TSVWithNamesAndTypes",
+	).Replace(template)
 }

--- a/pkg/proxy/headers/result_header.go
+++ b/pkg/proxy/headers/result_header.go
@@ -121,7 +121,7 @@ func parseResultHeaderVals(h string) ResultHeaderParts {
 					r.FastForwardStatus = val
 				}
 			case "fetched":
-				val = strings.ReplaceAll(strings.ReplaceAll(val, "[", ""), "]", "")
+				val = strings.NewReplacer("[", "", "]", "").Replace(val)
 				fparts := strings.Split(val, ";")
 				el := make(timeseries.ExtentList, len(fparts))
 				var k int


### PR DESCRIPTION
Minor improvement -- use a `strings.Replacer` instead of multiple `strings.Replace/ReplaceAll` calls.