### PR TITLE
fix: add gosec to golangci-lint and resolve warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - grouper
     - gocritic
     - revive
+    - gosec
   disable:
     - errcheck
   settings:
@@ -32,6 +33,11 @@ linters:
      disabled-checks:
        - unslice # stylistic choice, ok with slice[:] references
        - ifElseChain # false positives / prefers switch statements
+    gosec:
+      excludes:
+      - G401 # MD5 & SHA1 adequate for non-cryptographic use cases
+      - G501 # MD5 & SHA1, again
+      - G505 # MD5 & SHA1, again
     revive:
       enable-all-rules: true
       rules:

--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,6 @@ get-tools: get-msgpack
 	@echo "Installing tools..."
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.2
 	go install honnef.co/go/tools/cmd/staticcheck@2025.1.1
-	go install github.com/securego/gosec/v2/cmd/gosec@v2.22.3
 
 .PHONY: get-msgpack
 get-msgpack:

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -65,6 +65,9 @@ frontend:
 #   # 0 by default, unlimited.
 #   connections_limit: 0
 
+#  # reader_header_timeout defines is the amount of time allowed to read request headers by the frontend http proxy server
+#  # read_header_timeout: 10s
+
 # caches:
 #   default:
 #     # provider defines what kind of cache Trickster uses

--- a/pkg/backends/influxdb/model/marshal.go
+++ b/pkg/backends/influxdb/model/marshal.go
@@ -160,7 +160,8 @@ func toWireFormat(ds *dataset.DataSet,
 			row.Columns = make([]string, 0, len(s.Header.FieldsList)+1)
 			var tsColumnAdded bool
 			for i, header := range s.Header.FieldsList {
-				if i == s.Header.TimestampIndex {
+				index := uint32(i) // #nosec G115 -- i is positive, there should be no overflow
+				if index == s.Header.TimestampIndex {
 					row.Columns = append(row.Columns, timeColumnName)
 					tsColumnAdded = true
 				}
@@ -180,7 +181,8 @@ func toWireFormat(ds *dataset.DataSet,
 				vals := make([]any, 0, len(p.Values))
 				var tsValAdded bool
 				for n, v := range p.Values {
-					if n == s.Header.TimestampIndex {
+					index := uint32(n) // #nosec G115 -- i is positive
+					if index == s.Header.TimestampIndex {
 						vals = append(vals, df(p.Epoch, multiplier))
 						tsValAdded = true
 					}
@@ -231,7 +233,7 @@ func marshalTimeseriesCSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
 		if !headerWritten {
 			l := len(s.Header.FieldsList) + 1
 			cols := make([]string, l)
-			var j int
+			var j uint32
 			for _, f := range s.Header.FieldsList {
 				if j == s.Header.TimestampIndex {
 					cols[j] = timeColumnName
@@ -247,7 +249,8 @@ func marshalTimeseriesCSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
 			w.Write([]byte(s.Header.Name + ",\"" + s.Header.Tags.StringsWithSep("=", ",") + "\","))
 			lv := len(p.Values)
 			for n, v := range p.Values {
-				if n == s.Header.TimestampIndex {
+				index := uint32(n) // #nosec G115 -- i is positive
+				if index == s.Header.TimestampIndex {
 					dw(w, p.Epoch, multiplier)
 					if n < lv-1 {
 						w.Write([]byte(","))

--- a/pkg/backends/influxdb/model/marshal.go
+++ b/pkg/backends/influxdb/model/marshal.go
@@ -160,7 +160,7 @@ func toWireFormat(ds *dataset.DataSet,
 			row.Columns = make([]string, 0, len(s.Header.FieldsList)+1)
 			var tsColumnAdded bool
 			for i, header := range s.Header.FieldsList {
-				index := uint32(i) // #nosec G115 -- i is positive, there should be no overflow
+				index := uint64(i) // #nosec G115 -- i is positive, there should be no overflow
 				if index == s.Header.TimestampIndex {
 					row.Columns = append(row.Columns, timeColumnName)
 					tsColumnAdded = true
@@ -181,7 +181,7 @@ func toWireFormat(ds *dataset.DataSet,
 				vals := make([]any, 0, len(p.Values))
 				var tsValAdded bool
 				for n, v := range p.Values {
-					index := uint32(n) // #nosec G115 -- i is positive
+					index := uint64(n) // #nosec G115 -- i is positive
 					if index == s.Header.TimestampIndex {
 						vals = append(vals, df(p.Epoch, multiplier))
 						tsValAdded = true
@@ -233,7 +233,7 @@ func marshalTimeseriesCSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
 		if !headerWritten {
 			l := len(s.Header.FieldsList) + 1
 			cols := make([]string, l)
-			var j uint32
+			var j uint64
 			for _, f := range s.Header.FieldsList {
 				if j == s.Header.TimestampIndex {
 					cols[j] = timeColumnName
@@ -249,7 +249,7 @@ func marshalTimeseriesCSV(ds *dataset.DataSet, rlo *timeseries.RequestOptions,
 			w.Write([]byte(s.Header.Name + ",\"" + s.Header.Tags.StringsWithSep("=", ",") + "\","))
 			lv := len(p.Values)
 			for n, v := range p.Values {
-				index := uint32(n) // #nosec G115 -- i is positive
+				index := uint64(n) // #nosec G115 -- i is positive
 				if index == s.Header.TimestampIndex {
 					dw(w, p.Epoch, multiplier)
 					if n < lv-1 {

--- a/pkg/backends/influxdb/model/unmarshal.go
+++ b/pkg/backends/influxdb/model/unmarshal.go
@@ -145,9 +145,10 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 			sh.FieldsList = make([]timeseries.FieldDefinition, fdl)
 			var fdi int
 			for ci, cn := range wfd.Results[i].SeriesList[j].Columns {
+				index := uint32(ci) // #nosec G115 -- ci is positive
 				if cn == "time" || cn == "_time" {
 					timeFound = true
-					sh.TimestampIndex = ci
+					sh.TimestampIndex = index
 					continue
 				}
 				sh.FieldsList[fdi] = timeseries.FieldDefinition{Name: cn}
@@ -232,7 +233,7 @@ func tryParseTimestamp(v any) int64 {
 	return -1
 }
 
-func pointFromValues(v []interface{}, tsIndex int) (dataset.Point,
+func pointFromValues(v []interface{}, tsIndex uint32) (dataset.Point,
 	[]timeseries.FieldDataType, error) {
 	p := dataset.Point{}
 	ns := tryParseTimestamp(v[tsIndex])

--- a/pkg/backends/influxdb/model/unmarshal.go
+++ b/pkg/backends/influxdb/model/unmarshal.go
@@ -145,7 +145,7 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 			sh.FieldsList = make([]timeseries.FieldDefinition, fdl)
 			var fdi int
 			for ci, cn := range wfd.Results[i].SeriesList[j].Columns {
-				index := uint32(ci) // #nosec G115 -- ci is positive
+				index := uint64(ci) // #nosec G115 -- ci is positive
 				if cn == "time" || cn == "_time" {
 					timeFound = true
 					sh.TimestampIndex = index
@@ -233,7 +233,7 @@ func tryParseTimestamp(v any) int64 {
 	return -1
 }
 
-func pointFromValues(v []interface{}, tsIndex uint32) (dataset.Point,
+func pointFromValues(v []interface{}, tsIndex uint64) (dataset.Point,
 	[]timeseries.FieldDataType, error) {
 	p := dataset.Point{}
 	ns := tryParseTimestamp(v[tsIndex])

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -50,7 +50,7 @@ type Config struct {
 	Backends map[string]*bo.Options `yaml:"backends,omitempty"`
 	// Caches is a map of CacheConfigs
 	Caches map[string]*cache.Options `yaml:"caches,omitempty"`
-	// ProxyServer is provides configurations about the Proxy Front End
+	// Frontend provides configurations about the Proxy Front End
 	Frontend *fropt.Options `yaml:"frontend,omitempty"`
 	// Logging provides configurations that affect logging behavior
 	Logging *lo.Options `yaml:"logging,omitempty"`

--- a/pkg/config/tls.go
+++ b/pkg/config/tls.go
@@ -41,7 +41,11 @@ func (c *Config) TLSCertConfig() (*tls.Config, error) {
 		return nil, nil
 	}
 
-	tlsConfig := &tls.Config{Certificates: make([]tls.Certificate, l), NextProtos: []string{"h2"}}
+	tlsConfig := &tls.Config{
+		Certificates: make([]tls.Certificate, l),
+		NextProtos:   []string{"h2"},
+		MinVersion:   tls.VersionTLS12,
+	}
 
 	for i, tc := range to {
 		tlsConfig.Certificates[i], err = tls.LoadX509KeyPair(tc.TLS.FullChainCertPath, tc.TLS.PrivateKeyPath)

--- a/pkg/daemon/setup/listeners.go
+++ b/pkg/daemon/setup/listeners.go
@@ -98,7 +98,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 			go lg.StartListener("tlsListener",
 				conf.Frontend.TLSListenAddress, conf.Frontend.TLSListenPort,
 				conf.Frontend.ConnectionsLimit, tlsConfig, router, tracers, errorFunc,
-				time.Duration(conf.ReloadConfig.DrainTimeoutMS)*time.Millisecond)
+				time.Duration(conf.ReloadConfig.DrainTimeoutMS)*time.Millisecond, conf.Frontend.ReadHeaderTimeout)
 		}
 	case !conf.Frontend.ServeTLS && hasOldFC && oldConf.Frontend.ServeTLS:
 		// the TLS configs have been removed between the last config load and this one,
@@ -131,7 +131,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		}
 		go lg.StartListener("httpListener",
 			conf.Frontend.ListenAddress, conf.Frontend.ListenPort,
-			conf.Frontend.ConnectionsLimit, nil, router, t2, errorFunc, 0)
+			conf.Frontend.ConnectionsLimit, nil, router, t2, errorFunc, 0, conf.Frontend.ReadHeaderTimeout)
 	}
 
 	// if the Metrics HTTP port is configured, then set up the http listener instance
@@ -148,7 +148,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		}
 		go lg.StartListener("metricsListener",
 			conf.Metrics.ListenAddress, conf.Metrics.ListenPort,
-			conf.Frontend.ConnectionsLimit, nil, metricsRouter, nil, errorFunc, 0)
+			conf.Frontend.ConnectionsLimit, nil, metricsRouter, nil, errorFunc, 0, conf.Frontend.ReadHeaderTimeout)
 	} else {
 		metricsRouter.RegisterRoute("/metrics", nil, nil,
 			false, metrics.Handler())
@@ -176,7 +176,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		}
 		go lg.StartListener("reloadListener",
 			conf.ReloadConfig.ListenAddress, conf.ReloadConfig.ListenPort,
-			conf.Frontend.ConnectionsLimit, nil, rr, nil, errorFunc, 0)
+			conf.Frontend.ConnectionsLimit, nil, rr, nil, errorFunc, 0, conf.Frontend.ReadHeaderTimeout)
 	} else {
 		rr.RegisterRoute(conf.Main.ConfigHandlerPath, nil, nil,
 			false, http.HandlerFunc(handlers.ConfigHandleFunc(conf)))

--- a/pkg/frontend/options/defaults.go
+++ b/pkg/frontend/options/defaults.go
@@ -16,6 +16,8 @@
 
 package options
 
+import "time"
+
 const (
 	// DefaultProxyListenPort is the default port that the HTTP frontend will listen on
 	DefaultProxyListenPort = 8480
@@ -28,4 +30,7 @@ const (
 	DefaultTLSProxyListenPort = 8483
 	// DefaultTLSProxyListenAddress is the default address that the TLS frontend endpoint will listen on
 	DefaultTLSProxyListenAddress = ""
+
+	// DefaultReadHeaderTimeout is the default amount of time allowed to read request headers by the frontend proxy server
+	DefaultReadHeaderTimeout = 10 * time.Second
 )

--- a/pkg/frontend/options/options.go
+++ b/pkg/frontend/options/options.go
@@ -16,6 +16,8 @@
 
 package options
 
+import "time"
+
 // FrontendConfig is a collection of configurations for the main http frontend for the application
 type Options struct {
 	// ListenAddress is IP address for the main http listener for the application
@@ -28,7 +30,8 @@ type Options struct {
 	TLSListenPort int `yaml:"tls_listen_port,omitempty"`
 	// ConnectionsLimit indicates how many concurrent front end connections trickster will handle at any time
 	ConnectionsLimit int `yaml:"connections_limit,omitempty"`
-
+	// ReadHeaderTimeout is the amount of time allowed to read request headers.
+	ReadHeaderTimeout time.Duration `yaml:"read_header_timeout,omitempty"`
 	// ServeTLS indicates whether to listen and serve on the TLS port, meaning
 	// at least one backend options has a valid certificate and key file configured.
 	ServeTLS bool `yaml:"-"`
@@ -37,10 +40,11 @@ type Options struct {
 // New returns a new Frontend Options with default values
 func New() *Options {
 	return &Options{
-		ListenPort:       DefaultProxyListenPort,
-		ListenAddress:    DefaultProxyListenAddress,
-		TLSListenPort:    DefaultTLSProxyListenPort,
-		TLSListenAddress: DefaultTLSProxyListenAddress,
+		ListenPort:        DefaultProxyListenPort,
+		ListenAddress:     DefaultProxyListenAddress,
+		TLSListenPort:     DefaultTLSProxyListenPort,
+		TLSListenAddress:  DefaultTLSProxyListenAddress,
+		ReadHeaderTimeout: DefaultReadHeaderTimeout,
 	}
 }
 

--- a/pkg/frontend/options/options_test.go
+++ b/pkg/frontend/options/options_test.go
@@ -16,21 +16,22 @@
 
 package options
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
 
 func TestFrontendOptions(t *testing.T) {
 
+	// expect f1 and f2 to be equal
 	f1 := New()
 	f2 := New()
+	require.True(t, f1.Equal(f2))
 
-	b := f1.Equal(f2)
-	if !b {
-		t.Errorf("expected %t got %t", true, b)
-	}
-
-	f1.ListenAddress = "trickster"
+	// expect f1 and f2 to be equal, after modifying f1
 	f2 = f1.Clone()
-	if !f1.Equal(f2) {
-		t.Errorf("expected %t got %t", true, b)
-	}
+	f1.ListenAddress = "trickster"
+	require.NotEqual(t, f1.ListenAddress, f2.ListenAddress)
+	require.False(t, f1.Equal(f2))
 }

--- a/pkg/parsing/token/token_type.go
+++ b/pkg/parsing/token/token_type.go
@@ -106,7 +106,7 @@ func (t Typ) String() string {
 	if s, ok := typLookup[t]; ok {
 		return s
 	}
-	return strconv.Itoa(int(t))
+	return strconv.FormatUint(uint64(t), 10)
 }
 
 // IsBreakable returns true if the Typ is EOF or Error

--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -199,8 +199,9 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 
 	if tlsConfig != nil {
 		svr := &http.Server{
-			Handler:   l.routeSwapper,
-			TLSConfig: tlsConfig,
+			Handler:           l.routeSwapper,
+			TLSConfig:         tlsConfig,
+			ReadHeaderTimeout: time.Hour, // TODO: This needs to be configurable
 		}
 		l.server = svr
 		err = svr.Serve(l)
@@ -218,7 +219,8 @@ func (lg *ListenerGroup) StartListener(listenerName, address string, port int, c
 	}
 
 	svr := &http.Server{
-		Handler: l.routeSwapper,
+		Handler:           l.routeSwapper,
+		ReadHeaderTimeout: time.Hour, // TODO: This needs to be configurable
 	}
 	l.server = svr
 	err = svr.Serve(l)

--- a/pkg/proxy/listener/listener_test.go
+++ b/pkg/proxy/listener/listener_test.go
@@ -61,7 +61,7 @@ func TestListeners(t *testing.T) {
 			Certificates: make([]tls.Certificate, 1),
 		}
 		errs <- testLG.StartListener("httpListener",
-			"", 0, 20, tc, http.NewServeMux(), trs, nil, 0)
+			"", 0, 20, tc, http.NewServeMux(), trs, nil, 0, 0)
 		close(errs)
 	}()
 
@@ -79,7 +79,7 @@ func TestListeners(t *testing.T) {
 	go func() {
 		errs2 <- testLG.StartListenerRouter("httpListener2",
 			"", 0, 20, nil, "/", http.HandlerFunc(ph.HandleLocalResponse),
-			nil, nil, 0)
+			nil, nil, 0, 0)
 		close(errs2)
 	}()
 	time.Sleep(time.Millisecond * 300)
@@ -94,7 +94,7 @@ func TestListeners(t *testing.T) {
 	}
 
 	err = testLG.StartListener("testBadPort",
-		"", -31, 20, nil, http.NewServeMux(), trs, nil, 0)
+		"", -31, 20, nil, http.NewServeMux(), trs, nil, 0, 0)
 	if err == nil {
 		t.Error("expected invalid port error")
 	}
@@ -126,7 +126,7 @@ func TestListenerAccept(t *testing.T) {
 	var err error
 	go func() {
 		err = testLG.StartListener("httpListener",
-			"", 0, 20, nil, http.NewServeMux(), nil, nil, 0)
+			"", 0, 20, nil, http.NewServeMux(), nil, nil, 0, 0)
 	}()
 	time.Sleep(time.Millisecond * 500)
 	if err != nil {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -41,7 +41,7 @@ func NewHTTPClient(o *bo.Options) (*http.Client, error) {
 	var TLSConfig *tls.Config
 
 	if o.TLS != nil {
-		TLSConfig = &tls.Config{InsecureSkipVerify: o.TLS.InsecureSkipVerify}
+		TLSConfig = &tls.Config{InsecureSkipVerify: o.TLS.InsecureSkipVerify} // #nosec G402 -- this is a user-configurable option, accept risk
 
 		if o.TLS.ClientCertPath != "" && o.TLS.ClientKeyPath != "" {
 			// load client cert

--- a/pkg/timeseries/dataset/series_header.go
+++ b/pkg/timeseries/dataset/series_header.go
@@ -39,7 +39,7 @@ type SeriesHeader struct {
 	FieldsList []timeseries.FieldDefinition `msg:"fields"`
 	// TimestampIndex is the index of the TimeStamp field in the output when
 	// it's time to serialize the DataSet for the wire
-	TimestampIndex int `msg:"ti"`
+	TimestampIndex uint32 `msg:"ti"`
 	// QueryStatement is the original query to which this DataSet is associated
 	QueryStatement string `msg:"query"`
 	// Size is the memory utilization of the Header in bytes
@@ -65,7 +65,7 @@ func (sh *SeriesHeader) CalculateHash() Hash {
 		hash.Write([]byte{byte(fd.DataType)})
 	}
 	b := make([]byte, 4)
-	binary.LittleEndian.PutUint32(b, uint32(sh.TimestampIndex))
+	binary.LittleEndian.PutUint32(b, sh.TimestampIndex)
 	hash.Write(b)
 	sh.hash = Hash(hash.Sum64())
 	return sh.hash
@@ -121,7 +121,7 @@ func (sh *SeriesHeader) String() string {
 		}
 		sb.WriteString("],")
 	}
-	sb.WriteString(`"timestampIndex":` + strconv.Itoa(sh.TimestampIndex))
+	sb.WriteString(`"timestampIndex":` + strconv.FormatUint(uint64(sh.TimestampIndex), 10))
 	sb.WriteByte('}')
 	return sb.String()
 }

--- a/pkg/timeseries/dataset/series_header.go
+++ b/pkg/timeseries/dataset/series_header.go
@@ -39,7 +39,7 @@ type SeriesHeader struct {
 	FieldsList []timeseries.FieldDefinition `msg:"fields"`
 	// TimestampIndex is the index of the TimeStamp field in the output when
 	// it's time to serialize the DataSet for the wire
-	TimestampIndex uint32 `msg:"ti"`
+	TimestampIndex uint64 `msg:"ti"`
 	// QueryStatement is the original query to which this DataSet is associated
 	QueryStatement string `msg:"query"`
 	// Size is the memory utilization of the Header in bytes
@@ -64,8 +64,8 @@ func (sh *SeriesHeader) CalculateHash() Hash {
 		hash.Write([]byte(fd.Name))
 		hash.Write([]byte{byte(fd.DataType)})
 	}
-	b := make([]byte, 4)
-	binary.LittleEndian.PutUint32(b, sh.TimestampIndex)
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, sh.TimestampIndex)
 	hash.Write(b)
 	sh.hash = Hash(hash.Sum64())
 	return sh.hash
@@ -121,7 +121,7 @@ func (sh *SeriesHeader) String() string {
 		}
 		sb.WriteString("],")
 	}
-	sb.WriteString(`"timestampIndex":` + strconv.FormatUint(uint64(sh.TimestampIndex), 10))
+	sb.WriteString(`"timestampIndex":` + strconv.FormatUint(sh.TimestampIndex, 10))
 	sb.WriteByte('}')
 	return sb.String()
 }

--- a/pkg/timeseries/dataset/series_header_gen.go
+++ b/pkg/timeseries/dataset/series_header_gen.go
@@ -73,7 +73,7 @@ func (z *SeriesHeader) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 		case "ti":
-			z.TimestampIndex, err = dc.ReadUint32()
+			z.TimestampIndex, err = dc.ReadUint64()
 			if err != nil {
 				err = msgp.WrapError(err, "TimestampIndex")
 				return
@@ -146,7 +146,7 @@ func (z *SeriesHeader) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = en.WriteUint32(z.TimestampIndex)
+	err = en.WriteUint64(z.TimestampIndex)
 	if err != nil {
 		err = msgp.WrapError(err, "TimestampIndex")
 		return
@@ -200,7 +200,7 @@ func (z *SeriesHeader) MarshalMsg(b []byte) (o []byte, err error) {
 	}
 	// string "ti"
 	o = append(o, 0xa2, 0x74, 0x69)
-	o = msgp.AppendUint32(o, z.TimestampIndex)
+	o = msgp.AppendUint64(o, z.TimestampIndex)
 	// string "query"
 	o = append(o, 0xa5, 0x71, 0x75, 0x65, 0x72, 0x79)
 	o = msgp.AppendString(o, z.QueryStatement)
@@ -260,7 +260,7 @@ func (z *SeriesHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 		case "ti":
-			z.TimestampIndex, bts, err = msgp.ReadUint32Bytes(bts)
+			z.TimestampIndex, bts, err = msgp.ReadUint64Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "TimestampIndex")
 				return
@@ -295,6 +295,6 @@ func (z *SeriesHeader) Msgsize() (s int) {
 	for za0001 := range z.FieldsList {
 		s += z.FieldsList[za0001].Msgsize()
 	}
-	s += 3 + msgp.Uint32Size + 6 + msgp.StringPrefixSize + len(z.QueryStatement) + 5 + msgp.IntSize
+	s += 3 + msgp.Uint64Size + 6 + msgp.StringPrefixSize + len(z.QueryStatement) + 5 + msgp.IntSize
 	return
 }

--- a/pkg/timeseries/dataset/series_header_gen.go
+++ b/pkg/timeseries/dataset/series_header_gen.go
@@ -73,7 +73,7 @@ func (z *SeriesHeader) DecodeMsg(dc *msgp.Reader) (err error) {
 				}
 			}
 		case "ti":
-			z.TimestampIndex, err = dc.ReadInt()
+			z.TimestampIndex, err = dc.ReadUint32()
 			if err != nil {
 				err = msgp.WrapError(err, "TimestampIndex")
 				return
@@ -146,7 +146,7 @@ func (z *SeriesHeader) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = en.WriteInt(z.TimestampIndex)
+	err = en.WriteUint32(z.TimestampIndex)
 	if err != nil {
 		err = msgp.WrapError(err, "TimestampIndex")
 		return
@@ -200,7 +200,7 @@ func (z *SeriesHeader) MarshalMsg(b []byte) (o []byte, err error) {
 	}
 	// string "ti"
 	o = append(o, 0xa2, 0x74, 0x69)
-	o = msgp.AppendInt(o, z.TimestampIndex)
+	o = msgp.AppendUint32(o, z.TimestampIndex)
 	// string "query"
 	o = append(o, 0xa5, 0x71, 0x75, 0x65, 0x72, 0x79)
 	o = msgp.AppendString(o, z.QueryStatement)
@@ -260,7 +260,7 @@ func (z *SeriesHeader) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				}
 			}
 		case "ti":
-			z.TimestampIndex, bts, err = msgp.ReadIntBytes(bts)
+			z.TimestampIndex, bts, err = msgp.ReadUint32Bytes(bts)
 			if err != nil {
 				err = msgp.WrapError(err, "TimestampIndex")
 				return
@@ -295,6 +295,6 @@ func (z *SeriesHeader) Msgsize() (s int) {
 	for za0001 := range z.FieldsList {
 		s += z.FieldsList[za0001].Msgsize()
 	}
-	s += 3 + msgp.IntSize + 6 + msgp.StringPrefixSize + len(z.QueryStatement) + 5 + msgp.IntSize
+	s += 3 + msgp.Uint32Size + 6 + msgp.StringPrefixSize + len(z.QueryStatement) + 5 + msgp.IntSize
 	return
 }

--- a/pkg/timeseries/dataset/series_test.go
+++ b/pkg/timeseries/dataset/series_test.go
@@ -63,7 +63,7 @@ func TestString(t *testing.T) {
 		t.Errorf("expected %s got %s", expected, s.String())
 	}
 
-	expected = "[8621797787432305383]"
+	expected = "[15360041599306893527]"
 	sl := SeriesList{s}
 	if sl.String() != expected {
 		t.Errorf("expected %s got %s", expected, sl.String())

--- a/pkg/util/middleware/simulated_latency.go
+++ b/pkg/util/middleware/simulated_latency.go
@@ -33,7 +33,7 @@ func processSimulatedLatency(w http.ResponseWriter, minMS, maxMS int) {
 	if minMS >= maxMS {
 		ms = int64(minMS)
 	} else {
-		ms = (rand.Int63() % int64(maxMS-minMS)) + int64(minMS)
+		ms = (rand.Int63() % int64(maxMS-minMS)) + int64(minMS) // #nosec G404 -- we are OK with a weak random source, random-ish enough for our purposes, no security risk
 	}
 	if ms <= 0 {
 		return


### PR DESCRIPTION
Adds gosec to golangci-lint and resolves all warnings.

Notable changes:
- the series header calculate hash func was changed to render an 8 byte hash
- adds a new frontend config -- `read_header_timeout`
  - Re: `[CWE-400] Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server (Rule:G112, Severity:MEDIUM, Confidence:LOW)` 

Resolves #785

-----

To Do:

- [x] Add new "read header timeout" configuration value to trickster config & define proper default value, if possible
- [x] ~~Question~~: what are the maximum sizes of series? there's still technically some chance of overflow
  - mainly: I wasn't sure whether to choose uint32 or uint64 for the timestampIndex size. How large can indexes be?
    - If I change CalculateHash to support uint64, then more changes need to occur, as the hash needs to become larger. not sure if that's OK. 
    - in retrospect: I forget that uint should generally default to uint64; that's probably the better choice to pick and simplifies this concern
    - [x] TODO: update