### PR TITLE
improve extent list performance

### DIFF
--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -301,21 +301,11 @@ func (el ExtentList) Clone() ExtentList {
 // CloneRange returns a perfect copy of the ExtentList, cloning only the
 // Extents in the provided index range (upper-bound exclusive)
 func (el ExtentList) CloneRange(start, end int) ExtentList {
-	if end < start || start < 0 || end < 0 {
-		return nil
+	if end < start || start < 0 || end > len(el) {
+		return ExtentList{}
 	}
-	size := end - start
-	if size > len(el) {
-		return nil
-	}
-	c := make(ExtentList, size)
-	j := start
-	for i := 0; i < size; i++ {
-		c[i].Start = el[j].Start
-		c[i].End = el[j].End
-		c[i].LastUsed = el[j].LastUsed
-		j++
-	}
+	c := make(ExtentList, end-start)
+	copy(c, el[start:end])
 	return c
 }
 

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -384,7 +384,7 @@ func (el ExtentList) CalculateDeltas(need Extent, step time.Duration) ExtentList
 	var missStart time.Time
 	var j, k int
 	for ts := need.Start; !ts.After(need.End); ts = ts.Add(step) {
-		// this advances to j to the point in el where ts would be if it were
+		// this advances j to the point in el where ts would be if it were
 		// present in el (whether it currently is or not)
 		for j < len(el) && ts.After(el[j].End) {
 			j++

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -450,20 +450,21 @@ func (el ExtentList) TimestampCount(d time.Duration) int64 {
 	return c
 }
 
-// CalculateDeltas provides a list of extents that are not in a cached timeseries,
-// when provided a list of extents that are cached.
-func (el ExtentList) CalculateDeltas(want Extent, step time.Duration) ExtentList {
-	if step <= 0 || !want.End.After(want.Start) {
+// CalculateDeltas provides a list of extents that are not in el based on the
+// needed extent. step is used to determine which absolute timestamps in need
+// will be checked in el.
+func (el ExtentList) CalculateDeltas(need Extent, step time.Duration) ExtentList {
+	if step <= 0 || !need.End.After(need.Start) {
 		return nil
 	}
 	if len(el) == 0 {
-		return ExtentList{want}
+		return ExtentList{need}
 	}
 	sort.Sort(el)
 	out := make(ExtentList, len(el)+1)
 	stepNS := step.Nanoseconds()
-	startNS := want.Start.UnixNano()
-	endNS := want.End.UnixNano()
+	startNS := need.Start.UnixNano()
+	endNS := need.End.UnixNano()
 	var missStart int64 = -1
 	var j, k int
 	for ts := startNS; ts <= endNS; ts += stepNS {

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -307,11 +307,8 @@ func (el ExtentList) Swap(i, j int) {
 // Clone returns a true copy of the ExtentList
 func (el ExtentList) Clone() ExtentList {
 	c := make(ExtentList, len(el))
-	for i := range el {
-		c[i].Start = el[i].Start
-		c[i].End = el[i].End
-		c[i].LastUsed = el[i].LastUsed
-	}
+	// this is safe because all fields in an Extent are by value
+	copy(c, el)
 	return c
 }
 

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -309,26 +309,6 @@ func (el ExtentList) CloneRange(start, end int) ExtentList {
 	return c
 }
 
-// Equal returns true if the provided extent list is identical to the subject list
-func (el ExtentList) Equal(el2 ExtentList) bool {
-	if el2 == nil {
-		return false
-	}
-
-	l := len(el)
-	l2 := len(el2)
-	if l != l2 {
-		return false
-	}
-
-	for i := range el {
-		if el2[i] != el[i] {
-			return false
-		}
-	}
-	return true
-}
-
 // Remove removes the provided extent list ranges from the subject extent list
 func (el ExtentList) Remove(r ExtentList, step time.Duration) ExtentList {
 	if len(r) == 0 {

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -121,10 +121,11 @@ func (el ExtentList) Compress(step time.Duration) ExtentList {
 		return exc
 	}
 	l := len(el)
-	compressed := make(ExtentList, 0, l)
 	sort.Sort(exc)
 	e := Extent{}
 	extr := Extent{}
+	compressed := make(ExtentList, l)
+	var k int
 	for i := range exc {
 		e.LastUsed = exc[i].LastUsed
 		if e.Start.IsZero() && !exc[i].Start.IsZero() {
@@ -145,10 +146,11 @@ func (el ExtentList) Compress(step time.Duration) ExtentList {
 		if e.End.After(extr.End) {
 			extr.End = e.End
 		}
-		compressed = append(compressed, e)
+		compressed[k] = e
+		k++
 		e = Extent{}
 	}
-	return compressed
+	return compressed[:k]
 }
 
 // Splice breaks apart extents in the list into smaller, contiguous extents, based on the provided
@@ -420,16 +422,19 @@ func (el ExtentList) Remove(r ExtentList, step time.Duration) ExtentList {
 
 	// otherwise, make a version of the does not include the splice out indexes
 	// and includes any splice-in indexes
-	r = make(ExtentList, 0, len(r)+len(spliceIns))
+	r = make(ExtentList, (len(c)*len(r))+len(splices)+len(spliceIns)+1)
+	var k int
 	for i, ex := range c {
 		if ex2, ok := spliceIns[i]; ok {
-			r = append(r, ex2)
+			r[k] = ex2
+			k++
 		}
 		if _, ok := splices[i]; !ok {
-			r = append(r, ex)
+			r[k] = ex
+			k++
 		}
 	}
-	return r
+	return r[:k]
 }
 
 // TimestampCount returns the calculated number of timestamps based on the extents

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -161,60 +161,53 @@ func (el ExtentList) spliceByTimeAligned(step, maxRange, spliceStep time.Duratio
 	if step == 0 || maxRange == 0 || spliceStep == 0 {
 		return el.Clone()
 	}
-	// reserve enough capacity that 50% of extents could be spliced without having to re-allocate
-	out := make(ExtentList, 0, len(el)+(len(el)/2))
+	out := make(ExtentList, len(el)*4)
+	var k int
 	for _, e := range el {
-		// if the size of the extent is smaller than the max splice size, and
-		// the extent doesn't cross spliceSteps, pass through and continue
-		if e.End.Sub(e.Start) <= maxRange &&
-			e.End.Truncate(spliceStep).Equal(e.Start.Truncate(spliceStep)) {
-			out = append(out, e)
+		origStart := e.Start
+		origEnd := e.End
+		if origEnd.Sub(origStart) <= maxRange &&
+			origEnd.Truncate(spliceStep).Equal(origStart.Truncate(spliceStep)) {
+			out[k] = e
+			k++
 			continue
 		}
-		// otherwise the extent must be spliced.
-		t1 := e.Start.Truncate(spliceStep)
-		// if t1 == e.Start, then the extent falls perfectly on the spliceStep. If it does not,
-		// e will be spliced on the first spliceStep interval after e.Start
-		//
-		// this handles the left-side splice, when required
-		if t1.Before(e.Start) {
+		t1 := origStart.Truncate(spliceStep)
+		if t1.Before(origStart) {
 			t1 = t1.Add(spliceStep)
-			// this calculates the splice and adds it to the output
 			t2 := t1.Truncate(step)
-			// This ensures that if spliceStep is not a multiple of step, then the left-side
-			// splice's end time retreats to the step just prior to the start of the next splice
 			if !t2.Before(t1) {
 				t2 = t2.Add(-step)
 			}
-			out = append(out, Extent{Start: e.Start, End: t2})
-			// this advances e.Start to the first timeseries step on or after the new left boundary
-			e.Start = t2.Add(step)
+			end := t2
+			if end.Before(origStart) {
+				end = origStart
+			}
+			out[k] = Extent{Start: origStart, End: end, LastUsed: e.LastUsed}
+			k++
+			origStart = end.Add(step)
 		}
-		// now that left-side splicing is done, this splices the rest of e on the epoch.
-		//
-		// this re-checks if e is shallower than maxRange, since it might've just been reduced
-		if e.End.Sub(e.Start) <= maxRange &&
-			e.End.Truncate(spliceStep).Equal(e.Start.Truncate(spliceStep)) {
-			out = append(out, e)
+		if origEnd.Sub(origStart) <= maxRange &&
+			origEnd.Truncate(spliceStep).Equal(origStart.Truncate(spliceStep)) {
+			out[k] = Extent{Start: origStart, End: origEnd, LastUsed: e.LastUsed}
+			k++
 			continue
 		}
-		// otherwise, we still need to further splice e
-		for i := e.Start; !i.After(e.End); {
-			// this creates a new splice to add to the output
-			e2 := Extent{Start: i, End: i.Add(maxRange - step).Truncate(step)}
-			if e2.End.Before(e2.Start) {
-				e2.End = e2.Start
+		for i := origStart; !i.After(origEnd); {
+			end := i.Add(maxRange - step).Truncate(step)
+			if end.Before(i) {
+				end = i
 			}
-			// the final iteration may be partial/smaller than the splice size, so this clamps it
-			if e2.End.After(e.End) {
-				e2.End = e.End
+			if end.After(origEnd) {
+				end = origEnd
 			}
-			out = append(out, e2)
-			// this advances i forward a step beyond the current splice end, to start the next one
-			i = e2.End.Add(step)
+			out[k] = Extent{Start: i, End: end, LastUsed: e.LastUsed}
+			k++
+			i = end.Add(step)
 		}
 	}
-	return out
+
+	return out[:k]
 }
 
 // spliceByTime splices extents that are not aligned to any particular epoch cadence
@@ -222,31 +215,28 @@ func (el ExtentList) spliceByTime(step, maxRange time.Duration) ExtentList {
 	if step == 0 || maxRange == 0 {
 		return el.Clone()
 	}
-	// reserve enough capacity that 50% of extents could be spliced without having to re-allocate
-	out := make(ExtentList, 0, len(el)+(len(el)/2))
+	out := make(ExtentList, len(el)*4)
+	var k int
 	for _, e := range el {
-		// if the size of the extent is smaller than the max splice size, pass through and continue
 		if e.End.Sub(e.Start) <= maxRange {
-			out = append(out, e)
+			out[k] = e
+			k++
 			continue
 		}
-		// otherwise, we still need to further splice e
 		for i := e.Start; !i.After(e.End); {
-			// this creates a new splice to add to the output
-			e2 := Extent{Start: i, End: i.Add(maxRange - step).Truncate(step)}
-			// the final iteration may be partial/smaller than the splice size, so this clamps it
-			if e2.End.Before(e2.Start) {
-				e2.End = e2.Start
+			end := i.Add(maxRange - step).Truncate(step)
+			if end.Before(i) {
+				end = i
 			}
-			if e2.End.After(e.End) {
-				e2.End = e.End
+			if end.After(e.End) {
+				end = e.End
 			}
-			out = append(out, e2)
-			// this advances i forward a step beyond the current splice end, to start the next one
-			i = e2.End.Add(step)
+			out[k] = Extent{Start: i, End: end, LastUsed: e.LastUsed}
+			k++
+			i = end.Add(step)
 		}
 	}
-	return out
+	return out[:k]
 }
 
 // spliceByTime splices by a given number of contiguous timestamps (points) per splice
@@ -254,32 +244,35 @@ func (el ExtentList) spliceByPoints(step time.Duration, maxPoints int) ExtentLis
 	if maxPoints == 0 || step == 0 {
 		return el.Clone()
 	}
-	out := make(ExtentList, 0, len(el)+(len(el)/2))
+	out := make(ExtentList, len(el)*4)
+	var k int
+	spliceSpan := step * time.Duration(maxPoints-1)
 	for _, e := range el {
-		// this determines the number of timestamps in the extent
-		s := int(e.End.Sub(e.Start) / step)
-		// if the splice size is larger than the timestamp count, the extent can be passed through
-		if maxPoints > s || e.Start.IsZero() || e.End.IsZero() {
-			out = append(out, e)
+		if e.Start.IsZero() || e.End.IsZero() {
+			out[k] = e
+			k++
 			continue
 		}
-		// otherwise, this extent is larger than the splice size, so it needs to be spliced
+		numPoints := int(e.End.Sub(e.Start) / step)
+		if maxPoints > numPoints {
+			out[k] = e
+			k++
+			continue
+		}
 		for i := e.Start; !i.After(e.End); {
-			// this creates a new splice to add to the output
-			e2 := Extent{Start: i, End: i.Add(step * time.Duration(maxPoints-1))}
-			// the final iteration may be partial/smaller than the splice size, so this clamps it
-			if e2.End.Before(e2.Start) {
-				e2.End = e2.Start
+			end := i.Add(spliceSpan)
+			if end.Before(i) {
+				end = i
 			}
-			if e2.End.After(e.End) {
-				e2.End = e.End
+			if end.After(e.End) {
+				end = e.End
 			}
-			out = append(out, e2)
-			// this advances i forward a step beyond the current splice end, to start the next one
-			i = e2.End.Add(step)
+			out[k] = Extent{Start: i, End: end, LastUsed: e.LastUsed}
+			k++
+			i = end.Add(step)
 		}
 	}
-	return out
+	return out[:k]
 }
 
 // Len returns the length of a slice of type ExtentList

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -455,7 +455,7 @@ func (el ExtentList) TimestampCount(d time.Duration) int64 {
 // will be checked in el.
 func (el ExtentList) CalculateDeltas(need Extent, step time.Duration) ExtentList {
 	if step <= 0 || !need.End.After(need.Start) {
-		return nil
+		return ExtentList{}
 	}
 	if len(el) == 0 {
 		return ExtentList{need}

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -422,7 +422,7 @@ func (el ExtentList) Remove(r ExtentList, step time.Duration) ExtentList {
 
 	// otherwise, make a version of the does not include the splice out indexes
 	// and includes any splice-in indexes
-	r = make(ExtentList, (len(c)*len(r))+len(splices)+len(spliceIns)+1)
+	r = make(ExtentList, len(c)*2)
 	var k int
 	for i, ex := range c {
 		if ex2, ok := spliceIns[i]; ok {

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -444,11 +444,7 @@ func (el ExtentListLRU) Swap(i, j int) {
 // Clone returns a true copy of the ExtentListLRU
 func (el ExtentListLRU) Clone() ExtentListLRU {
 	c := make(ExtentListLRU, len(el))
-	for i := range el {
-		c[i].Start = el[i].Start
-		c[i].End = el[i].End
-		c[i].LastUsed = el[i].LastUsed
-	}
+	copy(c, el)
 	return c
 }
 

--- a/pkg/timeseries/extent_list_test.go
+++ b/pkg/timeseries/extent_list_test.go
@@ -19,6 +19,7 @@ package timeseries
 import (
 	"fmt"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"testing"
@@ -395,7 +396,7 @@ func TestRemove(t *testing.T) {
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			v := test.el.Remove(test.removals, step)
-			if !v.Equal(test.expected) {
+			if !slices.Equal(v, test.expected) {
 				t.Errorf("expected %v got %v", test.expected, v)
 			}
 		})
@@ -758,37 +759,6 @@ func TestCrop(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestEqual(t *testing.T) {
-
-	el := ExtentList{
-		Extent{Start: t100, End: t200},
-		Extent{Start: t600, End: t900},
-		Extent{Start: t1100, End: t1300},
-	}
-
-	b := el.Equal(nil)
-	if b {
-		t.Error("expected false")
-	}
-
-	b = el.Equal(ExtentList{})
-	if b {
-		t.Error("expected false")
-	}
-
-	el2 := ExtentList{
-		Extent{Start: t101, End: t200},
-		Extent{Start: t600, End: t900},
-		Extent{Start: t1100, End: t1300},
-	}
-
-	b = el.Equal(el2)
-	if b {
-		t.Error("expected false")
-	}
-
 }
 
 func TestExtentListLRUSort(t *testing.T) {
@@ -1195,7 +1165,7 @@ func TestSplice(t *testing.T) {
 			}
 			if (test.expected == nil && out != nil) ||
 				(out == nil && test.expected != nil) ||
-				(!out.Equal(test.expected)) {
+				(!slices.Equal(out, test.expected)) {
 				t.Errorf("expected %s\ngot      %s", test.expected, out)
 			}
 		})

--- a/pkg/timeseries/extent_list_test.go
+++ b/pkg/timeseries/extent_list_test.go
@@ -385,11 +385,7 @@ func TestRemove(t *testing.T) {
 				Extent{Start: t600, End: t900},
 				Extent{Start: t1100, End: t1300},
 			},
-			ExtentList{
-				Extent{Start: t101, End: t200},
-				Extent{Start: t600, End: t900},
-				Extent{Start: t1100, End: t1300},
-			},
+			ExtentList{},
 		},
 	}
 

--- a/pkg/timeseries/extent_list_test.go
+++ b/pkg/timeseries/extent_list_test.go
@@ -483,13 +483,24 @@ func TestCloneRange(t *testing.T) {
 	}
 
 	res := el.CloneRange(-1, -1)
-	if res != nil {
-		t.Error("expected nil result", res)
+	if len(res) != 0 {
+		t.Error("expected zero-length result", res)
 	}
 
 	res = el.CloneRange(0, 200)
-	if res != nil {
-		t.Error("expected nil result", res)
+	if len(res) != 0 {
+		t.Error("expected zero-length result", res)
+	}
+
+	el = ExtentList{
+		Extent{Start: t100, End: t200},
+		Extent{Start: t600, End: t900},
+		Extent{Start: t1100, End: t1300},
+	}
+
+	res = el.CloneRange(1, 3)
+	if len(res) != 2 {
+		t.Error("expected 2 got", len(res))
 	}
 
 }


### PR DESCRIPTION
This flattens `ExtentList.CalculateDeltas` to use an `O(n + m)` merge-sweep in place of the `O(n²)` nested loops, while eliminating appends. It also removes a few appends from ExtentList's `Remove` and `Compress` functions. Optimizes a number of ExtentList functions for splicing, merging, cropping, cloning, and removing ExtentList data.