### PR TITLE
feat: use time.duration throughout config

### DIFF
--- a/deploy/kube/configmap.yaml
+++ b/deploy/kube/configmap.yaml
@@ -84,9 +84,9 @@ data:
     #     # Redis and BadgerDB handle those functions natively and does not use the Tricksters Cache Index
     #     index:
     #       # reap_interval defines how long the Cache Index reaper sleeps between reap cycles. Default is 3 (3s)
-    #       reap_interval: 3000ms
+    #       reap_interval: 3s
     #       # flush_interval sets how often the Cache Index saves its metadata to the cache from application memory. Default is 5 (5s)
-    #       flush_interval: 5000ms
+    #       flush_interval: 5s
     #       # max_size_bytes indicates how large the cache can grow in bytes before the Index evicts least-recently-accessed items. default is 512MB
     #       max_size_bytes: 536870912
     #       # max_size_backoff_bytes indicates how far below max_size_bytes the cache size must be to complete a byte-size-based eviction exercise. default is 16MB
@@ -140,11 +140,11 @@ data:
     #       # max_retry_backoff is the maximum backoff time between each retry
     #       max_retry_backoff: 512ms
     #       # dial_timeout is the timeout for establishing new connections
-    #       dial_timeout: 5000ms
+    #       dial_timeout: 5s
     #       # read_timeout is the timeout for socket reads. If reached, commands will fail with a timeout instead of blocking.
-    #       read_timeout: 3000ms
+    #       read_timeout: 3s
     #       # write_timeout is the timeout for socket writes. If reached, commands will fail with a timeout instead of blocking.
-    #       write_timeout: 3000ms
+    #       write_timeout: 3s
     #       # pool_size is the maximum number of socket connections.
     #       pool_size: 20
     #       # min_idle_conns is the minimum number of idle connections which is useful when establishing new connection is slow.
@@ -154,9 +154,9 @@ data:
     #       # pool_timeout is the amount of time client waits for connection if all connections are busy before returning an error.
     #       pool_timeout: 4000ms
     #       # idle_timeout is the amount of time after which client closes idle connections.
-    #       idle_timeout: 300000ms
+    #       idle_timeout: 5m
     #       # idle_check_frequency is the frequency of idle checks made by idle connections reaper.
-    #       idle_check_frequency: 60000ms
+    #       idle_check_frequency: 1m
 
     #     ## Configuration options when using a Filesystem Cache ###############
     #     filesystem:
@@ -191,8 +191,8 @@ data:
     #       bucket: trickster
 
     #     index:
-    #       reap_interval: 3000ms
-    #       flush_interval: 5000ms
+    #       reap_interval: 3s
+    #       flush_interval: 5s
     #       max_size_bytes: 536870912
     #       size_backoff_bytes: 16777216
 
@@ -294,18 +294,18 @@ data:
     #     - text/javascript, text/css, text/plain, text/xml, text/json, application/json, application/javascript, application/xml ]
 
     #     # timeout defines how long Trickster will wait before aborting and upstream http request. Default: 180s
-    #     timeout: 180000ms
+    #     timeout: 180s
 
     #     # keep_alive_timeout defines how long Trickster will wait before closing a keep-alive connection due to inactivity
-    #     # if the origins keep-alive timeout is shorter than Tricksters, the connect will be closed sooner. Default: 300
-    #     keep_alive_timeout: 300000ms
+    #     # if the origins keep-alive timeout is shorter than Tricksters, the connect will be closed sooner. Default: 5 minutes
+    #     keep_alive_timeout: 5m
 
     #     # max_idle_conns set the maximum concurrent keep-alive connections Trickster may have opened to this backend
     #     # additional requests will be queued. Default: 20
     #     max_idle_conns: 20
 
-    #     # max_ttl defines the maximum allowed TTL for any object cached for this backend. default is 86400
-    #     max_ttl: 86400000ms
+    #     # max_ttl defines the maximum allowed TTL for any object cached for this backend. default is 24 hours
+    #     max_ttl: 24h
 
     #     # revalidation_factor is the multiplier for object lifetime expiration to determine cache object TTL; default is 2
     #     # for example, if a revalidatable object has Cache-Control: max-age=300, we will cache for 10 minutes (300s * 2)
@@ -319,14 +319,14 @@ data:
 
     #     # backfill_tolerance prevents new datapoints that fall within the tolerance window (relative to time.Now) from being cached
     #     # Think of it as "never cache the newest N milliseconds of real-time data, because it may be preliminary and subject to updates"
-    #     # default is 0
+    #     # default is 0ms
     #     backfill_tolerance: 0ms
 
     #     # timeseries_retention_factor defines the maximum number of recent timestamps to cache for a given query. Default is 1024
     #     timeseries_retention_factor: 1024
 
     #     # timeseries_ttl defines the relative expiration of cached timeseries. default is 6 hours (21600 seconds)
-    #     timeseries_ttl: 21600000ms
+    #     timeseries_ttl: 6h
 
     #     # timeseries_eviction_method selects the metholodogy used to determine which timestamps are removed once
     #     # the timeseries_retention_factor limit is reached. options are oldest and lru. Default is oldest
@@ -336,24 +336,24 @@ data:
     #     fast_forward_disable: false
 
     #     # fastforward_ttl defines the relative expiration of cached fast forward data. default is 15s
-    #     fastforward_ttl: 15000ms
+    #     fastforward_ttl: 15s
 
     #     # shard_max_size_points defines the maximum size of a timeseries request in unique timestamps,
     #     # before sharding into multiple requests of this denomination and reconsitituting the results.
-    #     # If shard_max_size_points and shard_max_size are both > 0, the configuration is invalid.
+    #     # If shard_max_size_points and shard_max_size_time are both > 0, the configuration is invalid.
     #     # default is 0
     #     shard_max_size_points: 0
 
-    #     # shard_max_size defines the max size of a timeseries request in milliseconds,
+    #     # shard_max_size_time defines the max size of a timeseries request in arbitrary time units (ns, ms, s, h, d),
     #     # before sharding into multiple requests of this denomination and reconsitituting the results.
-    #     # If shard_max_size and shard_max_size_points are both > 0, the configuration is invalid.
-    #     # default is 0
-    #     shard_max_size: 0ms
+    #     # If shard_max_size_time and shard_max_size_points are both > 0, the configuration is invalid.
+    #     # default is 0ms
+    #     shard_max_size_time: 0ms
 
     #     # shard_step defines the epoch-aligned cadence to use when creating shards. When set to 0,
-    #     # shards are not aligned to the epoch at a specific step. shard_max_size must be perfectly
+    #     # shards are not aligned to the epoch at a specific step. shard_max_size_time must be perfectly
     #     # divisible by shard_step when both are > 0, or the configuration is invalid.
-    #     # default is 0
+    #     # default is 0ms
     #     shard_step: 0ms
 
     #     #
@@ -451,8 +451,8 @@ data:
     #     negative_cache_name: general
     #     timeseries_retention_factor: 1024
     #     timeseries_eviction_method: oldest
-    #     timeout: 180000ms
-    #     backfill_tolerance: 180000ms
+    #     timeout: 18s
+    #     backfill_tolerance: 18s
     #     tracing_name: example
 
     # # Configuration Options for Request Routing Rules - see /docs/rule.md for more information
@@ -519,7 +519,7 @@ data:
     #     # timeout is the amount of time in milliseconds for the tracing post
     #     # to wait for a response before timing out
     #     # default is no timeout set
-    #     timeout: 5000ms
+    #     timeout: 5s
 
     #     # headers is a list of http headers to include in the tracing post
     #     # default is none
@@ -597,12 +597,12 @@ data:
     #   handler_path: /trickster/config/reload
     #   # drain_timeout defines how long old HTTP listeners will live to allow
     #   # outstanding connection to close organically, before the listener is forcefully closed
-    #   # the default is 30
-    #   drain_timeout: 30000ms
+    #   # the default is 30s
+    #   drain_timeout: 30s
     #   # rate_limit specifies the rate limit timeout duration to apply to the HTTP reload interface.
     #   # The reload interface is disabled for this duration of time whenever a config reload request is
-    #   # made that fails because the underlying config file is unmodified. default is 3
-    #   rate_limit: 3000ms
+    #   # made that fails because the underlying config file is unmodified. default is 3s
+    #   rate_limit: 3s
 
     # # Configuration Options for Logging Instrumentation
     # logging:

--- a/deploy/kube/configmap.yaml
+++ b/deploy/kube/configmap.yaml
@@ -83,10 +83,10 @@ data:
     #     # The Cache Index handles key management and retention for bbolt, filesystem and memory
     #     # Redis and BadgerDB handle those functions natively and does not use the Tricksters Cache Index
     #     index:
-    #       # reap_interval_ms defines how long the Cache Index reaper sleeps between reap cycles. Default is 3 (3s)
-    #       reap_interval_ms: 3000
-    #       # flush_interval_ms sets how often the Cache Index saves its metadata to the cache from application memory. Default is 5 (5s)
-    #       flush_interval_ms: 5000
+    #       # reap_interval defines how long the Cache Index reaper sleeps between reap cycles. Default is 3 (3s)
+    #       reap_interval: 3000ms
+    #       # flush_interval sets how often the Cache Index saves its metadata to the cache from application memory. Default is 5 (5s)
+    #       flush_interval: 5000ms
     #       # max_size_bytes indicates how large the cache can grow in bytes before the Index evicts least-recently-accessed items. default is 512MB
     #       max_size_bytes: 536870912
     #       # max_size_backoff_bytes indicates how far below max_size_bytes the cache size must be to complete a byte-size-based eviction exercise. default is 16MB
@@ -135,28 +135,28 @@ data:
     #       db: 0
     #       # max_retries is the maximum number of retries before giving up on the command
     #       max_retries: 0
-    #       # min_retry_backoff_ms is the minimum backoff time between each retry
-    #       min_retry_backoff_ms: 8
-    #       # max_retry_backoff_ms is the maximum backoff time between each retry
-    #       max_retry_backoff_ms: 512
-    #       # dial_timeout_ms is the timeout for establishing new connections
-    #       dial_timeout_ms: 5000
-    #       # read_timeout_ms is the timeout for socket reads. If reached, commands will fail with a timeout instead of blocking.
-    #       read_timeout_ms: 3000
-    #       # write_timeout_ms is the timeout for socket writes. If reached, commands will fail with a timeout instead of blocking.
-    #       write_timeout_ms: 3000
+    #       # min_retry_backoff is the minimum backoff time between each retry
+    #       min_retry_backoff: 8ms
+    #       # max_retry_backoff is the maximum backoff time between each retry
+    #       max_retry_backoff: 512ms
+    #       # dial_timeout is the timeout for establishing new connections
+    #       dial_timeout: 5000ms
+    #       # read_timeout is the timeout for socket reads. If reached, commands will fail with a timeout instead of blocking.
+    #       read_timeout: 3000ms
+    #       # write_timeout is the timeout for socket writes. If reached, commands will fail with a timeout instead of blocking.
+    #       write_timeout: 3000ms
     #       # pool_size is the maximum number of socket connections.
     #       pool_size: 20
     #       # min_idle_conns is the minimum number of idle connections which is useful when establishing new connection is slow.
     #       min_idle_conns: 0
-    #       # max_conn_age_ms is the connection age at which client retires (closes) the connection.
-    #       max_conn_age_ms: 0
-    #       # pool_timeout_ms is the amount of time client waits for connection if all connections are busy before returning an error.
-    #       pool_timeout_ms: 4000
-    #       # idle_timeout_ms is the amount of time after which client closes idle connections.
-    #       idle_timeout_ms: 300000
-    #       # idle_check_frequency_ms is the frequency of idle checks made by idle connections reaper.
-    #       idle_check_frequency_ms: 60000
+    #       # max_conn_age is the connection age at which client retires (closes) the connection.
+    #       max_conn_age: 0ms
+    #       # pool_timeout is the amount of time client waits for connection if all connections are busy before returning an error.
+    #       pool_timeout: 4000ms
+    #       # idle_timeout is the amount of time after which client closes idle connections.
+    #       idle_timeout: 300000ms
+    #       # idle_check_frequency is the frequency of idle checks made by idle connections reaper.
+    #       idle_check_frequency: 60000ms
 
     #     ## Configuration options when using a Filesystem Cache ###############
     #     filesystem:
@@ -191,8 +191,8 @@ data:
     #       bucket: trickster
 
     #     index:
-    #       reap_interval_ms: 3000
-    #       flush_interval_ms: 5000
+    #       reap_interval: 3000ms
+    #       flush_interval: 5000ms
     #       max_size_bytes: 536870912
     #       size_backoff_bytes: 16777216
 
@@ -293,19 +293,19 @@ data:
     #     compressable_types:
     #     - text/javascript, text/css, text/plain, text/xml, text/json, application/json, application/javascript, application/xml ]
 
-    #     # timeout_ms defines how long Trickster will wait before aborting and upstream http request. Default: 180s
-    #     timeout_ms: 180000
+    #     # timeout defines how long Trickster will wait before aborting and upstream http request. Default: 180s
+    #     timeout: 180000ms
 
-    #     # keep_alive_timeout_ms defines how long Trickster will wait before closing a keep-alive connection due to inactivity
+    #     # keep_alive_timeout defines how long Trickster will wait before closing a keep-alive connection due to inactivity
     #     # if the origins keep-alive timeout is shorter than Tricksters, the connect will be closed sooner. Default: 300
-    #     keep_alive_timeout_ms: 300000
+    #     keep_alive_timeout: 300000ms
 
     #     # max_idle_conns set the maximum concurrent keep-alive connections Trickster may have opened to this backend
     #     # additional requests will be queued. Default: 20
     #     max_idle_conns: 20
 
-    #     # max_ttl_ms defines the maximum allowed TTL for any object cached for this backend. default is 86400
-    #     max_ttl_ms: 86400000
+    #     # max_ttl defines the maximum allowed TTL for any object cached for this backend. default is 86400
+    #     max_ttl: 86400000ms
 
     #     # revalidation_factor is the multiplier for object lifetime expiration to determine cache object TTL; default is 2
     #     # for example, if a revalidatable object has Cache-Control: max-age=300, we will cache for 10 minutes (300s * 2)
@@ -317,16 +317,16 @@ data:
 
     #     # These next 6 settings only apply to Time Series backends
 
-    #     # backfill_tolerance_ms prevents new datapoints that fall within the tolerance window (relative to time.Now) from being cached
+    #     # backfill_tolerance prevents new datapoints that fall within the tolerance window (relative to time.Now) from being cached
     #     # Think of it as "never cache the newest N milliseconds of real-time data, because it may be preliminary and subject to updates"
     #     # default is 0
-    #     backfill_tolerance_ms: 0
+    #     backfill_tolerance: 0ms
 
     #     # timeseries_retention_factor defines the maximum number of recent timestamps to cache for a given query. Default is 1024
     #     timeseries_retention_factor: 1024
 
-    #     # timeseries_ttl_ms defines the relative expiration of cached timeseries. default is 6 hours (21600 seconds)
-    #     timeseries_ttl_ms: 21600000
+    #     # timeseries_ttl defines the relative expiration of cached timeseries. default is 6 hours (21600 seconds)
+    #     timeseries_ttl: 21600000ms
 
     #     # timeseries_eviction_method selects the metholodogy used to determine which timestamps are removed once
     #     # the timeseries_retention_factor limit is reached. options are oldest and lru. Default is oldest
@@ -335,26 +335,26 @@ data:
     #     # fast_forward_disable, when set to true, will turn off the fast forward feature for any requests proxied to this backend
     #     fast_forward_disable: false
 
-    #     # fastforward_ttl_ms defines the relative expiration of cached fast forward data. default is 15s
-    #     fastforward_ttl_ms: 15000
+    #     # fastforward_ttl defines the relative expiration of cached fast forward data. default is 15s
+    #     fastforward_ttl: 15000ms
 
     #     # shard_max_size_points defines the maximum size of a timeseries request in unique timestamps,
     #     # before sharding into multiple requests of this denomination and reconsitituting the results.
-    #     # If shard_max_size_points and shard_max_size_ms are both > 0, the configuration is invalid.
+    #     # If shard_max_size_points and shard_max_size are both > 0, the configuration is invalid.
     #     # default is 0
     #     shard_max_size_points: 0
 
-    #     # shard_max_size_ms defines the max size of a timeseries request in milliseconds,
+    #     # shard_max_size defines the max size of a timeseries request in milliseconds,
     #     # before sharding into multiple requests of this denomination and reconsitituting the results.
-    #     # If shard_max_size_ms and shard_max_size_points are both > 0, the configuration is invalid.
+    #     # If shard_max_size and shard_max_size_points are both > 0, the configuration is invalid.
     #     # default is 0
-    #     shard_max_size_ms: 0
+    #     shard_max_size: 0ms
 
-    #     # shard_step_ms defines the epoch-aligned cadence to use when creating shards. When set to 0,
-    #     # shards are not aligned to the epoch at a specific step. shard_max_size_ms must be perfectly
-    #     # divisible by shard_step_ms when both are > 0, or the configuration is invalid.
+    #     # shard_step defines the epoch-aligned cadence to use when creating shards. When set to 0,
+    #     # shards are not aligned to the epoch at a specific step. shard_max_size must be perfectly
+    #     # divisible by shard_step when both are > 0, or the configuration is invalid.
     #     # default is 0
-    #     shard_step_ms: 0
+    #     shard_step: 0ms
 
     #     #
     #     # Each backend provider implements their own defaults for health_check_upstream_url, health_check_verb and health_check_query,
@@ -451,8 +451,8 @@ data:
     #     negative_cache_name: general
     #     timeseries_retention_factor: 1024
     #     timeseries_eviction_method: oldest
-    #     timeout_ms: 180000
-    #     backfill_tolerance_ms: 180000
+    #     timeout: 180000ms
+    #     backfill_tolerance: 180000ms
     #     tracing_name: example
 
     # # Configuration Options for Request Routing Rules - see /docs/rule.md for more information
@@ -516,10 +516,10 @@ data:
     #     # required for Zipkin and OTLP, unused for stdout
     #     endpoint: http://jaeger:14268/api/traces
 
-    #     # timeout_ms is the amount of time in milliseconds for the tracing post
+    #     # timeout is the amount of time in milliseconds for the tracing post
     #     # to wait for a response before timing out
     #     # default is no timeout set
-    #     timeout_ms: 5000
+    #     timeout: 5000ms
 
     #     # headers is a list of http headers to include in the tracing post
     #     # default is none
@@ -595,14 +595,14 @@ data:
     #   # handler_path defines the HTTP path where the Reload interface is available.
     #   # by default, this is /trickster/config/reload
     #   handler_path: /trickster/config/reload
-    #   # drain_timeout_ms defines how long old HTTP listeners will live to allow
+    #   # drain_timeout defines how long old HTTP listeners will live to allow
     #   # outstanding connection to close organically, before the listener is forcefully closed
     #   # the default is 30
-    #   drain_timeout_ms: 30000
-    #   # rate_limit_ms specifies the rate limit timeout duration to apply to the HTTP reload interface.
+    #   drain_timeout: 30000ms
+    #   # rate_limit specifies the rate limit timeout duration to apply to the HTTP reload interface.
     #   # The reload interface is disabled for this duration of time whenever a config reload request is
     #   # made that fails because the underlying config file is unmodified. default is 3
-    #   rate_limit_ms: 3000
+    #   rate_limit: 3000ms
 
     # # Configuration Options for Logging Instrumentation
     # logging:

--- a/docs/alb.md
+++ b/docs/alb.md
@@ -282,13 +282,13 @@ backends:
     provider: prometheus
     origin_url: http://prom01.example.com:9090
     healthcheck:
-      interval_ms: 1000 # enables automatic health check polling for ALB pool reporting
+      interval: 1000ms # enables automatic health check polling for ALB pool reporting
 
   prom02:
     provider: prometheus
     origin_url: http://prom02.example.com:9090
     healthcheck:
-      interval_ms: 1000
+      interval: 1000ms
 
   prom-alb-tsm:
     provider: alb
@@ -317,13 +317,13 @@ backends:
     provider: prometheus
     origin_url: http://prom01.example.com:9090
     healthcheck:
-      interval_ms: 1000 # enables automatic health check polling every 1s
+      interval: 1000ms # enables automatic health check polling every 1s
 
   flux-01:
     provider: inflxudb
     origin_url: http://flux01.example.com:8086
     healthcheck:
-      interval_ms: 1000 # enables automatic health check polling every 1s
+      interval: 1000ms # enables automatic health check polling every 1s
 ```
 
 ```text

--- a/docs/chunked_caching.md
+++ b/docs/chunked_caching.md
@@ -1,7 +1,7 @@
 # Chunked Caching
 
 ## Overview
-In some caching setups, users may want to increase `timeseries_retention_factor` or `timeseries_ttl_ms` for a given backend to a very large size (e.g., a duration of days or weeks). This can cause issues if the cache provider is
+In some caching setups, users may want to increase `timeseries_retention_factor` or `timeseries_ttl` forms a given backend to a very large size (e.g., a duration of days or weeks). This can cause issues if the cache provider is
 `filesystem` or `redis`, because the entire time series is loaded to extract
 even just a few data points. Eventually, this could negate the effects of
 caching altogether.
@@ -122,8 +122,8 @@ tracing:
 
 backends:
   prom1:
-    latency_max_ms: 150
-    latency_min_ms: 50
+    latency_max: 150ms
+    latency_min: 50ms
     provider: prometheus
     origin_url: 'http://127.0.0.1:9090'
     cache_name: fs1
@@ -137,7 +137,7 @@ backends:
     provider: influxdb
     origin_url: 'http://127.0.0.1:8086'
     cache_name: mem1
-    backfill_tolerance_ms: 30000
+    backfill_tolerance: 30000ms
     timeseries_retention_factor: 5184000
 
 logging:

--- a/docs/developer/environment/trickster-config/trickster.yaml
+++ b/docs/developer/environment/trickster-config/trickster.yaml
@@ -84,7 +84,7 @@ backends:
         - lm1
         - lm2
   alb3:
-    latency_min_ms: 300
+    latency_min: 300ms
     provider: alb
     alb:
       mechanism: tsm
@@ -104,7 +104,7 @@ backends:
     provider: clickhouse
     origin_url: 'http://127.0.0.1:8123'
     cache_name: mem1
-    backfill_tolerance_ms: 60000
+    backfill_tolerance: 60000ms
     timeseries_retention_factor: 2048
   rp1:
     provider: proxy
@@ -113,8 +113,8 @@ backends:
     provider: rpc
     origin_url: 'http://127.0.0.1:9090'
   prom1:
-    latency_max_ms: 150
-    latency_min_ms: 50
+    latency_max: 150ms
+    latency_min: 50ms
     is_default: true
     provider: prometheus
     origin_url: 'http://127.0.0.1:9090'
@@ -127,13 +127,13 @@ backends:
     provider: influxdb
     origin_url: 'http://127.0.0.1:8186/'
     cache_name: mem1
-    backfill_tolerance_ms: 30000
+    backfill_tolerance: 30000ms
     timeseries_retention_factor: 5184000
   flux2:
     provider: influxdb
     origin_url: 'http://127.0.0.1:8086/'
     cache_name: mem1
-    backfill_tolerance_ms: 30000
+    backfill_tolerance: 30000ms
     timeseries_retention_factor: 5184000
   sim1:
     provider: prometheus
@@ -141,12 +141,12 @@ backends:
     cache_name: mem1
     max_idle_conns: 600
     timeseries_retention_factor: 5184000
-    timeseries_ttl_ms: 259200000
-    max_ttl_ms: 86400000
+    timeseries_ttl: 259200000ms
+    max_ttl: 86400000ms
     max_object_size_bytes: 67108864
     healthcheck:
-      interval_ms: 300
-      timeout_ms: 500
+      interval: 300ms
+      timeout: 500ms
     # uncomment and set certs to test TLS
     # tls:
     #   full_chain_cert_path: >-
@@ -164,8 +164,8 @@ backends:
     cache_name: mem1
     max_idle_conns: 600
     timeseries_retention_factor: 5184000
-    timeseries_ttl_ms: 259200000
-    max_ttl_ms: 86400000
+    timeseries_ttl: 259200000ms
+    max_ttl: 86400000ms
     max_object_size_bytes: 67108864
   lm1:
     provider: reverseproxycache

--- a/docs/health.md
+++ b/docs/health.md
@@ -60,7 +60,7 @@ backends:
       ## customizing the expected response
       #
       # hc fails if a response takes longer than 1s
-      timeout_ms: 1000
+      timeout: 1000ms
       # hc fails if the response code is not in the list
       expected_codes: [ 200, 204, 206, 301, 302, 304 ]
       #
@@ -89,9 +89,9 @@ backends:
     origin_url: http://server1
     healthcheck:
       path: /health
-      timeout_ms: 1000      # timeout_ms should be <= interval_ms
+      timeout: 1000ms      # timeout should be <= interval
       # for ALB integration:
-      interval_ms: 1000     # auto-poll health every 1s
+      interval: 1000ms     # auto-poll health every 1s
       failure_threshold: 3  # backend is unhealthy after 3 consecutive failures
       recovery_threshold: 3 # backend is healthy after 3 consecutive successes
 ```

--- a/docs/new-changed-2.0.md
+++ b/docs/new-changed-2.0.md
@@ -80,7 +80,10 @@ Using [tricktool](http://github.com/trickstercache/tricktool) to migrate your co
 
 - <https://www.convertsimple.com/convert-toml-to-yaml/> is a good starting point
 - The `[origins]` section of the Trickster 1.x TOML config is named `backends:` in the 2.0 YAML config
-- All duration-based values are now represented in milliseconds. 1.x values ending in `_secs` are the same in 2.0 but end in `_ms`. Be sure to multiply by 1000
+- All duration-based values are now represented in nanoseconds or as 'duration strings'.
+  - A duration string is a possibly signed sequence of decimals, with one or more optional unit suffixes. Example: `1s500ms`
+    - Supported time units: `"ns", "us" (or "µs"), "ms", "s", "m", "h"`
+  - 1.x values ending in `_secs` are the same in 2.0 but have no unit suffix (`timeout_secs` -> `timeout`). Be sure to add a unit -- `10 -> 10s`.
 - `origin_type`, `cache_type` and `tracing_type` are now called `provider`.
 - Health checking configurations now reside in their own `healthcheck` subsection under `backends` and use simplified config names like `method`, `path`, etc.
 

--- a/docs/new-changed-2.0.md
+++ b/docs/new-changed-2.0.md
@@ -30,7 +30,7 @@
   - Also supported by standard Reverse Proxy Cache for chunking objects by Byte Range
   - Disabled by default
 - We now support [Time Series Backend Request Sharding](./timeseries_sharding.md)
-  - Allows requests proxied to Time Series Backends to be chunked into multiple concurrent based on a configurable chunk size in milliseconds or data points.
+  - Allows requests proxied to Time Series Backends to be chunked into multiple concurrent based on a configurable chunk size in arbitrary time units (milliseconds, seconds, etc) or by data points.
   - Backend Responses are merged into a single response before caching
   - Disabled by default
   - You can use Cache Chunking and TS Backend Request Sharding in any combination (on/on, on/off, off/on, off/0ff) as theywork together seamlessly. They can be configured with the same or different chunk sizes.

--- a/docs/simulated-latency.md
+++ b/docs/simulated-latency.md
@@ -6,11 +6,11 @@ In `rule`, `alb` and other backend providers, where a request may transit multip
 
 ## Consistent Latency Duration
 
-In the Backend configuration, add a `latency_min_ms` value > 0, and the configured amount of latency will be introduced for each incoming request.
+In the Backend configuration, add a `latency_min` value > 0, and the configured amount of latency will be introduced for each incoming request.
 
 ## Random Latency
 
- To simulate random latency, set `latency_max_ms` to a value > `latency_min_ms`, which may be 0 for random latency. Trickster will introduce a random amount of latency between (inclusive) the provided min and max values.
+ To simulate random latency, set `latency_max` to a value > `latency_min`, which may be 0 for random latency. Trickster will introduce a random amount of latency between (inclusive) the provided min and max values.
 
 ## Response Header
 
@@ -40,13 +40,13 @@ backends:
     provider: reverseproxy
     #
     # introduce random latency between 50 and 150 milliseconds on each request
-    latency_min_ms: 50
-    latency_max_ms: 150
+    latency_min: 50ms
+    latency_max: 150ms
 
   backend2:
     origin_url: https://www.trickstercache.org
     provider: reverseproxy
     #
     # introduce latency of 300 milliseconds on each request
-    latency_min_ms: 300
+    latency_min: 300ms
 ```

--- a/docs/timeseries_sharding.md
+++ b/docs/timeseries_sharding.md
@@ -40,37 +40,37 @@ backends:
 
 ### Maximum Time Range Width Per Shard
 
-In the Trickster configuration, use the `shard_max_size_ms` configuration to shard requests by limiting the maximum width of each sharded request's time range.
+In the Trickster configuration, use the `shard_max_size` configuration to shard requests by limiting the maximum width of each sharded request's time range.
 
 ```yaml
 backends:
   example:
     provider: 'prometheus'
     origin_url: http://prometheus:9090
-    shard_max_size_ms: 7200000
+    shard_max_size: 7200000ms
 ```
 
 ### Epoch-Aligned Maximum Time Range Width Per Shard
 
-In the Trickster configuration, use the `shard_step_ms` configuration to shard requests by limiting the maximum width of each sharded request's time range, while ensuring shards align with the epoch on the configured cadence. This is useful for aligning shard boundaries with an upstream database's partition boundaries, ensuring that sharded requests have as little partition overlap as possible.
+In the Trickster configuration, use the `shard_step` configuration to shard requests by limiting the maximum width of each sharded request's time range, while ensuring shards align with the epoch on the configured cadence. This is useful for aligning shard boundaries with an upstream database's partition boundaries, ensuring that sharded requests have as little partition overlap as possible.
 
 ```yaml
 backends:
   example:
     provider: 'prometheus'
     origin_url: http://prometheus:9090
-    shard_step_ms: 7200000
+    shard_step: 7200000ms
 ```
 
-`shard_step_ms` can be used in conjunction with `shard_max_size_ms`, so long as `shard_max_size_ms` is perfectly divisible by `shard_step_ms`. This combination configuration will align shards against the configured shard step, while sizing each shard's time range to be multiple shard steps wide.
+`shard_step` can be used in conjunction with `shard_max_size`, so long as `shard_max_size` is perfectly divisible by `shard_step`. This combination configuration will align shards against the configured shard step, while sizing each shard's time range to be multiple shard steps wide.
 
 ```yaml
 backends:
   example:
     provider: 'prometheus'
     origin_url: http://prometheus:9090
-    shard_step_ms: 7200000
-    shard_max_size_ms: 14400000
+    shard_step: 7200000ms
+    shard_max_size: 14400000ms
 ```
 
-Neither `shard_step_ms` or `shard_max_size_ms` can be used in conjunction with `shard_max_size_points`.
+Neither `shard_step` or `shard_max_size` can be used in conjunction with `shard_max_size_points`.

--- a/examples/conf/example.alb.yaml
+++ b/examples/conf/example.alb.yaml
@@ -35,13 +35,13 @@ backends:
     provider: prometheus
     origin_url: "http://prom1:9090"
     healthcheck:
-      interval_ms: 1000
+      interval: 1000ms
       
   prom2:
     provider: prometheus
     origin_url: "http://prom2:9090"
     healthcheck:
-      interval_ms: 1000
+      interval: 1000ms
 
   ## 
 
@@ -50,12 +50,12 @@ backends:
     origin_url: "https://origin1/"
     healthcheck:
       path: /health
-      interval_ms: 1000
+      interval: 1000ms
 
   origin2:
     provider: rp # this one will not go through the cache
     origin_url: "http://origin2" # and will not use TLS
     healthcheck:
       path: /health
-      interval_ms: 1000
+      interval: 1000ms
   

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -79,10 +79,10 @@ frontend:
 #     # The Cache Index handles key management and retention for bbolt, filesystem and memory
 #     # Redis and BadgerDB handle those functions natively and does not use the Tricksters Cache Index
 #     index:
-#       # reap_interval_ms defines how long the Cache Index reaper sleeps between reap cycles. Default is 3 (3s)
-#       reap_interval_ms: 3000
-#       # flush_interval_ms sets how often the Cache Index saves its metadata to the cache from application memory. Default is 5 (5s)
-#       flush_interval_ms: 5000
+#       # reap_interval defines how long the Cache Index reaper sleeps between reap cycles. Default is 3 (3s)
+#       reap_interval: 3000ms
+#       # flush_interval sets how often the Cache Index saves its metadata to the cache from application memory. Default is 5 (5s)
+#       flush_interval: 5000ms
 #       # max_size_bytes indicates how large the cache can grow in bytes before the Index evicts least-recently-accessed items. default is 512MB
 #       max_size_bytes: 536870912
 #       # max_size_backoff_bytes indicates how far below max_size_bytes the cache size must be to complete a byte-size-based eviction exercise. default is 16MB
@@ -131,28 +131,28 @@ frontend:
 #       db: 0
 #       # max_retries is the maximum number of retries before giving up on the command
 #       max_retries: 0
-#       # min_retry_backoff_ms is the minimum backoff time between each retry
-#       min_retry_backoff_ms: 8
-#       # max_retry_backoff_ms is the maximum backoff time between each retry
-#       max_retry_backoff_ms: 512
-#       # dial_timeout_ms is the timeout for establishing new connections
-#       dial_timeout_ms: 5000
-#       # read_timeout_ms is the timeout for socket reads. If reached, commands will fail with a timeout instead of blocking.
-#       read_timeout_ms: 3000
-#       # write_timeout_ms is the timeout for socket writes. If reached, commands will fail with a timeout instead of blocking.
-#       write_timeout_ms: 3000
+#       # min_retry_backoff is the minimum backoff time between each retry
+#       min_retry_backoff: 8ms
+#       # max_retry_backoff is the maximum backoff time between each retry
+#       max_retry_backoff: 512ms
+#       # dial_timeout is the timeout for establishing new connections
+#       dial_timeout: 5000ms
+#       # read_timeout is the timeout for socket reads. If reached, commands will fail with a timeout instead of blocking.
+#       read_timeout: 3000ms
+#       # write_timeout is the timeout for socket writes. If reached, commands will fail with a timeout instead of blocking.
+#       write_timeout: 3000ms
 #       # pool_size is the maximum number of socket connections.
-#       pool_size: 20
+#       pool_size: 20ms
 #       # min_idle_conns is the minimum number of idle connections which is useful when establishing new connection is slow.
 #       min_idle_conns: 0
-#       # max_conn_age_ms is the connection age at which client retires (closes) the connection.
-#       max_conn_age_ms: 0
-#       # pool_timeout_ms is the amount of time client waits for connection if all connections are busy before returning an error.
-#       pool_timeout_ms: 4000
-#       # idle_timeout_ms is the amount of time after which client closes idle connections.
-#       idle_timeout_ms: 300000
-#       # idle_check_frequency_ms is the frequency of idle checks made by idle connections reaper.
-#       idle_check_frequency_ms: 60000
+#       # max_conn_age is the connection age at which client retires (closes) the connection.
+#       max_conn_age: 0ms
+#       # pool_timeout is the amount of time client waits for connection if all connections are busy before returning an error.
+#       pool_timeout: 4000ms
+#       # idle_timeout is the amount of time after which client closes idle connections.
+#       idle_timeout: 300000ms
+#       # idle_check_frequency is the frequency of idle checks made by idle connections reaper.
+#       idle_check_frequency: 60000ms
 
 #     ## Configuration options when using a Filesystem Cache ###############
 #     filesystem:
@@ -198,8 +198,8 @@ frontend:
 #       bucket: trickster
 
 #     index:
-#       reap_interval_ms: 3000
-#       flush_interval_ms: 5000
+#       reap_interval: 3000ms
+#       flush_interval: 5000ms
 #       max_size_bytes: 536870912
 #       size_backoff_bytes: 16777216
 
@@ -305,19 +305,19 @@ backends:
 #     compressable_types:
 #     - text/javascript, text/css, text/plain, text/xml, text/json, application/json, application/javascript, application/xml ]
 
-#     # timeout_ms defines how long Trickster will wait before aborting and upstream http request. Default: 180s
-#     timeout_ms: 180000
+#     # timeout defines how long Trickster will wait before aborting and upstream http request. Default: 180s
+#     timeout: 180000ms
 
-#     # keep_alive_timeout_ms defines how long Trickster will wait before closing a keep-alive connection due to inactivity
+#     # keep_alive_timeout defines how long Trickster will wait before closing a keep-alive connection due to inactivity
 #     # if the origins keep-alive timeout is shorter than Tricksters, the connect will be closed sooner. Default: 300
-#     keep_alive_timeout_ms: 300000
+#     keep_alive_timeout: 300000ms
 
 #     # max_idle_conns set the maximum concurrent keep-alive connections Trickster may have opened to this backend
 #     # additional requests will be queued. Default: 20
 #     max_idle_conns: 20
 
-#     # max_ttl_ms defines the maximum allowed TTL for any object cached for this backend. default is 86400
-#     max_ttl_ms: 86400000
+#     # max_ttl defines the maximum allowed TTL for any object cached for this backend. default is 86400
+#     max_ttl: 86400000ms
 
 #     # revalidation_factor is the multiplier for object lifetime expiration to determine cache object TTL; default is 2
 #     # for example, if a revalidatable object has Cache-Control: max-age=300, we will cache for 10 minutes (300s * 2)
@@ -329,20 +329,20 @@ backends:
 
 #     # These next 7 settings only apply to Time Series backends
 
-#     # backfill_tolerance_ms prevents new datapoints that fall within the tolerance window (relative to time.Now) from being permanently
+#     # backfill_tolerance prevents new datapoints that fall within the tolerance window (relative to time.Now) from being permanently
 #     # cached. Think of it as "the newest N milliseconds of real-time data are preliminary and subject to updates, so refresh them periodically"
 #     # default is 0
-#     backfill_tolerance_ms: 0
+#     backfill_tolerance: 0ms
 
-#     # backfill_tolerance_points works like the _ms version, except the methodology is based on # of intervaled timestamps (points) in the series
+#     # backfill_tolerance_points works like the  version, except the methodology is based on # of intervaled timestamps (points) in the series
 #     # instead of a relative time. You can set both values and the one impacting the most number of elements in the time series takes precedence
 #     backfill_tolerance_points: 0
 
 #     # timeseries_retention_factor defines the maximum number of recent timestamps to cache for a given query. Default is 1024
 #     timeseries_retention_factor: 1024
 
-#     # timeseries_ttl_ms defines the relative expiration of cached timeseries. default is 6 hours (21600 seconds)
-#     timeseries_ttl_ms: 21600000
+#     # timeseries_ttl defines the relative expiration of cached timeseries. default is 6 hours (21600 seconds)
+#     timeseries_ttl: 21600000ms
 
 #     # timeseries_eviction_method selects the metholodogy used to determine which timestamps are removed once
 #     # the timeseries_retention_factor limit is reached. options are oldest and lru. Default is oldest
@@ -351,32 +351,32 @@ backends:
 #     # fast_forward_disable, when set to true, will turn off the fast forward feature for any requests proxied to this backend
 #     fast_forward_disable: false
 
-#     # fastforward_ttl_ms defines the relative expiration of cached fast forward data. default is 15s
-#     fastforward_ttl_ms: 15000
+#     # fastforward_ttl defines the relative expiration of cached fast forward data. default is 15s
+#     fastforward_ttl: 15000ms
 
 #     # shard_max_size_points defines the maximum size of a timeseries request in unique timestamps,
 #     # before sharding into multiple requests of this denomination and reconsitituting the results.
-#     # If shard_max_size_points and shard_max_size_ms are both > 0, the configuration is invalid.
+#     # If shard_max_size_points and shard_max_size are both > 0, the configuration is invalid.
 #     # default is 0
 #     shard_max_size_points: 0
 
-#     # shard_max_size_ms defines the max size of a timeseries request in milliseconds,
+#     # shard_max_size defines the max size of a timeseries request in milliseconds,
 #     # before sharding into multiple requests of this denomination and reconsitituting the results.
-#     # If shard_max_size_ms and shard_max_size_points are both > 0, the configuration is invalid.
+#     # If shard_max_size and shard_max_size_points are both > 0, the configuration is invalid.
 #     # default is 0
-#     shard_max_size_ms: 0
+#     shard_max_size: 0ms
 
-#     # shard_step_ms defines the epoch-aligned cadence to use when creating shards. When set to 0,
-#     # shards are not aligned to the epoch at a specific step. shard_max_size_ms must be perfectly
-#     # divisible by shard_step_ms when both are > 0, or the configuration is invalid.
+#     # shard_step defines the epoch-aligned cadence to use when creating shards. When set to 0,
+#     # shards are not aligned to the epoch at a specific step. shard_max_size must be perfectly
+#     # divisible by shard_step when both are > 0, or the configuration is invalid.
 #     # default is 0
-#     shard_step_ms: 0
+#     shard_step: 0ms
 
 #     # Simulated Latency
-#     # set latency_min_ms > 0 to apply a consistent latency to each request to this backend
-#     # set latency_max_ms > latency_max_ms (which can be 0) to apply a random latency between the two
-#     latency_max_ms = 0
-#     latency_max_ms = 0
+#     # set latency_min > 0 to apply a consistent latency to each request to this backend
+#     # set latency_max > latency_max (which can be 0) to apply a random latency between the two
+#     latency_max = 0
+#     latency_max = 0
 
 #     #
 #     # Each backend provider implements their own defaults for health checking
@@ -421,9 +421,9 @@ backends:
 
 #       ## Crafting a Healthy Response Profile
 
-#       # timeout_ms is the maximum during the health checker will wait for a response before aborting the check
+#       # timeout is the maximum during the health checker will wait for a response before aborting the check
 #       # default is 3s
-#       timeout_ms: 3000
+#       timeout: 3000ms
 
 #       # expected_codes is the list of acceptable HTTP response codes when health checking the backend
 #       # for considering the backend healthy
@@ -512,14 +512,14 @@ backends:
 #     provider: reverseproxy
 #     origin_url: http://foo-origin-01
 #     healthcheck:
-#       interval_ms: 1000
+#       interval: 1000ms
 
 #   foo-02.example.com:
 #     is_default: false
 #     provider: reverseproxy
 #     origin_url: http://foo-origin-02
 #     healthcheck:
-#       interval_ms: 1000
+#       interval: 1000ms
 
 # # Application Load Balancer Backend configuration options, see /docs/alb.md for more information
 #
@@ -615,10 +615,10 @@ backends:
 #     # required for Zipkin and OTLP, unused for stdout
 #     endpoint: http://jaeger:14268/api/traces
 
-#     # timeout_ms is the amount of time in milliseconds for the tracing post
+#     # timeout is the amount of time in milliseconds for the tracing post
 #     # to wait for a response before timing out
 #     # default is no timeout set
-#     timeout_ms: 5000
+#     timeout: 5000ms
 
 #     # headers is a list of http headers to include in the tracing post
 #     # default is none
@@ -686,14 +686,14 @@ backends:
 #   # handler_path defines the HTTP path where the Reload interface is available.
 #   # by default, this is /trickster/config/reload
 #   handler_path: /trickster/config/reload
-#   # drain_timeout_ms defines how long old HTTP listeners will live to allow
+#   # drain_timeout defines how long old HTTP listeners will live to allow
 #   # outstanding connection to close organically, before the listener is forcefully closed
 #   # the default is 30
-#   drain_timeout_ms: 30000
-#   # rate_limit_ms specifies the rate limit timeout duration to apply to the HTTP reload interface.
+#   drain_timeout: 30000ms
+#   # rate_limit specifies the rate limit timeout duration to apply to the HTTP reload interface.
 #   # The reload interface is disabled for this duration of time whenever a config reload request is
 #   # made that fails because the underlying config file is unmodified. default is 3
-#   rate_limit_ms: 3000
+#   rate_limit: 3000ms
 
 # # Configuration Options for Logging Instrumentation
 # logging:

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -80,9 +80,9 @@ frontend:
 #     # Redis and BadgerDB handle those functions natively and does not use the Tricksters Cache Index
 #     index:
 #       # reap_interval defines how long the Cache Index reaper sleeps between reap cycles. Default is 3 (3s)
-#       reap_interval: 3000ms
+#       reap_interval: 3s
 #       # flush_interval sets how often the Cache Index saves its metadata to the cache from application memory. Default is 5 (5s)
-#       flush_interval: 5000ms
+#       flush_interval: 5s
 #       # max_size_bytes indicates how large the cache can grow in bytes before the Index evicts least-recently-accessed items. default is 512MB
 #       max_size_bytes: 536870912
 #       # max_size_backoff_bytes indicates how far below max_size_bytes the cache size must be to complete a byte-size-based eviction exercise. default is 16MB
@@ -136,11 +136,11 @@ frontend:
 #       # max_retry_backoff is the maximum backoff time between each retry
 #       max_retry_backoff: 512ms
 #       # dial_timeout is the timeout for establishing new connections
-#       dial_timeout: 5000ms
+#       dial_timeout: 5s
 #       # read_timeout is the timeout for socket reads. If reached, commands will fail with a timeout instead of blocking.
-#       read_timeout: 3000ms
+#       read_timeout: 3s
 #       # write_timeout is the timeout for socket writes. If reached, commands will fail with a timeout instead of blocking.
-#       write_timeout: 3000ms
+#       write_timeout: 3s
 #       # pool_size is the maximum number of socket connections.
 #       pool_size: 20ms
 #       # min_idle_conns is the minimum number of idle connections which is useful when establishing new connection is slow.
@@ -148,11 +148,11 @@ frontend:
 #       # max_conn_age is the connection age at which client retires (closes) the connection.
 #       max_conn_age: 0ms
 #       # pool_timeout is the amount of time client waits for connection if all connections are busy before returning an error.
-#       pool_timeout: 4000ms
+#       pool_timeout: 4s
 #       # idle_timeout is the amount of time after which client closes idle connections.
-#       idle_timeout: 300000ms
+#       idle_timeout: 5m
 #       # idle_check_frequency is the frequency of idle checks made by idle connections reaper.
-#       idle_check_frequency: 60000ms
+#       idle_check_frequency: 1m
 
 #     ## Configuration options when using a Filesystem Cache ###############
 #     filesystem:
@@ -198,8 +198,8 @@ frontend:
 #       bucket: trickster
 
 #     index:
-#       reap_interval: 3000ms
-#       flush_interval: 5000ms
+#       reap_interval: 3s
+#       flush_interval: 5s
 #       max_size_bytes: 536870912
 #       size_backoff_bytes: 16777216
 
@@ -306,18 +306,18 @@ backends:
 #     - text/javascript, text/css, text/plain, text/xml, text/json, application/json, application/javascript, application/xml ]
 
 #     # timeout defines how long Trickster will wait before aborting and upstream http request. Default: 180s
-#     timeout: 180000ms
+#     timeout: 180s
 
 #     # keep_alive_timeout defines how long Trickster will wait before closing a keep-alive connection due to inactivity
 #     # if the origins keep-alive timeout is shorter than Tricksters, the connect will be closed sooner. Default: 300
-#     keep_alive_timeout: 300000ms
+#     keep_alive_timeout: 5m
 
 #     # max_idle_conns set the maximum concurrent keep-alive connections Trickster may have opened to this backend
 #     # additional requests will be queued. Default: 20
 #     max_idle_conns: 20
 
-#     # max_ttl defines the maximum allowed TTL for any object cached for this backend. default is 86400
-#     max_ttl: 86400000ms
+#     # max_ttl defines the maximum allowed TTL for any object cached for this backend. default is 24 hours
+#     max_ttl: 24h
 
 #     # revalidation_factor is the multiplier for object lifetime expiration to determine cache object TTL; default is 2
 #     # for example, if a revalidatable object has Cache-Control: max-age=300, we will cache for 10 minutes (300s * 2)
@@ -331,7 +331,7 @@ backends:
 
 #     # backfill_tolerance prevents new datapoints that fall within the tolerance window (relative to time.Now) from being permanently
 #     # cached. Think of it as "the newest N milliseconds of real-time data are preliminary and subject to updates, so refresh them periodically"
-#     # default is 0
+#     # default is 0ms
 #     backfill_tolerance: 0ms
 
 #     # backfill_tolerance_points works like the  version, except the methodology is based on # of intervaled timestamps (points) in the series
@@ -342,7 +342,7 @@ backends:
 #     timeseries_retention_factor: 1024
 
 #     # timeseries_ttl defines the relative expiration of cached timeseries. default is 6 hours (21600 seconds)
-#     timeseries_ttl: 21600000ms
+#     timeseries_ttl: 6h
 
 #     # timeseries_eviction_method selects the metholodogy used to determine which timestamps are removed once
 #     # the timeseries_retention_factor limit is reached. options are oldest and lru. Default is oldest
@@ -352,24 +352,24 @@ backends:
 #     fast_forward_disable: false
 
 #     # fastforward_ttl defines the relative expiration of cached fast forward data. default is 15s
-#     fastforward_ttl: 15000ms
+#     fastforward_ttl: 15s
 
 #     # shard_max_size_points defines the maximum size of a timeseries request in unique timestamps,
 #     # before sharding into multiple requests of this denomination and reconsitituting the results.
-#     # If shard_max_size_points and shard_max_size are both > 0, the configuration is invalid.
+#     # If shard_max_size_points and shard_max_size_time are both > 0, the configuration is invalid.
 #     # default is 0
 #     shard_max_size_points: 0
 
-#     # shard_max_size defines the max size of a timeseries request in milliseconds,
+#     # shard_max_size_time defines the max size of a timeseries request in arbitrary time units (ns, ms, s, h, d),
 #     # before sharding into multiple requests of this denomination and reconsitituting the results.
-#     # If shard_max_size and shard_max_size_points are both > 0, the configuration is invalid.
-#     # default is 0
-#     shard_max_size: 0ms
+#     # If shard_max_size_time and shard_max_size_points are both > 0, the configuration is invalid.
+#     # default is 0ms
+#     shard_max_size_time: 0ms
 
 #     # shard_step defines the epoch-aligned cadence to use when creating shards. When set to 0,
-#     # shards are not aligned to the epoch at a specific step. shard_max_size must be perfectly
+#     # shards are not aligned to the epoch at a specific step. shard_max_size_time must be perfectly
 #     # divisible by shard_step when both are > 0, or the configuration is invalid.
-#     # default is 0
+#     # default is 0ms
 #     shard_step: 0ms
 
 #     # Simulated Latency
@@ -423,7 +423,7 @@ backends:
 
 #       # timeout is the maximum during the health checker will wait for a response before aborting the check
 #       # default is 3s
-#       timeout: 3000ms
+#       timeout: 3s
 
 #       # expected_codes is the list of acceptable HTTP response codes when health checking the backend
 #       # for considering the backend healthy
@@ -512,14 +512,14 @@ backends:
 #     provider: reverseproxy
 #     origin_url: http://foo-origin-01
 #     healthcheck:
-#       interval: 1000ms
+#       interval: 1s
 
 #   foo-02.example.com:
 #     is_default: false
 #     provider: reverseproxy
 #     origin_url: http://foo-origin-02
 #     healthcheck:
-#       interval: 1000ms
+#       interval: 1s
 
 # # Application Load Balancer Backend configuration options, see /docs/alb.md for more information
 #
@@ -615,10 +615,10 @@ backends:
 #     # required for Zipkin and OTLP, unused for stdout
 #     endpoint: http://jaeger:14268/api/traces
 
-#     # timeout is the amount of time in milliseconds for the tracing post
+#     # timeout is the amount of time in arbitrary time units (ns, ms, s, h, d) for the tracing post
 #     # to wait for a response before timing out
 #     # default is no timeout set
-#     timeout: 5000ms
+#     timeout: 5s
 
 #     # headers is a list of http headers to include in the tracing post
 #     # default is none
@@ -688,12 +688,12 @@ backends:
 #   handler_path: /trickster/config/reload
 #   # drain_timeout defines how long old HTTP listeners will live to allow
 #   # outstanding connection to close organically, before the listener is forcefully closed
-#   # the default is 30
-#   drain_timeout: 30000ms
+#   # the default is 30s
+#   drain_timeout: 30s
 #   # rate_limit specifies the rate limit timeout duration to apply to the HTTP reload interface.
 #   # The reload interface is disabled for this duration of time whenever a config reload request is
 #   # made that fails because the underlying config file is unmodified. default is 3
-#   rate_limit: 3000ms
+#   rate_limit: 3s
 
 # # Configuration Options for Logging Instrumentation
 # logging:

--- a/examples/conf/exmple.sharding.yaml
+++ b/examples/conf/exmple.sharding.yaml
@@ -18,7 +18,7 @@ backends:
     # update FQDN and Port to work in your environment
     origin_url: 'http://prometheus:9090'
     provider: 'prometheus'
-    shard_step_ms: 7200000 # this will make shards bounded by 0:00, 2:00, 4:00, 8:00, etc., (UTC)
+    shard_step: 7200000ms # this will make shards bounded by 0:00, 2:00, 4:00, 8:00, etc., (UTC)
 
 metrics:
   listen_port: 8481   # available for scraping at http://<trickster>:<metrics.listen_port>/metrics

--- a/examples/docker-compose/docker-compose-data/trickster-config/trickster.yaml
+++ b/examples/docker-compose/docker-compose-data/trickster-config/trickster.yaml
@@ -55,7 +55,7 @@ backends:
     origin_url: 'http://influxdb:8086'
     tracing_name: jc1
     cache_name: mem1
-    backfill_tolerance_ms: 60000
+    backfill_tolerance: 60000ms
   sim1: # simulated prometheus cached with a memory cache, traces sent to jaeger agent
     provider: prometheus
     origin_url: 'http://mockster:8482/prometheus'

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -19,6 +19,7 @@ package backends
 import (
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
 	ho "github.com/trickstercache/trickster/v2/pkg/backends/healthcheck/options"
@@ -95,9 +96,9 @@ func New(name string, o *bo.Options, registrar Registrar,
 		err = err2
 	}
 
-	var tms int
+	var tms time.Duration
 	if o != nil && o.HealthCheck != nil {
-		tms = o.HealthCheck.TimeoutMS
+		tms = o.HealthCheck.Timeout
 	}
 	if hcc != nil {
 		hcc.Timeout = ho.CalibrateTimeout(tms)

--- a/pkg/backends/backend.go
+++ b/pkg/backends/backend.go
@@ -96,12 +96,12 @@ func New(name string, o *bo.Options, registrar Registrar,
 		err = err2
 	}
 
-	var tms time.Duration
+	var d time.Duration
 	if o != nil && o.HealthCheck != nil {
-		tms = o.HealthCheck.Timeout
+		d = o.HealthCheck.Timeout
 	}
 	if hcc != nil {
-		hcc.Timeout = ho.CalibrateTimeout(tms)
+		hcc.Timeout = ho.CalibrateTimeout(d)
 	}
 
 	var bur *url.URL

--- a/pkg/backends/healthcheck/healthcheck_test.go
+++ b/pkg/backends/healthcheck/healthcheck_test.go
@@ -62,7 +62,7 @@ func TestRegister(t *testing.T) {
 	logger.SetLogger(testLogger)
 	hc := New().(*healthChecker)
 	o := ho.New()
-	o.IntervalMS = 500
+	o.Interval = 500
 	_, err := hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {
 		t.Error(err)
@@ -90,7 +90,7 @@ func TestUnregister(t *testing.T) {
 	hc := New().(*healthChecker)
 	logger.SetLogger(testLogger)
 	o := ho.New()
-	o.IntervalMS = 500
+	o.Interval = 500
 	_, err := hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {
 		t.Error(err)
@@ -106,7 +106,7 @@ func TestStatus(t *testing.T) {
 	logger.SetLogger(testLogger)
 	hc := New().(*healthChecker)
 	o := ho.New()
-	o.IntervalMS = 500
+	o.Interval = 500
 	_, err := hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {
 		t.Error(err)
@@ -132,7 +132,7 @@ func TestStatuses(t *testing.T) {
 	logger.SetLogger(testLogger)
 	hc := New().(*healthChecker)
 	o := ho.New()
-	o.IntervalMS = 500
+	o.Interval = 500
 	_, err := hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {
 		t.Error(err)

--- a/pkg/backends/healthcheck/healthcheck_test.go
+++ b/pkg/backends/healthcheck/healthcheck_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"testing"
+	"time"
 
 	ho "github.com/trickstercache/trickster/v2/pkg/backends/healthcheck/options"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
@@ -62,7 +63,7 @@ func TestRegister(t *testing.T) {
 	logger.SetLogger(testLogger)
 	hc := New().(*healthChecker)
 	o := ho.New()
-	o.Interval = 500
+	o.Interval = 500 * time.Millisecond
 	_, err := hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {
 		t.Error(err)
@@ -90,7 +91,7 @@ func TestUnregister(t *testing.T) {
 	hc := New().(*healthChecker)
 	logger.SetLogger(testLogger)
 	o := ho.New()
-	o.Interval = 500
+	o.Interval = 500 * time.Millisecond
 	_, err := hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {
 		t.Error(err)
@@ -106,7 +107,7 @@ func TestStatus(t *testing.T) {
 	logger.SetLogger(testLogger)
 	hc := New().(*healthChecker)
 	o := ho.New()
-	o.Interval = 500
+	o.Interval = 500 * time.Millisecond
 	_, err := hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {
 		t.Error(err)
@@ -132,7 +133,7 @@ func TestStatuses(t *testing.T) {
 	logger.SetLogger(testLogger)
 	hc := New().(*healthChecker)
 	o := ho.New()
-	o.Interval = 500
+	o.Interval = 500 * time.Millisecond
 	_, err := hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {
 		t.Error(err)

--- a/pkg/backends/healthcheck/options/defaults.go
+++ b/pkg/backends/healthcheck/options/defaults.go
@@ -29,7 +29,7 @@ const (
 	// DefaultHealthCheckVerb is the default value (noop) for Backends' Health Check Verb
 	DefaultHealthCheckVerb = http.MethodGet
 	// DefaultHealthCheckTimeout is the default duration for health check probes to wait before timing out
-	DefaultHealthCheckTimeout = 3000 * time.Millisecond
+	DefaultHealthCheckTimeout = 3 * time.Second
 	// DefaultHealthCheckRecoveryThreshold defines the default number of successful health checks
 	// following failure to indicate true recovery
 	DefaultHealthCheckRecoveryThreshold = 3

--- a/pkg/backends/healthcheck/options/defaults.go
+++ b/pkg/backends/healthcheck/options/defaults.go
@@ -16,7 +16,10 @@
 
 package options
 
-import "net/http"
+import (
+	"net/http"
+	"time"
+)
 
 const (
 	// DefaultHealthCheckPath is the default value (noop) for Backends' Health Check Path
@@ -25,8 +28,8 @@ const (
 	DefaultHealthCheckQuery = ""
 	// DefaultHealthCheckVerb is the default value (noop) for Backends' Health Check Verb
 	DefaultHealthCheckVerb = http.MethodGet
-	// DefaultHealthCheckTimeoutMS is the default duration for health check probes to wait before timing out
-	DefaultHealthCheckTimeoutMS = 3000
+	// DefaultHealthCheckTimeout is the default duration for health check probes to wait before timing out
+	DefaultHealthCheckTimeout = 3000 * time.Millisecond
 	// DefaultHealthCheckRecoveryThreshold defines the default number of successful health checks
 	// following failure to indicate true recovery
 	DefaultHealthCheckRecoveryThreshold = 3

--- a/pkg/backends/healthcheck/options/options.go
+++ b/pkg/backends/healthcheck/options/options.go
@@ -27,11 +27,11 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/util/yamlx"
 )
 
-// MaxProbeWaitMS is the maximum time a health check will wait before timing out
-const MaxProbeWaitMS = 30000
+// MaxProbeWait is the maximum time a health check will wait before timing out
+const MaxProbeWait = 30000 * time.Millisecond
 
-// MinProbeWaitMS is the minimum time a health check will wait before timing out
-const MinProbeWaitMS = 100
+// MinProbeWait is the minimum time a health check will wait before timing out
+const MinProbeWait = 100 * time.Millisecond
 
 // ErrNoOptionsProvided returns an error for no health check options provided
 var ErrNoOptionsProvided = errors.New("no health check options provided")
@@ -39,8 +39,8 @@ var ErrNoOptionsProvided = errors.New("no health check options provided")
 // Options defines Health Checking Options
 type Options struct {
 
-	// IntervalMS defines the interval in milliseconds at which the target will be probed
-	IntervalMS int `yaml:"interval_ms,omitempty"`
+	// Interval defines the interval in milliseconds at which the target will be probed
+	Interval time.Duration `yaml:"interval,omitempty"`
 	// FailureThreshold indicates the number of consecutive failed probes required to
 	// mark an available target as unavailable
 	FailureThreshold int `yaml:"failure_threshold,omitempty"`
@@ -63,9 +63,9 @@ type Options struct {
 	Headers types.EnvStringMap `yaml:"headers,omitempty"`
 	// Body provides a body to apply when making an upstream health check request
 	Body string `yaml:"body,omitempty"`
-	// TimeoutMS is the amount of time a health check probe should wait for a response
+	// Timeout is the amount of time a health check probe should wait for a response
 	// before timing out
-	TimeoutMS int `yaml:"timeout_ms,omitempty"`
+	Timeout time.Duration `yaml:"timeout,omitempty"`
 	// Target Probe Response Options
 	// ExpectedCodes is the list of Status Codes that positively indicate a Healthy status
 	ExpectedCodes []int `yaml:"expected_codes,omitempty"`
@@ -107,7 +107,7 @@ func (o *Options) Clone() *Options {
 	c.Path = o.Path
 	c.Query = o.Query
 	c.Body = o.Body
-	c.IntervalMS = o.IntervalMS
+	c.Interval = o.Interval
 	c.ExpectedBody = o.ExpectedBody
 	if o.Headers != nil {
 		c.Headers = types.EnvStringMap(headers.Lookup(o.Headers).Clone())
@@ -153,8 +153,8 @@ func (o *Options) Overlay(name string, custom *Options) {
 	if custom.md.IsDefined("backends", name, "healthcheck", "expected_headers") {
 		o.ExpectedHeaders = custom.ExpectedHeaders
 	}
-	if custom.md.IsDefined("backends", name, "healthcheck", "interval_ms") {
-		o.IntervalMS = custom.IntervalMS
+	if custom.md.IsDefined("backends", name, "healthcheck", "interval") {
+		o.Interval = custom.Interval
 	}
 }
 
@@ -182,14 +182,14 @@ func (o *Options) SetExpectedBody(body string) {
 
 // CalibrateTimeout returns a time.Duration representing a calibrated
 // timeout value based on the milliseconds of duration provided
-func CalibrateTimeout(ms int) time.Duration {
+func CalibrateTimeout(ms time.Duration) time.Duration {
 	switch {
-	case ms > MaxProbeWaitMS:
-		ms = MaxProbeWaitMS
+	case ms > MaxProbeWait:
+		ms = MaxProbeWait
 	case ms <= 0:
-		ms = DefaultHealthCheckTimeoutMS
-	case ms < MinProbeWaitMS:
-		ms = MinProbeWaitMS
+		ms = DefaultHealthCheckTimeout
+	case ms < MinProbeWait:
+		ms = MinProbeWait
 	}
-	return time.Duration(ms) * time.Millisecond
+	return ms
 }

--- a/pkg/backends/healthcheck/options/options.go
+++ b/pkg/backends/healthcheck/options/options.go
@@ -182,14 +182,14 @@ func (o *Options) SetExpectedBody(body string) {
 
 // CalibrateTimeout returns a time.Duration representing a calibrated
 // timeout value based on the milliseconds of duration provided
-func CalibrateTimeout(ms time.Duration) time.Duration {
+func CalibrateTimeout(d time.Duration) time.Duration {
 	switch {
-	case ms > MaxProbeWait:
-		ms = MaxProbeWait
-	case ms <= 0:
-		ms = DefaultHealthCheckTimeout
-	case ms < MinProbeWait:
-		ms = MinProbeWait
+	case d > MaxProbeWait:
+		d = MaxProbeWait
+	case d <= 0:
+		d = DefaultHealthCheckTimeout
+	case d < MinProbeWait:
+		d = MinProbeWait
 	}
-	return ms
+	return d
 }

--- a/pkg/backends/healthcheck/options/options.go
+++ b/pkg/backends/healthcheck/options/options.go
@@ -39,7 +39,7 @@ var ErrNoOptionsProvided = errors.New("no health check options provided")
 // Options defines Health Checking Options
 type Options struct {
 
-	// Interval defines the interval in milliseconds at which the target will be probed
+	// Interval defines the interval at which the target will be probed
 	Interval time.Duration `yaml:"interval,omitempty"`
 	// FailureThreshold indicates the number of consecutive failed probes required to
 	// mark an available target as unavailable

--- a/pkg/backends/healthcheck/options/options_test.go
+++ b/pkg/backends/healthcheck/options/options_test.go
@@ -94,7 +94,7 @@ func TestOverlay(t *testing.T) {
 
 	o := New()
 	o.Overlay("", nil)
-	if o.IntervalMS != 0 {
+	if o.Interval != 0 {
 		t.Error("expected 0")
 	}
 
@@ -112,8 +112,8 @@ func TestOverlay(t *testing.T) {
 	o2 := New()
 	o2.md = md
 	o.Overlay("test", o2)
-	if o.IntervalMS != 0 {
-		t.Error("expected 5000 got ", o.IntervalMS)
+	if o.Interval != 0 {
+		t.Error("expected 5000 got ", o.Interval)
 	}
 }
 
@@ -128,7 +128,7 @@ backends:
       expected_codes:
         - 200
       expected_body: expected body
-      interval_ms: 0
+      interval: 0
       headers:
         TestHeader: test-header-val
       expected_headers:
@@ -137,12 +137,12 @@ backends:
 
 func TestCalibrateTimeout(t *testing.T) {
 
-	const defaultTimeout = time.Duration(DefaultHealthCheckTimeoutMS) * time.Millisecond
-	const maxTimeout = time.Duration(MaxProbeWaitMS) * time.Millisecond
-	const minTimeout = time.Duration(MinProbeWaitMS) * time.Millisecond
+	const defaultTimeout = DefaultHealthCheckTimeout
+	const maxTimeout = MaxProbeWait
+	const minTimeout = MinProbeWait
 
 	tests := []struct {
-		input    int
+		input    time.Duration
 		expected time.Duration
 	}{
 		{
@@ -155,16 +155,16 @@ func TestCalibrateTimeout(t *testing.T) {
 			1, minTimeout,
 		},
 		{
-			MinProbeWaitMS, minTimeout,
+			MinProbeWait, minTimeout,
 		},
 		{
-			MinProbeWaitMS + 5, time.Duration(MinProbeWaitMS+5) * time.Millisecond,
+			MinProbeWait + 5, time.Duration(MinProbeWait + 5),
 		},
 		{
-			MaxProbeWaitMS, maxTimeout,
+			MaxProbeWait, maxTimeout,
 		},
 		{
-			MaxProbeWaitMS + 5, maxTimeout,
+			MaxProbeWait + 5, maxTimeout,
 		},
 	}
 

--- a/pkg/backends/healthcheck/target.go
+++ b/pkg/backends/healthcheck/target.go
@@ -81,9 +81,9 @@ func newTarget(ctx context.Context,
 	if len(o.Headers) > 0 {
 		r.Header = headers.Lookup(o.Headers).ToHeader()
 	}
-	interval := time.Duration(o.IntervalMS) * time.Millisecond
+	interval := o.Interval
 	if client == nil {
-		client = newHTTPClient(ho.CalibrateTimeout(o.TimeoutMS))
+		client = newHTTPClient(ho.CalibrateTimeout(o.Timeout))
 	}
 	if o.FailureThreshold < 1 {
 		o.FailureThreshold = 3 // default to 3

--- a/pkg/backends/options/defaults.go
+++ b/pkg/backends/options/defaults.go
@@ -17,17 +17,19 @@
 package options
 
 import (
+	"time"
+
 	"github.com/trickstercache/trickster/v2/pkg/cache/evictionmethods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 )
 
 const (
-	// DefaultTimeseriesTTLMS is the default Cache TTL for Time Series Objects
-	DefaultTimeseriesTTLMS = 21600000
-	// DefaultFastForwardTTLMS is the default Cache TTL for Time Series Fast Forward Objects
-	DefaultFastForwardTTLMS = 15000
-	// DefaultMaxTTLMS is the default Maximum TTL of any cache object
-	DefaultMaxTTLMS = 86400000
+	// DefaultTimeseriesTTL is the default Cache TTL for Time Series Objects
+	DefaultTimeseriesTTL = 21600000 * time.Millisecond
+	// DefaultFastForwardTTL is the default Cache TTL for Time Series Fast Forward Objects
+	DefaultFastForwardTTL = 15000 * time.Millisecond
+	// DefaultMaxTTL is the default Maximum TTL of any cache object
+	DefaultMaxTTL = 86400000 * time.Millisecond
 	// DefaultRevalidationFactor is the default Cache Object Freshness Lifetime to TTL multiplier
 	DefaultRevalidationFactor = 2
 	// DefaultMaxObjectSizeBytes is the default Max Size of any Cache Object
@@ -38,20 +40,20 @@ const (
 	DefaultBackendTEM = evictionmethods.EvictionMethodOldest
 	// DefaultBackendTEMName is the default Timeseries Eviction Method name for Time Series-based Backends
 	DefaultBackendTEMName = "oldest"
-	// DefaultBackendTimeoutMS is the default Upstream Request Timeout for Backends
-	DefaultBackendTimeoutMS = 180000
+	// DefaultBackendTimeout is the default Upstream Request Timeout for Backends
+	DefaultBackendTimeout = 180000 * time.Millisecond
 	// DefaultBackendCacheName is the default Cache Name for Backends
 	DefaultBackendCacheName = "default"
 	// DefaultBackendNegativeCacheName is the default Negative Cache Name for Backends
 	DefaultBackendNegativeCacheName = "default"
 	// DefaultTracingConfigName is the default Tracing Config Name for Backends
 	DefaultTracingConfigName = "default"
-	// DefaultBackfillToleranceMS is the default Backfill Tolerance setting for Backends
-	DefaultBackfillToleranceMS = 0
+	// DefaultBackfillTolerance is the default Backfill Tolerance setting for Backends
+	DefaultBackfillTolerance = 0 * time.Millisecond
 	// DefaultBackfillTolerancePoints is the default Backfill Tolerance setting for Backends
 	DefaultBackfillTolerancePoints = 0
-	// DefaultKeepAliveTimeoutMS is the default Keep Alive Timeout for Backends' upstream client pools
-	DefaultKeepAliveTimeoutMS = 300000
+	// DefaultKeepAliveTimeout is the default Keep Alive Timeout for Backends' upstream client pools
+	DefaultKeepAliveTimeout = 300000 * time.Millisecond
 	// DefaultMaxIdleConns is the default number of Idle Connections in Backends' upstream client pools
 	DefaultMaxIdleConns = 20
 	// DefaultForwardedHeaders defines which class of 'Forwarded' headers are attached to upstream requests

--- a/pkg/backends/options/defaults.go
+++ b/pkg/backends/options/defaults.go
@@ -25,11 +25,11 @@ import (
 
 const (
 	// DefaultTimeseriesTTL is the default Cache TTL for Time Series Objects
-	DefaultTimeseriesTTL = 21600000 * time.Millisecond
+	DefaultTimeseriesTTL = 6 * time.Hour
 	// DefaultFastForwardTTL is the default Cache TTL for Time Series Fast Forward Objects
-	DefaultFastForwardTTL = 15000 * time.Millisecond
+	DefaultFastForwardTTL = 15 * time.Second
 	// DefaultMaxTTL is the default Maximum TTL of any cache object
-	DefaultMaxTTL = 86400000 * time.Millisecond
+	DefaultMaxTTL = 25 * time.Hour
 	// DefaultRevalidationFactor is the default Cache Object Freshness Lifetime to TTL multiplier
 	DefaultRevalidationFactor = 2
 	// DefaultMaxObjectSizeBytes is the default Max Size of any Cache Object
@@ -41,7 +41,7 @@ const (
 	// DefaultBackendTEMName is the default Timeseries Eviction Method name for Time Series-based Backends
 	DefaultBackendTEMName = "oldest"
 	// DefaultBackendTimeout is the default Upstream Request Timeout for Backends
-	DefaultBackendTimeout = 180000 * time.Millisecond
+	DefaultBackendTimeout = 3 * time.Minute
 	// DefaultBackendCacheName is the default Cache Name for Backends
 	DefaultBackendCacheName = "default"
 	// DefaultBackendNegativeCacheName is the default Negative Cache Name for Backends
@@ -53,7 +53,7 @@ const (
 	// DefaultBackfillTolerancePoints is the default Backfill Tolerance setting for Backends
 	DefaultBackfillTolerancePoints = 0
 	// DefaultKeepAliveTimeout is the default Keep Alive Timeout for Backends' upstream client pools
-	DefaultKeepAliveTimeout = 300000 * time.Millisecond
+	DefaultKeepAliveTimeout = 5 * time.Minute
 	// DefaultMaxIdleConns is the default number of Idle Connections in Backends' upstream client pools
 	DefaultMaxIdleConns = 20
 	// DefaultForwardedHeaders defines which class of 'Forwarded' headers are attached to upstream requests

--- a/pkg/backends/options/errors.go
+++ b/pkg/backends/options/errors.go
@@ -24,15 +24,15 @@ import (
 // ErrInvalidMetadata is an error for invalid metadata
 var ErrInvalidMetadata = errors.New("invalid options metadata")
 
-// ErrInvalidMaxShardSizeMS is an error for when 'shard_max_size' is not
+// ErrInvalidMaxShardSizeMS is an error for when 'shard_max_size_time' is not
 // a multiple 'shard_step'
 var ErrInvalidMaxShardSizeMS = errors.New(
-	"'shard_max_size' must be a multiple of 'shard_step' when both are non-zero")
+	"'shard_max_size_time' must be a multiple of 'shard_step' when both are non-zero")
 
-// ErrInvalidMaxShardSize is an error for when both 'shard_max_size' and
+// ErrInvalidMaxShardSize is an error for when both 'shard_max_size_time' and
 // 'shard_max_size_points' are used on the same backend
 var ErrInvalidMaxShardSize = errors.New(
-	"'shard_max_size' and 'shard_max_size_points' cannot both be non-zero")
+	"'shard_max_size_time' and 'shard_max_size_points' cannot both be non-zero")
 
 // ErrMissingProvider is an error type for missing provider
 type ErrMissingProvider struct {

--- a/pkg/backends/options/errors.go
+++ b/pkg/backends/options/errors.go
@@ -24,9 +24,9 @@ import (
 // ErrInvalidMetadata is an error for invalid metadata
 var ErrInvalidMetadata = errors.New("invalid options metadata")
 
-// ErrInvalidMaxShardSizeMS is an error for when 'shard_max_size_time' is not
+// ErrInvalidMaxShardSizeTime is an error for when 'shard_max_size_time' is not
 // a multiple 'shard_step'
-var ErrInvalidMaxShardSizeMS = errors.New(
+var ErrInvalidMaxShardSizeTime = errors.New(
 	"'shard_max_size_time' must be a multiple of 'shard_step' when both are non-zero")
 
 // ErrInvalidMaxShardSize is an error for when both 'shard_max_size_time' and

--- a/pkg/backends/options/errors.go
+++ b/pkg/backends/options/errors.go
@@ -24,15 +24,15 @@ import (
 // ErrInvalidMetadata is an error for invalid metadata
 var ErrInvalidMetadata = errors.New("invalid options metadata")
 
-// ErrInvalidMaxShardSizeMS is an error for when 'shard_max_size_ms' is not
-// a multiple 'shard_step_ms'
+// ErrInvalidMaxShardSizeMS is an error for when 'shard_max_size' is not
+// a multiple 'shard_step'
 var ErrInvalidMaxShardSizeMS = errors.New(
-	"'shard_max_size_ms' must be a multiple of 'shard_step_ms' when both are non-zero")
+	"'shard_max_size' must be a multiple of 'shard_step' when both are non-zero")
 
-// ErrInvalidMaxShardSize is an error for when both 'shard_max_size_ms' and
+// ErrInvalidMaxShardSize is an error for when both 'shard_max_size' and
 // 'shard_max_size_points' are used on the same backend
 var ErrInvalidMaxShardSize = errors.New(
-	"'shard_max_size_ms' and 'shard_max_size_points' cannot both be non-zero")
+	"'shard_max_size' and 'shard_max_size_points' cannot both be non-zero")
 
 // ErrMissingProvider is an error type for missing provider
 type ErrMissingProvider struct {

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -354,7 +354,7 @@ func (l Lookup) Validate(ncl negative.Lookups) error {
 		}
 
 		if o.ShardStep > 0 && o.MaxShardSizeTime%o.ShardStep != 0 {
-			return ErrInvalidMaxShardSizeMS
+			return ErrInvalidMaxShardSizeTime
 		}
 
 		if o.CompressibleTypeList != nil {

--- a/pkg/backends/options/options_data_test.go
+++ b/pkg/backends/options/options_data_test.go
@@ -47,17 +47,17 @@ backends:
     origin_url: 'scheme://test_host/test_path_prefix'
     api_path: test_api_path
     max_idle_conns: 23
-    keep_alive_timeout_ms: 7000
+    keep_alive_timeout: 7000
     ignore_caching_headers: true
     timeseries_retention_factor: 666
     timeseries_eviction_method: lru
     fast_forward_disable: true
-    backfill_tolerance_ms: 301000
+    backfill_tolerance: 301000ms
     backfill_tolerance_points: 2
-    timeout_ms: 37000
-    timeseries_ttl_ms: 8666000
-    max_ttl_ms: 300000
-    fastforward_ttl_ms: 382000
+    timeout: 37000ms
+    timeseries_ttl: 8666000ms
+    max_ttl: 300000ms
+    fastforward_ttl: 382000ms
     require_tls: true
     max_object_size_bytes: 999
     cache_key_prefix: test-prefix
@@ -65,9 +65,9 @@ backends:
     forwarded_headers: x
     negative_cache_name: test
     rule_name: ''
-    shard_max_size_ms: 0
+    shard_max_size: 0ms
     shard_max_size_points: 0
-    shard_step_ms: 0
+    shard_step: 0ms
     healthcheck:
       headers:
         Authorization: Basic SomeHash

--- a/pkg/backends/options/options_data_test.go
+++ b/pkg/backends/options/options_data_test.go
@@ -65,7 +65,7 @@ backends:
     forwarded_headers: x
     negative_cache_name: test
     rule_name: ''
-    shard_max_size: 0ms
+    shard_max_size_time: 0ms
     shard_max_size_points: 0
     shard_step: 0ms
     healthcheck:

--- a/pkg/backends/options/options_test.go
+++ b/pkg/backends/options/options_test.go
@@ -159,12 +159,12 @@ func testStringValueValidationError(to *testOptions, location *string, testValue
 }
 
 type intSwapper struct {
-	location   *int
-	restoreVal int
-	testValue  int
+	location   *time.Duration
+	restoreVal time.Duration
+	testValue  time.Duration
 }
 
-func testIntegerValueValidationError(to *testOptions, sws []intSwapper) error {
+func testDurationValueValidationError(to *testOptions, sws []intSwapper) error {
 	for i := range sws {
 		sws[i].restoreVal = *sws[i].location
 		*sws[i].location = sws[i].testValue
@@ -269,25 +269,11 @@ func TestValidate(t *testing.T) {
 		sw       []intSwapper
 		expected any
 	}{
-		{ // case 0 - MaxShardSizeMS > 0 and MaxShardSizePoints > 0 are mutually exclusive
-			to: to,
-			sw: []intSwapper{
-				{
-					location:  &o.MaxShardSizeMS,
-					testValue: 1,
-				},
-				{
-					location:  &o.MaxShardSizePoints,
-					testValue: 1,
-				},
-			},
-			expected: ErrInvalidMaxShardSize,
-		},
 		{ // case 1 - verifies: if ShardStep > 0 && MaxShardSize == 0 { MaxShardSize = ShardStep }
 			to: to,
 			sw: []intSwapper{
 				{
-					location:  &o.ShardStepMS,
+					location:  &o.ShardStep,
 					testValue: 1,
 				},
 			},
@@ -297,11 +283,11 @@ func TestValidate(t *testing.T) {
 			to: to,
 			sw: []intSwapper{
 				{
-					location:  &o.ShardStepMS,
+					location:  &o.MaxShardSize,
 					testValue: 10,
 				},
 				{
-					location:  &o.MaxShardSizeMS,
+					location:  &o.ShardStep,
 					testValue: 32,
 				},
 			},
@@ -311,7 +297,7 @@ func TestValidate(t *testing.T) {
 
 	for i, test := range tests2 {
 		t.Run(fmt.Sprintf("ints %d", i), func(t *testing.T) {
-			err = testIntegerValueValidationError(test.to, test.sw)
+			err = testDurationValueValidationError(test.to, test.sw)
 			if err == nil && test.expected == nil {
 				return
 			}

--- a/pkg/backends/options/options_test.go
+++ b/pkg/backends/options/options_test.go
@@ -292,7 +292,7 @@ func TestValidate(t *testing.T) {
 					testValue: 32,
 				},
 			},
-			expected: ErrInvalidMaxShardSizeMS,
+			expected: ErrInvalidMaxShardSizeTime,
 		},
 	}
 

--- a/pkg/backends/prometheus/options/defaults.go
+++ b/pkg/backends/prometheus/options/defaults.go
@@ -19,4 +19,4 @@ package options
 import "time"
 
 // DefaultInstantRound is the default Instant Rounding Value for Prometheus
-const DefaultInstantRound = 15000 * time.Millisecond
+const DefaultInstantRound = 15 * time.Second

--- a/pkg/backends/prometheus/options/defaults.go
+++ b/pkg/backends/prometheus/options/defaults.go
@@ -16,5 +16,7 @@
 
 package options
 
-// DefaultInstantRoundMS is the default Instant Rounding Value for Prometheus
-const DefaultInstantRoundMS = 15000
+import "time"
+
+// DefaultInstantRound is the default Instant Rounding Value for Prometheus
+const DefaultInstantRound = 15000 * time.Millisecond

--- a/pkg/backends/prometheus/options/options.go
+++ b/pkg/backends/prometheus/options/options.go
@@ -16,17 +16,20 @@
 
 package options
 
-import "maps"
+import (
+	"maps"
+	"time"
+)
 
 // Options stores information about Prometheus Options
 type Options struct {
-	Labels         map[string]string `yaml:"labels,omitempty"`
-	InstantRoundMS int               `yaml:"instant_round_ms,omitempty"`
+	Labels       map[string]string `yaml:"labels,omitempty"`
+	InstantRound time.Duration     `yaml:"instant_round,omitempty"`
 }
 
 func (o *Options) Clone() *Options {
 	return &Options{
-		InstantRoundMS: o.InstantRoundMS,
-		Labels:         maps.Clone(o.Labels),
+		InstantRound: o.InstantRound,
+		Labels:       maps.Clone(o.Labels),
 	}
 }

--- a/pkg/backends/prometheus/options/options_test.go
+++ b/pkg/backends/prometheus/options/options_test.go
@@ -24,13 +24,13 @@ func TestClone(t *testing.T) {
 	const expectedLen = 1
 
 	o := &Options{
-		InstantRoundMS: expectedMS,
-		Labels:         map[string]string{"test": "trickster"},
+		InstantRound: expectedMS,
+		Labels:       map[string]string{"test": "trickster"},
 	}
 
 	o2 := o.Clone()
-	if o2.InstantRoundMS != expectedMS {
-		t.Errorf("expected %d got %d", expectedMS, o2.InstantRoundMS)
+	if o2.InstantRound != expectedMS {
+		t.Errorf("expected %d got %d", expectedMS, o2.InstantRound)
 	}
 	if len(o2.Labels) != expectedLen {
 		t.Errorf("expected %d got %d", expectedLen, len(o2.Labels))

--- a/pkg/backends/prometheus/prometheus.go
+++ b/pkg/backends/prometheus/prometheus.go
@@ -86,12 +86,12 @@ func NewClient(name string, o *bo.Options, router http.Handler,
 		cache, modelprom.NewModeler())
 	c.TimeseriesBackend = b
 
-	rounder := time.Duration(po.DefaultInstantRoundMS) * time.Millisecond
+	rounder := po.DefaultInstantRound
 	if o != nil {
 		if o.Prometheus == nil {
-			o.Prometheus = &po.Options{InstantRoundMS: po.DefaultInstantRoundMS}
+			o.Prometheus = &po.Options{InstantRound: po.DefaultInstantRound}
 		} else {
-			rounder = time.Duration(o.Prometheus.InstantRoundMS) * time.Millisecond
+			rounder = o.Prometheus.InstantRound
 			c.injectLabels = o.Prometheus.Labels
 			c.hasTransformations = len(c.injectLabels) > 0
 		}

--- a/pkg/backends/prometheus/routes.go
+++ b/pkg/backends/prometheus/routes.go
@@ -69,7 +69,7 @@ func (c *Client) DefaultPathConfigs(o *bo.Options) map[string]*po.Options {
 	var rhts map[string]string
 	if o != nil {
 		rhts = map[string]string{
-			headers.NameCacheControl: fmt.Sprintf("%s=%d", headers.ValueSharedMaxAge, o.TimeseriesTTL/(1000*time.Millisecond))}
+			headers.NameCacheControl: fmt.Sprintf("%s=%d", headers.ValueSharedMaxAge, o.TimeseriesTTL/(1*time.Second))}
 	}
 	rhinst := map[string]string{
 		headers.NameCacheControl: fmt.Sprintf("%s=%d", headers.ValueSharedMaxAge, 30)}

--- a/pkg/backends/prometheus/routes.go
+++ b/pkg/backends/prometheus/routes.go
@@ -19,6 +19,7 @@ package prometheus
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
@@ -68,7 +69,7 @@ func (c *Client) DefaultPathConfigs(o *bo.Options) map[string]*po.Options {
 	var rhts map[string]string
 	if o != nil {
 		rhts = map[string]string{
-			headers.NameCacheControl: fmt.Sprintf("%s=%d", headers.ValueSharedMaxAge, o.TimeseriesTTLMS/1000)}
+			headers.NameCacheControl: fmt.Sprintf("%s=%d", headers.ValueSharedMaxAge, o.TimeseriesTTL/(1000*time.Millisecond))}
 	}
 	rhinst := map[string]string{
 		headers.NameCacheControl: fmt.Sprintf("%s=%d", headers.ValueSharedMaxAge, 30)}

--- a/pkg/cache/index/options/defaults.go
+++ b/pkg/cache/index/options/defaults.go
@@ -20,9 +20,9 @@ import "time"
 
 const (
 	// DefaultCacheIndexReap is the default Cache Index Reap interval
-	DefaultCacheIndexReap = 3000 * time.Millisecond
+	DefaultCacheIndexReap = 3 * time.Second
 	// DefaultCacheIndexFlush is the default Cache Index Flush interval
-	DefaultCacheIndexFlush = 5000 * time.Millisecond
+	DefaultCacheIndexFlush = 5 * time.Second
 	// DefaultCacheMaxSizeBytes is the default Max Cache Size in Bytes
 	DefaultCacheMaxSizeBytes = 536870912
 	// DefaultMaxSizeBackoffBytes is the default Max Cache Backoff Size in Bytes

--- a/pkg/cache/index/options/defaults.go
+++ b/pkg/cache/index/options/defaults.go
@@ -19,9 +19,9 @@ package options
 import "time"
 
 const (
-	// DefaultCacheIndexReap is the default Cache Index Reap interval (in milliseconds)
+	// DefaultCacheIndexReap is the default Cache Index Reap interval
 	DefaultCacheIndexReap = 3000 * time.Millisecond
-	// DefaultCacheIndexFlush is the default Cache Index Flush interval (in milliseconds)
+	// DefaultCacheIndexFlush is the default Cache Index Flush interval
 	DefaultCacheIndexFlush = 5000 * time.Millisecond
 	// DefaultCacheMaxSizeBytes is the default Max Cache Size in Bytes
 	DefaultCacheMaxSizeBytes = 536870912

--- a/pkg/cache/index/options/defaults.go
+++ b/pkg/cache/index/options/defaults.go
@@ -16,11 +16,13 @@
 
 package options
 
+import "time"
+
 const (
 	// DefaultCacheIndexReap is the default Cache Index Reap interval (in milliseconds)
-	DefaultCacheIndexReap = 3000
+	DefaultCacheIndexReap = 3000 * time.Millisecond
 	// DefaultCacheIndexFlush is the default Cache Index Flush interval (in milliseconds)
-	DefaultCacheIndexFlush = 5000
+	DefaultCacheIndexFlush = 5000 * time.Millisecond
 	// DefaultCacheMaxSizeBytes is the default Max Cache Size in Bytes
 	DefaultCacheMaxSizeBytes = 536870912
 	// DefaultMaxSizeBackoffBytes is the default Max Cache Backoff Size in Bytes

--- a/pkg/cache/index/options/options.go
+++ b/pkg/cache/index/options/options.go
@@ -22,10 +22,10 @@ import (
 
 // Options defines the operation of the Cache Indexer
 type Options struct {
-	// ReapIntervalMS defines how long the Cache Index reaper sleeps between reap cycles
-	ReapIntervalMS int `yaml:"reap_interval_ms,omitempty"`
-	// FlushIntervalMS sets how often the Cache Index saves its metadata to the cache from application memory
-	FlushIntervalMS int `yaml:"flush_interval_ms,omitempty"`
+	// ReapInterval defines how long the Cache Index reaper sleeps between reap cycles
+	ReapInterval time.Duration `yaml:"reap_interval,omitempty"`
+	// FlushInterval sets how often the Cache Index saves its metadata to the cache from application memory
+	FlushInterval time.Duration `yaml:"flush_interval,omitempty"`
 	// MaxSizeBytes indicates how large the cache can grow in bytes before the Index evicts
 	// least-recently-accessed items.
 	MaxSizeBytes int64 `yaml:"max_size_bytes,omitempty"`
@@ -38,18 +38,13 @@ type Options struct {
 	// MaxSizeBackoffObjects indicates how far under max_size_objects the cache size must
 	// be to complete object-size-based eviction exercise.
 	MaxSizeBackoffObjects int64 `yaml:"max_size_backoff_objects,omitempty"`
-
-	ReapInterval  time.Duration `yaml:"-"`
-	FlushInterval time.Duration `yaml:"-"`
 }
 
 // New returns a new Cache Index Options Reference with default values set
 func New() *Options {
 	return &Options{
-		ReapIntervalMS:        DefaultCacheIndexReap,
-		ReapInterval:          time.Duration(DefaultCacheIndexReap) * time.Millisecond,
-		FlushIntervalMS:       DefaultCacheIndexFlush,
-		FlushInterval:         time.Duration(DefaultCacheIndexFlush) * time.Millisecond,
+		ReapInterval:          DefaultCacheIndexReap,
+		FlushInterval:         DefaultCacheIndexFlush,
 		MaxSizeBytes:          DefaultCacheMaxSizeBytes,
 		MaxSizeBackoffBytes:   DefaultMaxSizeBackoffBytes,
 		MaxSizeObjects:        DefaultMaxSizeObjects,
@@ -65,8 +60,8 @@ func (o *Options) Equal(o2 *Options) bool {
 		return false
 	}
 
-	return o.ReapIntervalMS == o2.ReapIntervalMS &&
-		o.FlushIntervalMS == o2.FlushIntervalMS &&
+	return o.ReapInterval == o2.ReapInterval &&
+		o.FlushInterval == o2.FlushInterval &&
 		o.MaxSizeBytes == o2.MaxSizeBytes &&
 		o.MaxSizeBackoffBytes == o2.MaxSizeBackoffBytes &&
 		o.MaxSizeObjects == o2.MaxSizeObjects &&

--- a/pkg/cache/options/options.go
+++ b/pkg/cache/options/options.go
@@ -91,13 +91,13 @@ func (cc *Options) Clone() *Options {
 	c.ProviderID = cc.ProviderID
 
 	c.Index.FlushInterval = cc.Index.FlushInterval
-	c.Index.FlushIntervalMS = cc.Index.FlushIntervalMS
+	c.Index.FlushInterval = cc.Index.FlushInterval
 	c.Index.MaxSizeBackoffBytes = cc.Index.MaxSizeBackoffBytes
 	c.Index.MaxSizeBackoffObjects = cc.Index.MaxSizeBackoffObjects
 	c.Index.MaxSizeBytes = cc.Index.MaxSizeBytes
 	c.Index.MaxSizeObjects = cc.Index.MaxSizeObjects
 	c.Index.ReapInterval = cc.Index.ReapInterval
-	c.Index.ReapIntervalMS = cc.Index.ReapIntervalMS
+	c.Index.ReapInterval = cc.Index.ReapInterval
 
 	c.Badger.Directory = cc.Badger.Directory
 	c.Badger.ValueDirectory = cc.Badger.ValueDirectory
@@ -109,23 +109,23 @@ func (cc *Options) Clone() *Options {
 
 	c.Redis.ClientType = cc.Redis.ClientType
 	c.Redis.DB = cc.Redis.DB
-	c.Redis.DialTimeoutMS = cc.Redis.DialTimeoutMS
+	c.Redis.DialTimeout = cc.Redis.DialTimeout
 	c.Redis.Endpoint = cc.Redis.Endpoint
 	c.Redis.Endpoints = cc.Redis.Endpoints
-	c.Redis.IdleCheckFrequencyMS = cc.Redis.IdleCheckFrequencyMS
-	c.Redis.IdleTimeoutMS = cc.Redis.IdleTimeoutMS
-	c.Redis.MaxConnAgeMS = cc.Redis.MaxConnAgeMS
+	c.Redis.IdleCheckFrequency = cc.Redis.IdleCheckFrequency
+	c.Redis.IdleTimeout = cc.Redis.IdleTimeout
+	c.Redis.MaxConnAge = cc.Redis.MaxConnAge
 	c.Redis.MaxRetries = cc.Redis.MaxRetries
-	c.Redis.MaxRetryBackoffMS = cc.Redis.MaxRetryBackoffMS
+	c.Redis.MaxRetryBackoff = cc.Redis.MaxRetryBackoff
 	c.Redis.MinIdleConns = cc.Redis.MinIdleConns
-	c.Redis.MinRetryBackoffMS = cc.Redis.MinRetryBackoffMS
+	c.Redis.MinRetryBackoff = cc.Redis.MinRetryBackoff
 	c.Redis.Password = cc.Redis.Password
 	c.Redis.PoolSize = cc.Redis.PoolSize
-	c.Redis.PoolTimeoutMS = cc.Redis.PoolTimeoutMS
+	c.Redis.PoolTimeout = cc.Redis.PoolTimeout
 	c.Redis.Protocol = cc.Redis.Protocol
-	c.Redis.ReadTimeoutMS = cc.Redis.ReadTimeoutMS
+	c.Redis.ReadTimeout = cc.Redis.ReadTimeout
 	c.Redis.SentinelMaster = cc.Redis.SentinelMaster
-	c.Redis.WriteTimeoutMS = cc.Redis.WriteTimeoutMS
+	c.Redis.WriteTimeout = cc.Redis.WriteTimeout
 
 	c.UseCacheChunking = cc.UseCacheChunking
 	c.TimeseriesChunkFactor = cc.TimeseriesChunkFactor
@@ -177,12 +177,12 @@ func (l Lookup) SetDefaults(metadata yamlx.KeyLookup, activeCaches sets.Set[stri
 			}
 		}
 
-		if metadata.IsDefined("caches", k, "index", "reap_interval_ms") {
-			cc.Index.ReapIntervalMS = v.Index.ReapIntervalMS
+		if metadata.IsDefined("caches", k, "index", "reap_interval") {
+			cc.Index.ReapInterval = v.Index.ReapInterval
 		}
 
-		if metadata.IsDefined("caches", k, "index", "flush_interval_ms") {
-			cc.Index.FlushIntervalMS = v.Index.FlushIntervalMS
+		if metadata.IsDefined("caches", k, "index", "flush_interval") {
+			cc.Index.FlushInterval = v.Index.FlushInterval
 		}
 
 		if metadata.IsDefined("caches", k, "index", "max_size_bytes") {
@@ -261,24 +261,24 @@ func (l Lookup) SetDefaults(metadata yamlx.KeyLookup, activeCaches sets.Set[stri
 				cc.Redis.MaxRetries = v.Redis.MaxRetries
 			}
 
-			if metadata.IsDefined("caches", k, "redis", "min_retry_backoff_ms") {
-				cc.Redis.MinRetryBackoffMS = v.Redis.MinRetryBackoffMS
+			if metadata.IsDefined("caches", k, "redis", "min_retry_backoff") {
+				cc.Redis.MinRetryBackoff = v.Redis.MinRetryBackoff
 			}
 
-			if metadata.IsDefined("caches", k, "redis", "max_retry_backoff_ms") {
-				cc.Redis.MaxRetryBackoffMS = v.Redis.MaxRetryBackoffMS
+			if metadata.IsDefined("caches", k, "redis", "max_retry_backoff") {
+				cc.Redis.MaxRetryBackoff = v.Redis.MaxRetryBackoff
 			}
 
-			if metadata.IsDefined("caches", k, "redis", "dial_timeout_ms") {
-				cc.Redis.DialTimeoutMS = v.Redis.DialTimeoutMS
+			if metadata.IsDefined("caches", k, "redis", "dial_timeout") {
+				cc.Redis.DialTimeout = v.Redis.DialTimeout
 			}
 
-			if metadata.IsDefined("caches", k, "redis", "read_timeout_ms") {
-				cc.Redis.ReadTimeoutMS = v.Redis.ReadTimeoutMS
+			if metadata.IsDefined("caches", k, "redis", "read_timeout") {
+				cc.Redis.ReadTimeout = v.Redis.ReadTimeout
 			}
 
-			if metadata.IsDefined("caches", k, "redis", "write_timeout_ms") {
-				cc.Redis.WriteTimeoutMS = v.Redis.WriteTimeoutMS
+			if metadata.IsDefined("caches", k, "redis", "write_timeout") {
+				cc.Redis.WriteTimeout = v.Redis.WriteTimeout
 			}
 
 			if metadata.IsDefined("caches", k, "redis", "pool_size") {
@@ -289,20 +289,20 @@ func (l Lookup) SetDefaults(metadata yamlx.KeyLookup, activeCaches sets.Set[stri
 				cc.Redis.MinIdleConns = v.Redis.MinIdleConns
 			}
 
-			if metadata.IsDefined("caches", k, "redis", "max_conn_age_ms") {
-				cc.Redis.MaxConnAgeMS = v.Redis.MaxConnAgeMS
+			if metadata.IsDefined("caches", k, "redis", "max_conn_age") {
+				cc.Redis.MaxConnAge = v.Redis.MaxConnAge
 			}
 
-			if metadata.IsDefined("caches", k, "redis", "pool_timeout_ms") {
-				cc.Redis.PoolTimeoutMS = v.Redis.PoolTimeoutMS
+			if metadata.IsDefined("caches", k, "redis", "pool_timeout") {
+				cc.Redis.PoolTimeout = v.Redis.PoolTimeout
 			}
 
-			if metadata.IsDefined("caches", k, "redis", "idle_timeout_ms") {
-				cc.Redis.IdleTimeoutMS = v.Redis.IdleTimeoutMS
+			if metadata.IsDefined("caches", k, "redis", "idle_timeout") {
+				cc.Redis.IdleTimeout = v.Redis.IdleTimeout
 			}
 
-			if metadata.IsDefined("caches", k, "redis", "idle_check_frequency_ms") {
-				cc.Redis.IdleCheckFrequencyMS = v.Redis.IdleCheckFrequencyMS
+			if metadata.IsDefined("caches", k, "redis", "idle_check_frequency") {
+				cc.Redis.IdleCheckFrequency = v.Redis.IdleCheckFrequency
 			}
 		}
 

--- a/pkg/cache/options/options_test.go
+++ b/pkg/cache/options/options_test.go
@@ -134,17 +134,17 @@ caches:
       password: '********'
       db: trickster
       max_retries: 3
-      min_retry_backoff_ms: 2000
-      max_retry_backoff_ms: 4000
-      dial_timeout_ms: 2000
-      read_timeout_ms: 1000
-      write_timeout_ms: 3000
+      min_retry_backoff: 2000ms
+      max_retry_backoff: 4000ms
+      dial_timeout: 2000ms
+      read_timeout: 1000ms
+      write_timeout: 3000ms
       pool_size: 16
       min_idle_conns: 16
-      max_conn_age_ms: 16
-      pool_timeout_ms: 16
-      idle_timeout_ms: 16
-      idle_check_frequency_ms: 16
+      max_conn_age: 16ms
+      pool_timeout: 16ms
+      idle_timeout: 16ms
+      idle_check_frequency: 16ms
     filesystem:
       cache_path: /tmp/trickster
     bbolt:
@@ -154,8 +154,8 @@ caches:
       directory: /tmp/trickster
       value_directory: /tmp/trickster
     index:
-      reap_interval_ms: 2000
-      flush_interval_ms: 2000
+      reap_interval: 2000ms
+      flush_interval: 2000ms
       max_size_bytes: 1
       max_size_backoff_bytes: 16384
       max_size_objects: 4096

--- a/pkg/cache/redis/cluster.go
+++ b/pkg/cache/redis/cluster.go
@@ -38,24 +38,24 @@ func (c *Cache) clusterOpts() (*redis.ClusterOptions, error) {
 		o.MaxRetries = c.Config.Redis.MaxRetries
 	}
 
-	if c.Config.Redis.MinRetryBackoffMS != 0 {
-		o.MinRetryBackoff = durationFromMS(c.Config.Redis.MinRetryBackoffMS)
+	if c.Config.Redis.MinRetryBackoff != 0 {
+		o.MinRetryBackoff = c.Config.Redis.MinRetryBackoff
 	}
 
-	if c.Config.Redis.MaxRetryBackoffMS != 0 {
-		o.MaxRetryBackoff = durationFromMS(c.Config.Redis.MaxRetryBackoffMS)
+	if c.Config.Redis.MaxRetryBackoff != 0 {
+		o.MaxRetryBackoff = c.Config.Redis.MaxRetryBackoff
 	}
 
-	if c.Config.Redis.DialTimeoutMS != 0 {
-		o.DialTimeout = durationFromMS(c.Config.Redis.DialTimeoutMS)
+	if c.Config.Redis.DialTimeout != 0 {
+		o.DialTimeout = c.Config.Redis.DialTimeout
 	}
 
-	if c.Config.Redis.ReadTimeoutMS != 0 {
-		o.ReadTimeout = durationFromMS(c.Config.Redis.ReadTimeoutMS)
+	if c.Config.Redis.ReadTimeout != 0 {
+		o.ReadTimeout = c.Config.Redis.ReadTimeout
 	}
 
-	if c.Config.Redis.WriteTimeoutMS != 0 {
-		o.WriteTimeout = durationFromMS(c.Config.Redis.WriteTimeoutMS)
+	if c.Config.Redis.WriteTimeout != 0 {
+		o.WriteTimeout = c.Config.Redis.WriteTimeout
 	}
 
 	if c.Config.Redis.PoolSize != 0 {
@@ -66,20 +66,20 @@ func (c *Cache) clusterOpts() (*redis.ClusterOptions, error) {
 		o.MinIdleConns = c.Config.Redis.MinIdleConns
 	}
 
-	if c.Config.Redis.MaxConnAgeMS != 0 {
-		o.MaxConnAge = durationFromMS(c.Config.Redis.MaxConnAgeMS)
+	if c.Config.Redis.MaxConnAge != 0 {
+		o.MaxConnAge = c.Config.Redis.MaxConnAge
 	}
 
-	if c.Config.Redis.PoolTimeoutMS != 0 {
-		o.PoolTimeout = durationFromMS(c.Config.Redis.PoolTimeoutMS)
+	if c.Config.Redis.PoolTimeout != 0 {
+		o.PoolTimeout = c.Config.Redis.PoolTimeout
 	}
 
-	if c.Config.Redis.IdleTimeoutMS != 0 {
-		o.IdleTimeout = durationFromMS(c.Config.Redis.IdleTimeoutMS)
+	if c.Config.Redis.IdleTimeout != 0 {
+		o.IdleTimeout = c.Config.Redis.IdleTimeout
 	}
 
-	if c.Config.Redis.IdleCheckFrequencyMS != 0 {
-		o.IdleCheckFrequency = durationFromMS(c.Config.Redis.IdleCheckFrequencyMS)
+	if c.Config.Redis.IdleCheckFrequency != 0 {
+		o.IdleCheckFrequency = c.Config.Redis.IdleCheckFrequency
 	}
 
 	return o, nil

--- a/pkg/cache/redis/options/options.go
+++ b/pkg/cache/redis/options/options.go
@@ -16,7 +16,11 @@
 
 package options
 
-import "github.com/trickstercache/trickster/v2/pkg/config/types"
+import (
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/config/types"
+)
 
 // Options is a collection of Configurations for Connecting to Redis
 type Options struct {
@@ -36,32 +40,32 @@ type Options struct {
 	DB int `yaml:"db,omitempty"`
 	// MaxRetries is the maximum number of retries before giving up on the command
 	MaxRetries int `yaml:"max_retries,omitempty"`
-	// MinRetryBackoffMS is the minimum backoff between each retry.
-	MinRetryBackoffMS int `yaml:"min_retry_backoff_ms,omitempty"`
-	// MaxRetryBackoffMS is the Maximum backoff between each retry.
-	MaxRetryBackoffMS int `yaml:"max_retry_backoff_ms,omitempty"`
-	// DialTimeoutMS is the timeout for establishing new connections.
-	DialTimeoutMS int `yaml:"dial_timeout_ms,omitempty"`
-	// ReadTimeoutMS is the timeout for socket reads.
+	// MinRetryBackoff is the minimum backoff between each retry.
+	MinRetryBackoff time.Duration `yaml:"min_retry_backoff,omitempty"`
+	// MaxRetryBackoff is the Maximum backoff between each retry.
+	MaxRetryBackoff time.Duration `yaml:"max_retry_backoff,omitempty"`
+	// DialTimeout is the timeout for establishing new connections.
+	DialTimeout time.Duration `yaml:"dial_timeout,omitempty"`
+	// ReadTimeout is the timeout for socket reads.
 	// If reached, commands will fail with a timeout instead of blocking.
-	ReadTimeoutMS int `yaml:"read_timeout_ms,omitempty"`
-	// WriteTimeoutMS is the timeout for socket writes.
+	ReadTimeout time.Duration `yaml:"read_timeout,omitempty"`
+	// WriteTimeout is the timeout for socket writes.
 	// If reached, commands will fail with a timeout instead of blocking.
-	WriteTimeoutMS int `yaml:"write_timeout_ms,omitempty"`
+	WriteTimeout time.Duration `yaml:"write_timeout,omitempty"`
 	// PoolSize is the maximum number of socket connections.
 	PoolSize int `yaml:"pool_size,omitempty"`
 	// MinIdleConns is the minimum number of idle connections
 	// which is useful when establishing new connection is slow.
 	MinIdleConns int `yaml:"min_idle_conns,omitempty"`
-	// MaxConnAgeMS is the connection age at which client retires (closes) the connection.
-	MaxConnAgeMS int `yaml:"max_conn_age_ms,omitempty"`
-	// PoolTimeoutMS is the amount of time client waits for connection if all
+	// MaxConnAge is the connection age at which client retires (closes) the connection.
+	MaxConnAge time.Duration `yaml:"max_conn_age,omitempty"`
+	// PoolTimeout is the amount of time client waits for connection if all
 	// connections are busy before returning an error.
-	PoolTimeoutMS int `yaml:"pool_timeout_ms,omitempty"`
-	// IdleTimeoutMS is the amount of time after which client closes idle connections.
-	IdleTimeoutMS int `yaml:"idle_timeout_ms,omitempty"`
-	// IdleCheckFrequencyMS is the frequency of idle checks made by idle connections reaper.
-	IdleCheckFrequencyMS int `yaml:"idle_check_frequency_ms,omitempty"`
+	PoolTimeout time.Duration `yaml:"pool_timeout,omitempty"`
+	// IdleTimeout is the amount of time after which client closes idle connections.
+	IdleTimeout time.Duration `yaml:"idle_timeout,omitempty"`
+	// IdleCheckFrequency is the frequency of idle checks made by idle connections reaper.
+	IdleCheckFrequency time.Duration `yaml:"idle_check_frequency,omitempty"`
 }
 
 // New returns a new Redis Options Reference with default values set

--- a/pkg/cache/redis/redis.go
+++ b/pkg/cache/redis/redis.go
@@ -149,7 +149,3 @@ func (c *Cache) Close() error {
 	logger.Info("closing redis connection", nil)
 	return c.closer()
 }
-
-func durationFromMS(input int) time.Duration {
-	return time.Duration(int64(input)) * time.Millisecond
-}

--- a/pkg/cache/redis/redis_test.go
+++ b/pkg/cache/redis/redis_test.go
@@ -205,30 +205,6 @@ func TestClientSelectionStandard(t *testing.T) {
 	}
 }
 
-func TestDurationFromMS(t *testing.T) {
-
-	tests := []struct {
-		input    int
-		expected time.Duration
-	}{
-		{0, time.Duration(0)},
-		{5000, time.Duration(5000) * time.Millisecond},
-		{60000, time.Duration(60000) * time.Millisecond},
-	}
-
-	for i, test := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-
-			res := durationFromMS(test.input)
-
-			if res != test.expected {
-				t.Fatalf("Mismatch in durationFromMS: expected=%f actual=%f", test.expected.Seconds(), res.Seconds())
-			}
-		})
-	}
-
-}
-
 func TestRedisCache_SetTTL(t *testing.T) {
 
 	const expected = "data"

--- a/pkg/cache/redis/sentinel.go
+++ b/pkg/cache/redis/sentinel.go
@@ -47,24 +47,24 @@ func (c *Cache) sentinelOpts() (*redis.FailoverOptions, error) {
 		o.MaxRetries = c.Config.Redis.MaxRetries
 	}
 
-	if c.Config.Redis.MinRetryBackoffMS != 0 {
-		o.MinRetryBackoff = durationFromMS(c.Config.Redis.MinRetryBackoffMS)
+	if c.Config.Redis.MinRetryBackoff != 0 {
+		o.MinRetryBackoff = c.Config.Redis.MinRetryBackoff
 	}
 
-	if c.Config.Redis.MaxRetryBackoffMS != 0 {
-		o.MaxRetryBackoff = durationFromMS(c.Config.Redis.MaxRetryBackoffMS)
+	if c.Config.Redis.MaxRetryBackoff != 0 {
+		o.MaxRetryBackoff = c.Config.Redis.MaxRetryBackoff
 	}
 
-	if c.Config.Redis.DialTimeoutMS != 0 {
-		o.DialTimeout = durationFromMS(c.Config.Redis.DialTimeoutMS)
+	if c.Config.Redis.DialTimeout != 0 {
+		o.DialTimeout = c.Config.Redis.DialTimeout
 	}
 
-	if c.Config.Redis.ReadTimeoutMS != 0 {
-		o.ReadTimeout = durationFromMS(c.Config.Redis.ReadTimeoutMS)
+	if c.Config.Redis.ReadTimeout != 0 {
+		o.ReadTimeout = c.Config.Redis.ReadTimeout
 	}
 
-	if c.Config.Redis.WriteTimeoutMS != 0 {
-		o.WriteTimeout = durationFromMS(c.Config.Redis.WriteTimeoutMS)
+	if c.Config.Redis.WriteTimeout != 0 {
+		o.WriteTimeout = c.Config.Redis.WriteTimeout
 	}
 
 	if c.Config.Redis.PoolSize != 0 {
@@ -75,20 +75,20 @@ func (c *Cache) sentinelOpts() (*redis.FailoverOptions, error) {
 		o.MinIdleConns = c.Config.Redis.MinIdleConns
 	}
 
-	if c.Config.Redis.MaxConnAgeMS != 0 {
-		o.MaxConnAge = durationFromMS(c.Config.Redis.MaxConnAgeMS)
+	if c.Config.Redis.MaxConnAge != 0 {
+		o.MaxConnAge = c.Config.Redis.MaxConnAge
 	}
 
-	if c.Config.Redis.PoolTimeoutMS != 0 {
-		o.PoolTimeout = durationFromMS(c.Config.Redis.PoolTimeoutMS)
+	if c.Config.Redis.PoolTimeout != 0 {
+		o.PoolTimeout = c.Config.Redis.PoolTimeout
 	}
 
-	if c.Config.Redis.IdleTimeoutMS != 0 {
-		o.IdleTimeout = durationFromMS(c.Config.Redis.IdleTimeoutMS)
+	if c.Config.Redis.IdleTimeout != 0 {
+		o.IdleTimeout = c.Config.Redis.IdleTimeout
 	}
 
-	if c.Config.Redis.IdleCheckFrequencyMS != 0 {
-		o.IdleCheckFrequency = durationFromMS(c.Config.Redis.IdleCheckFrequencyMS)
+	if c.Config.Redis.IdleCheckFrequency != 0 {
+		o.IdleCheckFrequency = c.Config.Redis.IdleCheckFrequency
 	}
 
 	return o, nil

--- a/pkg/cache/redis/standard.go
+++ b/pkg/cache/redis/standard.go
@@ -48,24 +48,24 @@ func (c *Cache) clientOpts() (*redis.Options, error) {
 		o.MaxRetries = c.Config.Redis.MaxRetries
 	}
 
-	if c.Config.Redis.MinRetryBackoffMS != 0 {
-		o.MinRetryBackoff = durationFromMS(c.Config.Redis.MinRetryBackoffMS)
+	if c.Config.Redis.MinRetryBackoff != 0 {
+		o.MinRetryBackoff = c.Config.Redis.MinRetryBackoff
 	}
 
-	if c.Config.Redis.MaxRetryBackoffMS != 0 {
-		o.MaxRetryBackoff = durationFromMS(c.Config.Redis.MaxRetryBackoffMS)
+	if c.Config.Redis.MaxRetryBackoff != 0 {
+		o.MaxRetryBackoff = c.Config.Redis.MaxRetryBackoff
 	}
 
-	if c.Config.Redis.DialTimeoutMS != 0 {
-		o.DialTimeout = durationFromMS(c.Config.Redis.DialTimeoutMS)
+	if c.Config.Redis.DialTimeout != 0 {
+		o.DialTimeout = c.Config.Redis.DialTimeout
 	}
 
-	if c.Config.Redis.ReadTimeoutMS != 0 {
-		o.ReadTimeout = durationFromMS(c.Config.Redis.ReadTimeoutMS)
+	if c.Config.Redis.ReadTimeout != 0 {
+		o.ReadTimeout = c.Config.Redis.ReadTimeout
 	}
 
-	if c.Config.Redis.WriteTimeoutMS != 0 {
-		o.WriteTimeout = durationFromMS(c.Config.Redis.WriteTimeoutMS)
+	if c.Config.Redis.WriteTimeout != 0 {
+		o.WriteTimeout = c.Config.Redis.WriteTimeout
 	}
 
 	if c.Config.Redis.PoolSize != 0 {
@@ -76,20 +76,20 @@ func (c *Cache) clientOpts() (*redis.Options, error) {
 		o.MinIdleConns = c.Config.Redis.MinIdleConns
 	}
 
-	if c.Config.Redis.MaxConnAgeMS != 0 {
-		o.MaxConnAge = durationFromMS(c.Config.Redis.MaxConnAgeMS)
+	if c.Config.Redis.MaxConnAge != 0 {
+		o.MaxConnAge = c.Config.Redis.MaxConnAge
 	}
 
-	if c.Config.Redis.PoolTimeoutMS != 0 {
-		o.PoolTimeout = durationFromMS(c.Config.Redis.PoolTimeoutMS)
+	if c.Config.Redis.PoolTimeout != 0 {
+		o.PoolTimeout = c.Config.Redis.PoolTimeout
 	}
 
-	if c.Config.Redis.IdleTimeoutMS != 0 {
-		o.IdleTimeout = durationFromMS(c.Config.Redis.IdleTimeoutMS)
+	if c.Config.Redis.IdleTimeout != 0 {
+		o.IdleTimeout = c.Config.Redis.IdleTimeout
 	}
 
-	if c.Config.Redis.IdleCheckFrequencyMS != 0 {
-		o.IdleCheckFrequency = durationFromMS(c.Config.Redis.IdleCheckFrequencyMS)
+	if c.Config.Redis.IdleCheckFrequency != 0 {
+		o.IdleCheckFrequency = c.Config.Redis.IdleCheckFrequency
 	}
 
 	return o, nil

--- a/pkg/cache/registration/registration_test.go
+++ b/pkg/cache/registration/registration_test.go
@@ -95,8 +95,8 @@ func newCacheConfig(t *testing.T, cacheProvider string) *co.Options {
 		BBolt:      &bbo.Options{Filename: "/tmp/test.db", Bucket: "trickster_test"},
 		Badger:     &bao.Options{Directory: bd, ValueDirectory: bd},
 		Index: &io.Options{
-			ReapIntervalMS:        3000,
-			FlushIntervalMS:       5000,
+			ReapInterval:          3000,
+			FlushInterval:         5000,
 			MaxSizeBytes:          536870912,
 			MaxSizeBackoffBytes:   16777216,
 			MaxSizeObjects:        0,

--- a/pkg/cache/registration/registration_test.go
+++ b/pkg/cache/registration/registration_test.go
@@ -18,6 +18,7 @@ package registration
 
 import (
 	"testing"
+	"time"
 
 	bao "github.com/trickstercache/trickster/v2/pkg/cache/badger/options"
 	bbo "github.com/trickstercache/trickster/v2/pkg/cache/bbolt/options"
@@ -95,8 +96,8 @@ func newCacheConfig(t *testing.T, cacheProvider string) *co.Options {
 		BBolt:      &bbo.Options{Filename: "/tmp/test.db", Bucket: "trickster_test"},
 		Badger:     &bao.Options{Directory: bd, ValueDirectory: bd},
 		Index: &io.Options{
-			ReapInterval:          3000,
-			FlushInterval:         5000,
+			ReapInterval:          3 * time.Millisecond,
+			FlushInterval:         5 * time.Millisecond,
 			MaxSizeBytes:          536870912,
 			MaxSizeBackoffBytes:   16777216,
 			MaxSizeObjects:        0,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -346,7 +346,7 @@ func (c *Config) IsStale() bool {
 	}
 
 	c.Main.configRateLimitTime =
-		time.Now().Add(time.Millisecond * time.Duration(c.ReloadConfig.RateLimitMS))
+		time.Now().Add(c.ReloadConfig.RateLimit)
 	t := c.CheckFileLastModified()
 	if t.IsZero() {
 		return false

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -277,7 +277,7 @@ func TestIsStale(t *testing.T) {
 	}
 
 	c, _ := Load([]string{"-config", testFile})
-	c.ReloadConfig.RateLimitMS = 0
+	c.ReloadConfig.RateLimit = 0
 
 	if c.IsStale() {
 		t.Error("expected non-stale config")

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -19,7 +19,6 @@ package config
 import (
 	"net/url"
 	"strings"
-	"time"
 
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/negative"
@@ -95,11 +94,6 @@ func Load(args []string) (*Config, error) {
 	err = bo.Lookup(c.Backends).Validate(ncl)
 	if err != nil {
 		return nil, err
-	}
-
-	for _, c := range c.Caches {
-		c.Index.FlushInterval = time.Duration(c.Index.FlushIntervalMS) * time.Millisecond
-		c.Index.ReapInterval = time.Duration(c.Index.ReapIntervalMS) * time.Millisecond
 	}
 
 	return c, nil

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -217,12 +217,12 @@ func TestFullLoadConfiguration(t *testing.T) {
 		t.Errorf("expected fast_forward_disable true, got %t", o.FastForwardDisable)
 	}
 
-	if o.BackfillToleranceMS != 301000 {
-		t.Errorf("expected 301000, got %d", o.BackfillToleranceMS)
+	if o.BackfillTolerance != 301000*time.Millisecond {
+		t.Errorf("expected 301000, got %d", o.BackfillTolerance)
 	}
 
-	if o.TimeoutMS != 37000 {
-		t.Errorf("expected 37000, got %d", o.TimeoutMS)
+	if o.Timeout != 37000*time.Millisecond {
+		t.Errorf("expected 37000, got %d", o.Timeout)
 	}
 
 	if o.IsDefault != true {
@@ -233,18 +233,18 @@ func TestFullLoadConfiguration(t *testing.T) {
 		t.Errorf("expected %d got %d", 23, o.MaxIdleConns)
 	}
 
-	if o.KeepAliveTimeoutMS != 7000 {
-		t.Errorf("expected %d got %d", 7, o.KeepAliveTimeoutMS)
+	if o.KeepAliveTimeout != 7000*time.Millisecond {
+		t.Errorf("expected %d got %d", 7, o.KeepAliveTimeout)
 	}
 
 	// MaxTTLMS is 300, thus should override TimeseriesTTLMS = 8666
-	if o.TimeseriesTTLMS != 300000 {
-		t.Errorf("expected 300000, got %d", o.TimeseriesTTLMS)
+	if o.TimeseriesTTL != 300000*time.Millisecond {
+		t.Errorf("expected 300000, got %d", o.TimeseriesTTL)
 	}
 
 	// MaxTTLMS is 300, thus should override FastForwardTTLMS = 382
-	if o.FastForwardTTLMS != 300000 {
-		t.Errorf("expected 300000, got %d", o.FastForwardTTLMS)
+	if o.FastForwardTTL != 300000*time.Millisecond {
+		t.Errorf("expected 300000, got %d", o.FastForwardTTL)
 	}
 
 	if o.TLS == nil {
@@ -283,12 +283,12 @@ func TestFullLoadConfiguration(t *testing.T) {
 		t.Errorf("expected redis, got %s", c.Provider)
 	}
 
-	if c.Index.ReapIntervalMS != 4000 {
-		t.Errorf("expected 4000, got %d", c.Index.ReapIntervalMS)
+	if c.Index.ReapInterval != 4000 {
+		t.Errorf("expected 4000, got %d", c.Index.ReapInterval)
 	}
 
-	if c.Index.FlushIntervalMS != 6000 {
-		t.Errorf("expected 6000, got %d", c.Index.FlushIntervalMS)
+	if c.Index.FlushInterval != 6000 {
+		t.Errorf("expected 6000, got %d", c.Index.FlushInterval)
 	}
 
 	if c.Index.MaxSizeBytes != 536870913 {
@@ -307,8 +307,8 @@ func TestFullLoadConfiguration(t *testing.T) {
 		t.Errorf("expected 20, got %d", c.Index.MaxSizeBackoffObjects)
 	}
 
-	if c.Index.ReapIntervalMS != 4000 {
-		t.Errorf("expected 4000, got %d", c.Index.ReapIntervalMS)
+	if c.Index.ReapInterval != 4000 {
+		t.Errorf("expected 4000, got %d", c.Index.ReapInterval)
 	}
 
 	if c.Redis.ClientType != "test_redis_type" {
@@ -339,24 +339,24 @@ func TestFullLoadConfiguration(t *testing.T) {
 		t.Errorf("expected 6, got %d", c.Redis.MaxRetries)
 	}
 
-	if c.Redis.MinRetryBackoffMS != 9 {
-		t.Errorf("expected 9, got %d", c.Redis.MinRetryBackoffMS)
+	if c.Redis.MinRetryBackoff != 9 {
+		t.Errorf("expected 9, got %d", c.Redis.MinRetryBackoff)
 	}
 
-	if c.Redis.MaxRetryBackoffMS != 513 {
-		t.Errorf("expected 513, got %d", c.Redis.MaxRetryBackoffMS)
+	if c.Redis.MaxRetryBackoff != 513 {
+		t.Errorf("expected 513, got %d", c.Redis.MaxRetryBackoff)
 	}
 
-	if c.Redis.DialTimeoutMS != 5001 {
-		t.Errorf("expected 5001, got %d", c.Redis.DialTimeoutMS)
+	if c.Redis.DialTimeout != 5001 {
+		t.Errorf("expected 5001, got %d", c.Redis.DialTimeout)
 	}
 
-	if c.Redis.ReadTimeoutMS != 3001 {
-		t.Errorf("expected 3001, got %d", c.Redis.ReadTimeoutMS)
+	if c.Redis.ReadTimeout != 3001 {
+		t.Errorf("expected 3001, got %d", c.Redis.ReadTimeout)
 	}
 
-	if c.Redis.WriteTimeoutMS != 3002 {
-		t.Errorf("expected 3002, got %d", c.Redis.WriteTimeoutMS)
+	if c.Redis.WriteTimeout != 3002 {
+		t.Errorf("expected 3002, got %d", c.Redis.WriteTimeout)
 	}
 
 	if c.Redis.PoolSize != 21 {
@@ -367,20 +367,20 @@ func TestFullLoadConfiguration(t *testing.T) {
 		t.Errorf("expected 5, got %d", c.Redis.PoolSize)
 	}
 
-	if c.Redis.MaxConnAgeMS != 2000 {
-		t.Errorf("expected 2000, got %d", c.Redis.MaxConnAgeMS)
+	if c.Redis.MaxConnAge != 2000 {
+		t.Errorf("expected 2000, got %d", c.Redis.MaxConnAge)
 	}
 
-	if c.Redis.PoolTimeoutMS != 4001 {
-		t.Errorf("expected 4001, got %d", c.Redis.PoolTimeoutMS)
+	if c.Redis.PoolTimeout != 4001 {
+		t.Errorf("expected 4001, got %d", c.Redis.PoolTimeout)
 	}
 
-	if c.Redis.IdleTimeoutMS != 300001 {
-		t.Errorf("expected 300001, got %d", c.Redis.IdleTimeoutMS)
+	if c.Redis.IdleTimeout != 300001 {
+		t.Errorf("expected 300001, got %d", c.Redis.IdleTimeout)
 	}
 
-	if c.Redis.IdleCheckFrequencyMS != 60001 {
-		t.Errorf("expected 60001, got %d", c.Redis.IdleCheckFrequencyMS)
+	if c.Redis.IdleCheckFrequency != 60001 {
+		t.Errorf("expected 60001, got %d", c.Redis.IdleCheckFrequency)
 	}
 
 	if c.Filesystem.CachePath != "test_cache_path" {
@@ -452,8 +452,8 @@ func TestEmptyLoadConfiguration(t *testing.T) {
 		return
 	}
 
-	if c.Index.ReapIntervalMS != 3000 {
-		t.Errorf("expected 3000, got %d", c.Index.ReapIntervalMS)
+	if c.Index.ReapInterval != 3000*time.Millisecond {
+		t.Errorf("expected 3000, got %d", c.Index.ReapInterval)
 	}
 
 	if c.Redis.Endpoint != "redis:6379" {
@@ -476,24 +476,24 @@ func TestEmptyLoadConfiguration(t *testing.T) {
 		t.Errorf("expected 0, got %d", c.Redis.MaxRetries)
 	}
 
-	if c.Redis.MinRetryBackoffMS != 0 {
-		t.Errorf("expected 0, got %d", c.Redis.MinRetryBackoffMS)
+	if c.Redis.MinRetryBackoff != 0 {
+		t.Errorf("expected 0, got %d", c.Redis.MinRetryBackoff)
 	}
 
-	if c.Redis.MaxRetryBackoffMS != 0 {
-		t.Errorf("expected 0, got %d", c.Redis.MaxRetryBackoffMS)
+	if c.Redis.MaxRetryBackoff != 0 {
+		t.Errorf("expected 0, got %d", c.Redis.MaxRetryBackoff)
 	}
 
-	if c.Redis.DialTimeoutMS != 0 {
-		t.Errorf("expected 0, got %d", c.Redis.DialTimeoutMS)
+	if c.Redis.DialTimeout != 0 {
+		t.Errorf("expected 0, got %d", c.Redis.DialTimeout)
 	}
 
-	if c.Redis.ReadTimeoutMS != 0 {
-		t.Errorf("expected 0, got %d", c.Redis.ReadTimeoutMS)
+	if c.Redis.ReadTimeout != 0 {
+		t.Errorf("expected 0, got %d", c.Redis.ReadTimeout)
 	}
 
-	if c.Redis.WriteTimeoutMS != 0 {
-		t.Errorf("expected 0, got %d", c.Redis.WriteTimeoutMS)
+	if c.Redis.WriteTimeout != 0 {
+		t.Errorf("expected 0, got %d", c.Redis.WriteTimeout)
 	}
 
 	if c.Redis.PoolSize != 0 {
@@ -504,20 +504,20 @@ func TestEmptyLoadConfiguration(t *testing.T) {
 		t.Errorf("expected 0, got %d", c.Redis.PoolSize)
 	}
 
-	if c.Redis.MaxConnAgeMS != 0 {
-		t.Errorf("expected 0, got %d", c.Redis.MaxConnAgeMS)
+	if c.Redis.MaxConnAge != 0 {
+		t.Errorf("expected 0, got %d", c.Redis.MaxConnAge)
 	}
 
-	if c.Redis.PoolTimeoutMS != 0 {
-		t.Errorf("expected 0, got %d", c.Redis.PoolTimeoutMS)
+	if c.Redis.PoolTimeout != 0 {
+		t.Errorf("expected 0, got %d", c.Redis.PoolTimeout)
 	}
 
-	if c.Redis.IdleTimeoutMS != 0 {
-		t.Errorf("expected 0, got %d", c.Redis.IdleTimeoutMS)
+	if c.Redis.IdleTimeout != 0 {
+		t.Errorf("expected 0, got %d", c.Redis.IdleTimeout)
 	}
 
-	if c.Redis.IdleCheckFrequencyMS != 0 {
-		t.Errorf("expected 0, got %d", c.Redis.IdleCheckFrequencyMS)
+	if c.Redis.IdleCheckFrequency != 0 {
+		t.Errorf("expected 0, got %d", c.Redis.IdleCheckFrequency)
 	}
 
 	if c.Filesystem.CachePath != "/tmp/trickster" {

--- a/pkg/config/reload/options/defaults.go
+++ b/pkg/config/reload/options/defaults.go
@@ -16,16 +16,18 @@
 
 package options
 
+import "time"
+
 const (
 	// DefaultReloadPort is the default port that the Reload endpoint will listen on
 	DefaultReloadPort = 8484
 	// DefaultReloadAddress is the default address that the Reload endpoint will listen on
 	DefaultReloadAddress = "127.0.0.1"
-	// DefaultDrainTimeoutMS is the default time that is allowed for an old configuration's requests to drain
+	// DefaultDrainTimeout is the default time that is allowed for an old configuration's requests to drain
 	// before its resources are closed
-	DefaultDrainTimeoutMS = 30000
-	// DefaultRateLimitMS is the default Rate Limit time for Config Reloads
-	DefaultRateLimitMS = 3000
+	DefaultDrainTimeout = 30000 * time.Millisecond
+	// DefaultRateLimit is the default Rate Limit time for Config Reloads
+	DefaultRateLimit = 3000 * time.Millisecond
 	// DefaultReloadHandlerPath defines the default path for the Reload Handler
 	DefaultReloadHandlerPath = "/trickster/config/reload"
 )

--- a/pkg/config/reload/options/defaults.go
+++ b/pkg/config/reload/options/defaults.go
@@ -25,9 +25,9 @@ const (
 	DefaultReloadAddress = "127.0.0.1"
 	// DefaultDrainTimeout is the default time that is allowed for an old configuration's requests to drain
 	// before its resources are closed
-	DefaultDrainTimeout = 30000 * time.Millisecond
+	DefaultDrainTimeout = 30 * time.Second
 	// DefaultRateLimit is the default Rate Limit time for Config Reloads
-	DefaultRateLimit = 3000 * time.Millisecond
+	DefaultRateLimit = 3 * time.Second
 	// DefaultReloadHandlerPath defines the default path for the Reload Handler
 	DefaultReloadHandlerPath = "/trickster/config/reload"
 )

--- a/pkg/config/reload/options/options.go
+++ b/pkg/config/reload/options/options.go
@@ -17,6 +17,8 @@
 // Package options provides options for configuration reload support
 package options
 
+import "time"
+
 // Options is a collection of configurations for in-process config reloading
 type Options struct {
 	// ListenAddress is IP address from which the Reload API is available at ReloadHandlerPath
@@ -25,23 +27,23 @@ type Options struct {
 	ListenPort int `yaml:"listen_port,omitempty"`
 	// ReloadHandlerPath provides the path to register the Config Reload Handler
 	HandlerPath string `yaml:"handler_path,omitempty"`
-	// DrainTimeoutMS provides the duration to wait for all sessions to drain before closing
+	// DrainTimeout provides the duration to wait for all sessions to drain before closing
 	// old resources following a reload
-	DrainTimeoutMS int `yaml:"drain_timeout_ms,omitempty"`
-	// RateLimitMS limits the # of handled config reload HTTP requests to 1 per CheckRateMS
+	DrainTimeout time.Duration `yaml:"drain_timeout,omitempty"`
+	// RateLimit limits the # of handled config reload HTTP requests to 1 per CheckRateMS
 	// if multiple HTTP requests are received in the rate limit window, only the first is handled
 	// This prevents a bad actor from stating the config file with millions of concurrent requests
 	// The rate limit does not apply to SIGHUP-based reload requests
-	RateLimitMS int `yaml:"rate_limit_ms,omitempty"`
+	RateLimit time.Duration `yaml:"rate_limit,omitempty"`
 }
 
 // New returns a new Options references with Default Values set
 func New() *Options {
 	return &Options{
-		ListenAddress:  DefaultReloadAddress,
-		ListenPort:     DefaultReloadPort,
-		HandlerPath:    DefaultReloadHandlerPath,
-		DrainTimeoutMS: DefaultDrainTimeoutMS,
-		RateLimitMS:    DefaultRateLimitMS,
+		ListenAddress: DefaultReloadAddress,
+		ListenPort:    DefaultReloadPort,
+		HandlerPath:   DefaultReloadHandlerPath,
+		DrainTimeout:  DefaultDrainTimeout,
+		RateLimit:     DefaultRateLimit,
 	}
 }

--- a/pkg/daemon/setup/listeners.go
+++ b/pkg/daemon/setup/listeners.go
@@ -78,7 +78,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 	hasOldFC := oldConf != nil && oldConf.Frontend != nil
 	hasOldMC := oldConf != nil && oldConf.Metrics != nil
 	hasOldRC := oldConf != nil && oldConf.ReloadConfig != nil
-	drainTimeout := time.Duration(conf.ReloadConfig.DrainTimeoutMS) * time.Millisecond
+	drainTimeout := conf.ReloadConfig.DrainTimeout
 	var tracerFlusherSet bool
 
 	// if TLS port is configured and at least one origin is mapped to a good tls config,
@@ -98,7 +98,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 			go lg.StartListener("tlsListener",
 				conf.Frontend.TLSListenAddress, conf.Frontend.TLSListenPort,
 				conf.Frontend.ConnectionsLimit, tlsConfig, router, tracers, errorFunc,
-				time.Duration(conf.ReloadConfig.DrainTimeoutMS)*time.Millisecond, conf.Frontend.ReadHeaderTimeout)
+				conf.ReloadConfig.DrainTimeout, conf.Frontend.ReadHeaderTimeout)
 		}
 	case !conf.Frontend.ServeTLS && hasOldFC && oldConf.Frontend.ServeTLS:
 		// the TLS configs have been removed between the last config load and this one,

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -172,8 +172,7 @@ func applyLoggingConfig(c, o *config.Config) {
 			if o.Logging.LogFile != "" {
 				// if we're changing from file1 -> console or file1 -> file2, close file1 handle
 				// the extra 1s allows HTTP listeners to close first and finish their log writes
-				go delayedLogCloser(oldLogger,
-					time.Duration(c.ReloadConfig.DrainTimeoutMS+1000)*time.Millisecond)
+				go delayedLogCloser(oldLogger, c.ReloadConfig.DrainTimeout+(1*time.Millisecond))
 			}
 			initLogger(c)
 			return
@@ -233,7 +232,7 @@ func applyCachingConfig(si *instance.ServerInstance,
 
 			// if we got to this point, the cache won't be used, so lets close it
 			go func() {
-				time.Sleep(time.Millisecond * time.Duration(newConf.ReloadConfig.DrainTimeoutMS))
+				time.Sleep(newConf.ReloadConfig.DrainTimeout)
 				w.Close()
 			}()
 		}

--- a/pkg/observability/tracing/exporters/otlp/otlp.go
+++ b/pkg/observability/tracing/exporters/otlp/otlp.go
@@ -20,7 +20,6 @@ package otlp
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	errs "github.com/trickstercache/trickster/v2/pkg/observability/tracing/errors"
@@ -75,10 +74,8 @@ func New(o *options.Options) (*tracing.Tracer, error) {
 		otlp.WithEndpoint(o.Endpoint)
 	}
 
-	if o.TimeoutMS > 0 {
-		opts = append(opts, otlp.WithTimeout(
-			time.Millisecond*time.Duration(int64(o.TimeoutMS))),
-		)
+	if o.Timeout > 0 {
+		opts = append(opts, otlp.WithTimeout(o.Timeout))
 	}
 
 	if len(o.Headers) > 0 {

--- a/pkg/observability/tracing/options/options.go
+++ b/pkg/observability/tracing/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"maps"
 	"slices"
+	"time"
 
 	stdoutopts "github.com/trickstercache/trickster/v2/pkg/observability/tracing/exporters/stdout/options"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
@@ -31,7 +32,7 @@ type Options struct {
 	Provider           string            `yaml:"provider,omitempty"`
 	ServiceName        string            `yaml:"service_name,omitempty"`
 	Endpoint           string            `yaml:"endpoint,omitempty"`
-	TimeoutMS          int               `yaml:"timeout_ms,omitempty"`
+	Timeout            time.Duration     `yaml:"timeout,omitempty"`
 	Headers            map[string]string `yaml:"headers,omitempty"`
 	DisableCompression bool              `yaml:"disable_compression,omitempty"`
 	SampleRate         float64           `yaml:"sample_rate,omitempty"`

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -344,7 +344,7 @@ checkCache:
 	// this concurrently fetches all missing ranges from the origin
 	if len(missRanges) > 0 {
 		if o.DoesShard {
-			missRanges = missRanges.Splice(trq.Step, o.MaxShardSize, o.ShardStep, o.MaxShardSizePoints)
+			missRanges = missRanges.Splice(trq.Step, o.MaxShardSizeTime, o.ShardStep, o.MaxShardSizePoints)
 		}
 		dpStatus["extentsFetched"] = missRanges.String()
 		frsc := request.NewResources(o, pc, cc, cache, client, rsc.Tracer)
@@ -522,7 +522,7 @@ func fetchTimeseries(pr *proxyRequest, trq *timeseries.TimeRangeQuery,
 
 	start := time.Now()
 	mts, _, resp, err := fetchExtents(timeseries.ExtentList{trq.Extent}.Splice(trq.Step,
-		o.MaxShardSize, o.ShardStep, o.MaxShardSizePoints), rsc,
+		o.MaxShardSizeTime, o.ShardStep, o.MaxShardSizePoints), rsc,
 		http.Header{}, client, pr, modeler.WireUnmarshalerReader, nil)
 
 	// elaspsed measures only the time spent making origin requests

--- a/pkg/proxy/engines/objectproxycache_bench_test.go
+++ b/pkg/proxy/engines/objectproxycache_bench_test.go
@@ -46,8 +46,7 @@ func BenchmarkObjectProxyCache(b *testing.B) {
 	r.Header.Add(headers.NameRange, "bytes=0-10000")
 
 	o := rsc.BackendOptions
-	o.MaxTTLMS = 15000
-	o.MaxTTL = time.Duration(o.MaxTTLMS) * time.Millisecond
+	o.MaxTTL = time.Duration(15000) * time.Millisecond
 
 	w := httptest.NewRecorder()
 	for i := 0; i < b.N; i++ {
@@ -75,8 +74,7 @@ func BenchmarkObjectProxyCacheChunks(b *testing.B) {
 	r.Header.Add(headers.NameRange, "bytes=0-10000")
 
 	o := rsc.BackendOptions
-	o.MaxTTLMS = 15000
-	o.MaxTTL = time.Duration(o.MaxTTLMS) * time.Millisecond
+	o.MaxTTL = time.Duration(15000) * time.Millisecond
 
 	w := httptest.NewRecorder()
 	for i := 0; i < b.N; i++ {

--- a/pkg/proxy/engines/objectproxycache_chunk_test.go
+++ b/pkg/proxy/engines/objectproxycache_chunk_test.go
@@ -47,8 +47,7 @@ func TestObjectProxyCacheRequestChunks(t *testing.T) {
 	r.Header.Add(headers.NameRange, "bytes=0-3")
 
 	o := rsc.BackendOptions
-	o.MaxTTLMS = 15000
-	o.MaxTTL = time.Duration(o.MaxTTLMS) * time.Millisecond
+	o.MaxTTL = time.Duration(15000) * time.Millisecond
 
 	_, e := testFetchOPC(r, http.StatusPartialContent, "test", map[string]string{"status": "kmiss"})
 	for _, err = range e {
@@ -489,8 +488,7 @@ func TestObjectProxyCacheRequestWithPCFChunks(t *testing.T) {
 	defer ts.Close()
 
 	o := rsc.BackendOptions
-	o.MaxTTLMS = 15000
-	o.MaxTTL = time.Duration(o.MaxTTLMS) * time.Millisecond
+	o.MaxTTL = time.Duration(15000) * time.Millisecond
 
 	r.Header.Set("testHeaderName", "testHeaderValue")
 

--- a/pkg/proxy/engines/objectproxycache_test.go
+++ b/pkg/proxy/engines/objectproxycache_test.go
@@ -132,8 +132,7 @@ func TestObjectProxyCacheRequest(t *testing.T) {
 	r.Header.Add(headers.NameRange, "bytes=0-3")
 
 	o := rsc.BackendOptions
-	o.MaxTTLMS = 15000
-	o.MaxTTL = time.Duration(o.MaxTTLMS) * time.Millisecond
+	o.MaxTTL = time.Duration(15000) * time.Millisecond
 
 	_, e := testFetchOPC(r, http.StatusPartialContent, "test", map[string]string{"status": "kmiss"})
 	for _, err = range e {
@@ -567,8 +566,7 @@ func TestObjectProxyCacheRequestWithPCF(t *testing.T) {
 	defer ts.Close()
 
 	o := rsc.BackendOptions
-	o.MaxTTLMS = 15000
-	o.MaxTTL = time.Duration(o.MaxTTLMS) * time.Millisecond
+	o.MaxTTL = time.Duration(15000) * time.Millisecond
 
 	r.Header.Set("testHeaderName", "testHeaderValue")
 

--- a/pkg/proxy/handlers/trickster/reload/reload_test.go
+++ b/pkg/proxy/handlers/trickster/reload/reload_test.go
@@ -50,7 +50,7 @@ func TestReloadHandleFunc(t *testing.T) {
 	}
 
 	cfg, _ := config.Load([]string{"-config", testFile})
-	cfg.ReloadConfig.RateLimitMS = 0
+	cfg.ReloadConfig.RateLimit = 0
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "/", nil)
 

--- a/pkg/proxy/paths/options/options.go
+++ b/pkg/proxy/paths/options/options.go
@@ -194,7 +194,7 @@ func (o *Options) Merge(o2 *Options) {
 }
 
 var pathMembers = []string{"path", "match_type", "handler", "methods", "cache_key_params",
-	"cache_key_headers", "default_ttl_ms", "request_params", "request_headers", "response_headers",
+	"cache_key_headers", "default_ttl", "request_params", "request_headers", "response_headers",
 	"response_headers", "response_code", "response_body", "no_metrics", "collapsed_forwarding",
 	"req_rewriter_name",
 }

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/prometheus/common/sigv4"
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
@@ -84,7 +83,7 @@ func NewHTTPClient(o *bo.Options) (*http.Client, error) {
 			return http.ErrUseLastResponse
 		},
 		Transport: &http.Transport{
-			Dial:                (&net.Dialer{KeepAlive: time.Duration(o.KeepAliveTimeoutMS) * time.Millisecond}).Dial,
+			Dial:                (&net.Dialer{KeepAlive: o.KeepAliveTimeout}).Dial,
 			MaxIdleConns:        o.MaxIdleConns,
 			MaxIdleConnsPerHost: o.MaxIdleConns,
 			TLSClientConfig:     TLSConfig,

--- a/pkg/util/middleware/config_context.go
+++ b/pkg/util/middleware/config_context.go
@@ -34,8 +34,8 @@ func WithResourcesContext(client backends.Backend, o *bo.Options,
 	next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
-		if o != nil && (o.LatencyMinMS > 0 || o.LatencyMaxMS > 0) {
-			processSimulatedLatency(w, o.LatencyMinMS, o.LatencyMaxMS)
+		if o != nil && (o.LatencyMin > 0 || o.LatencyMax > 0) {
+			processSimulatedLatency(w, o.LatencyMin, o.LatencyMax)
 		}
 
 		var resources *request.Resources

--- a/pkg/util/middleware/simulated_latency.go
+++ b/pkg/util/middleware/simulated_latency.go
@@ -25,15 +25,19 @@ import (
 
 const latencyHeaderName = "x-simulated-latency"
 
-func processSimulatedLatency(w http.ResponseWriter, minMS, maxMS int) {
-	if (minMS == 0 && maxMS == 0) || (minMS < 0 || maxMS < 0) {
+func processSimulatedLatency(w http.ResponseWriter, min, max time.Duration) {
+	if (min == 0 && max == 0) || (min < 0 || max < 0) {
 		return
 	}
+
+	minMS := min.Milliseconds()
+	maxMS := max.Milliseconds()
+
 	var ms int64
 	if minMS >= maxMS {
-		ms = int64(minMS)
+		ms = minMS
 	} else {
-		ms = (rand.Int63() % int64(maxMS-minMS)) + int64(minMS) // #nosec G404 -- we are OK with a weak random source, random-ish enough for our purposes, no security risk
+		ms = (rand.Int63()%maxMS - minMS) + minMS // #nosec G404 -- we are OK with a weak random source, random-ish enough for our purposes, no security risk
 	}
 	if ms <= 0 {
 		return

--- a/testdata/test.bad-cache-name.conf
+++ b/testdata/test.bad-cache-name.conf
@@ -20,12 +20,12 @@ caches:
   test:
     type: redis
     compression: true
-    timeseries_ttl_ms: 8666000
-    fastforward_ttl_ms: 17000
-    object_ttl_ms: 39000
+    timeseries_ttl: 8666000ms
+    fastforward_ttl: 17000ms
+    object_ttl: 39000ms
     index:
-      reap_interval_ms: 4000
-      flush_interval_ms: 6000
+      reap_interval: 4000ms
+      flush_interval: 6000ms
       max_size_bytes: 536870913
       max_size_backoff_bytes: 16777217
       max_size_objects: 80
@@ -40,17 +40,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9ms
+      max_retry_backoff: 513ms
+      dial_timeout: 5001ms
+      read_timeout: 3001ms
+      write_timeout: 3002ms
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000ms
+      pool_timeout: 4001ms
+      idle_timeout: 300001ms
+      idle_check_frequency: 60001ms
     filesystem:
       cache_path: test_cache_path
     bbolt:
@@ -71,11 +71,11 @@ backends:
     timeseries_retention_factor: 666
     timeseries_eviction_method: lru
     fast_forward_disable: true
-    backfill_tolerance_ms: 301000
-    timeout_ms: 37000
+    backfill_tolerance: 301000ms
+    timeout: 37000ms
     is_default: true
     max_idle_conns: 23
-    keep_alive_timeout_ms: 7000
+    keep_alive_timeout: 7000ms
     full_chain_cert_path: ../../testdata/test.01.cert.pem
     private_key_path: ../../testdata/test.01.key.pem
     require_tls: true

--- a/testdata/test.bad_origin_url.conf
+++ b/testdata/test.bad_origin_url.conf
@@ -20,12 +20,12 @@ caches:
   test:
     provider: test_type
     compression: true
-    timeseries_ttl_ms: 8666000
-    fastforward_ttl_ms: 17000
-    object_ttl_ms: 39000
+    timeseries_ttl: 8666000ms
+    fastforward_ttl: 17000ms
+    object_ttl: 39000ms
     index:
-      reap_interval_ms: 4000
-      flush_interval_ms: 6000
+      reap_interval: 4000ms
+      flush_interval: 6000ms
       max_size_bytes: 536870913
       max_size_backoff_bytes: 16777217
       max_size_objects: 80
@@ -40,17 +40,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9ms
+      max_retry_backoff: 513ms
+      dial_timeout: 5001ms
+      read_timeout: 3001ms
+      write_timeout: 3002ms
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000ms
+      pool_timeout: 4001ms
+      idle_timeout: 300001ms
+      idle_check_frequency: 60001ms
     filesystem:
       cache_path: test_cache_path
     bbolt:
@@ -67,12 +67,12 @@ backends:
     origin_url: 'sasdf_asd[as;://asdf923_-=a*'
     api_path: test_api_path
     max_idle_conns: 63
-    keep_alive_timeout_ms: 86400000
+    keep_alive_timeout: 86400000ms
     ignore_caching_headers: true
     value_retention_factor: 666
     fast_forward_disable: true
-    backfill_tolerance_ms: 301000
-    timeout_ms: 37000
+    backfill_tolerance: 301000ms
+    timeout: 37000ms
     health_check_endpoint: /test_health
     health_check_upstream_path: /test/upstream/endpoint
     health_check_verb: test_verb

--- a/testdata/test.cache-lru.conf
+++ b/testdata/test.cache-lru.conf
@@ -23,5 +23,5 @@ backends:
     origin_url: 'http://0.0.0.0/'
     timeseries_eviction_method: lru
     timeseries_retention_factor: 5
-    backfill_tolerance_ms: 1200000
+    backfill_tolerance: 1200000ms
 

--- a/testdata/test.full.02.conf
+++ b/testdata/test.full.02.conf
@@ -27,10 +27,10 @@ exporter:
 caches:
   test:
     provider: redis
-    object_ttl_ms: 39000
+    object_ttl: 39000ms
     index:
-      reap_interval_ms: 4000
-      flush_interval_ms: 6000
+      reap_interval: 4000
+      flush_interval: 6000
       max_size_bytes: 536870913
       max_size_backoff_bytes: 16777217
       max_size_objects: 80
@@ -45,17 +45,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9
+      max_retry_backoff: 513
+      dial_timeout: 5001
+      read_timeout: 3001
+      write_timeout: 3002
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000
+      pool_timeout: 4001
+      idle_timeout: 300001
+      idle_check_frequency: 60001
     filesystem:
       cache_path: test_cache_path
     bbolt:
@@ -80,20 +80,20 @@ backends:
     origin_url: 'scheme://test_host/test_path_prefix'
     api_path: test_api_path
     max_idle_conns: 23
-    keep_alive_timeout_ms: 7000
+    keep_alive_timeout: 7000ms
     ignore_caching_headers: true
     timeseries_retention_factor: 666
     timeseries_eviction_method: lru
     fast_forward_disable: true
-    backfill_tolerance_ms: 301000
-    timeout_ms: 37000
+    timeout: 37000ms
+    backfill_tolerance: 301000ms
     health_check_endpoint: /test_health
     health_check_upstream_path: /test/upstream/endpoint
     health_check_verb: test_verb
     health_check_query: query=1234
-    timeseries_ttl_ms: 8666000
-    max_ttl_ms: 300000
-    fastforward_ttl_ms: 382000
+    timeseries_ttl: 8666000ms
+    max_ttl: 300000ms
+    fastforward_ttl: 382000ms
     require_tls: true
     max_object_size_bytes: 999
     cache_key_prefix: test-prefix

--- a/testdata/test.full.conf
+++ b/testdata/test.full.conf
@@ -27,10 +27,10 @@ exporter:
 caches:
   test:
     provider: redis
-    object_ttl_ms: 39000
+    object_ttl: 39000ms
     index:
-      reap_interval_ms: 4000
-      flush_interval_ms: 6000
+      reap_interval: 4000ms
+      flush_interval: 6000ms
       max_size_bytes: 536870913
       max_size_backoff_bytes: 16777217
       max_size_objects: 80
@@ -45,17 +45,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9ms
+      max_retry_backoff: 513ms
+      dial_timeout: 5001ms
+      read_timeout: 3001ms
+      write_timeout: 3002ms
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000ms
+      pool_timeout: 4001ms
+      idle_timeout: 300001ms
+      idle_check_frequency: 60001ms
     filesystem:
       cache_path: test_cache_path
     bbolt:
@@ -80,20 +80,20 @@ backends:
     origin_url: 'scheme://test_host/test_path_prefix'
     api_path: test_api_path
     max_idle_conns: 23
-    keep_alive_timeout_ms: 7000
+    keep_alive_timeout: 7000ms
     ignore_caching_headers: true
     timeseries_retention_factor: 666
     timeseries_eviction_method: lru
     fast_forward_disable: true
-    backfill_tolerance_ms: 301000
-    timeout_ms: 37000
+    backfill_tolerance: 301000ms
+    timeout: 37000ms
     health_check_endpoint: /test_health
     health_check_upstream_path: /test/upstream/endpoint
     health_check_verb: test_verb
     health_check_query: query=1234
-    timeseries_ttl_ms: 8666000
-    max_ttl_ms: 300000
-    fastforward_ttl_ms: 382000
+    timeseries_ttl: 8666000ms
+    max_ttl: 300000ms
+    fastforward_ttl: 382000ms
     require_tls: true
     max_object_size_bytes: 999
     cache_key_prefix: test-prefix

--- a/testdata/test.full.tls.conf
+++ b/testdata/test.full.tls.conf
@@ -27,10 +27,10 @@ exporter:
 caches:
   test:
     provider: redis
-    object_ttl_ms: 39000
+    object_ttl: 39000ms
     index:
-      reap_interval_ms: 4000
-      flush_interval_ms: 6000
+      reap_interval: 4000ms
+      flush_interval: 6000ms
       max_size_bytes: 536870913
       max_size_backoff_bytes: 16777217
       max_size_objects: 80
@@ -45,17 +45,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9ms
+      max_retry_backoff: 513ms
+      dial_timeout: 5001ms
+      read_timeout: 3001ms
+      write_timeout: 3002ms
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000ms
+      pool_timeout: 4001ms
+      idle_timeout: 300001ms
+      idle_check_frequency: 60001ms
     filesystem:
       cache_path: test_cache_path
     bbolt:
@@ -80,20 +80,20 @@ backends:
     origin_url: 'scheme://test_host/test_path_prefix'
     api_path: test_api_path
     max_idle_conns: 23
-    keep_alive_timeout_ms: 7000
+    keep_alive_timeout: 7000ms
     ignore_caching_headers: true
     timeseries_retention_factor: 666
     timeseries_eviction_method: lru
     fast_forward_disable: true
-    backfill_tolerance_ms: 301000
-    timeout_ms: 37000
+    backfill_tolerance: 301000ms
+    timeout: 37000ms
     health_check_endpoint: /test_health
     health_check_upstream_path: /test/upstream/endpoint
     health_check_verb: test_verb
     health_check_query: query=1234
-    timeseries_ttl_ms: 8666000
-    max_ttl_ms: 300000
-    fastforward_ttl_ms: 382000
+    timeseries_ttl: 8666000ms
+    max_ttl: 300000ms
+    fastforward_ttl: 382000ms
     require_tls: true
     max_object_size_bytes: 999
     cache_key_prefix: test-prefix

--- a/testdata/test.invalid-pcf-name.conf
+++ b/testdata/test.invalid-pcf-name.conf
@@ -27,10 +27,10 @@ exporter:
 caches:
   test:
     provider: redis
-    object_ttl_ms: 39000
+    object_ttl: 39000ms
     index:
-      reap_interval_ms: 4000
-      flush_interval_ms: 6000
+      reap_interval: 4000ms
+      flush_interval: 6000ms
       max_size_bytes: 536870913
       max_size_backoff_bytes: 16777217
       max_size_objects: 80
@@ -45,17 +45,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9ms
+      max_retry_backoff: 513ms
+      dial_timeout: 5001ms
+      read_timeout: 3001ms
+      write_timeout: 3002ms
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000ms
+      pool_timeout: 4001ms
+      idle_timeout: 300001ms
+      idle_check_frequency: 60001ms
     filesystem:
       cache_path: test_cache_path
     bbolt:
@@ -80,20 +80,20 @@ backends:
     origin_url: 'scheme://test_host/test_path_prefix'
     api_path: test_api_path
     max_idle_conns: 23
-    keep_alive_timeout_ms: 7000
+    keep_alive_timeout: 7000ms
     ignore_caching_headers: true
     timeseries_retention_factor: 666
     timeseries_eviction_method: lru
     fast_forward_disable: true
-    backfill_tolerance_ms: 301000
-    timeout_ms: 37000
+    backfill_tolerance: 301000ms
+    timeout: 37000ms
     health_check_endpoint: /test_health
     health_check_upstream_path: /test/upstream/endpoint
     health_check_verb: test_verb
     health_check_query: query=1234
-    timeseries_ttl_ms: 8666000
-    max_ttl_ms: 300000
-    fastforward_ttl_ms: 382000
+    timeseries_ttl: 8666000ms
+    max_ttl: 300000ms
+    fastforward_ttl: 382000ms
     require_tls: true
     max_object_size_bytes: 999
     cache_key_prefix: test-prefix

--- a/testdata/test.missing_backend_provider.conf
+++ b/testdata/test.missing_backend_provider.conf
@@ -20,12 +20,12 @@ caches:
   test:
     provider: test_type
     compression: true
-    timeseries_ttl_ms: 8666000
-    fastforward_ttl_ms: 17000
-    object_ttl_ms: 39000
+    timeseries_ttl: 8666000ms
+    fastforward_ttl: 17000ms
+    object_ttl: 39000ms
     index:
-      reap_interval_ms: 4000
-      flush_interval_ms: 6000
+      reap_interval: 4000ms
+      flush_interval: 6000ms
       max_size_bytes: 536870913
       max_size_backoff_bytes: 16777217
       max_size_objects: 80
@@ -40,17 +40,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9ms
+      max_retry_backoff: 513ms
+      dial_timeout: 5001ms
+      read_timeout: 3001ms
+      write_timeout: 3002ms
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000ms
+      pool_timeout: 4001ms
+      idle_timeout: 300001ms
+      idle_check_frequency: 60001ms
     filesystem:
       cache_path: test_cache_path
     bbolt:
@@ -66,12 +66,12 @@ backends:
     origin_url: 'http://1'
     api_path: test_api_path
     max_idle_conns: 63
-    keep_alive_timeout_ms: 86400000
+    keep_alive_timeout: 86400000ms
     ignore_caching_headers: true
     value_retention_factor: 666
     fast_forward_disable: true
-    backfill_tolerance_ms: 301000
-    timeout_ms: 37000
+    backfill_tolerance: 301000ms
+    timeout: 37000ms
     health_check_endpoint: /test_health
     health_check_upstream_path: /test/upstream/endpoint
     health_check_verb: test_verb

--- a/testdata/test.redis-cluster.conf
+++ b/testdata/test.redis-cluster.conf
@@ -17,7 +17,7 @@ caches:
   test:
     provider: redis
     compression: true
-    object_ttl_ms: 39000
+    object_ttl: 39000ms
     redis:
       client_type: cluster
       protocol: test_protocol
@@ -28,17 +28,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9ms
+      max_retry_backoff: 513ms
+      dial_timeout: 5001ms
+      read_timeout: 3001ms
+      write_timeout: 3002ms
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000ms
+      pool_timeout: 4001ms
+      idle_timeout: 300001ms
+      idle_check_frequency: 60001ms
 frontend:
   listen_port: 57821
   listen_address: test

--- a/testdata/test.redis-sentinel.conf
+++ b/testdata/test.redis-sentinel.conf
@@ -17,7 +17,7 @@ caches:
   test:
     provider: redis
     compression: true
-    object_ttl_ms: 39000
+    object_ttl: 39000ms
     redis:
       client_type: sentinel
       protocol: test_protocol
@@ -28,17 +28,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9ms
+      max_retry_backoff: 513ms
+      dial_timeout: 5001ms
+      read_timeout: 3001ms
+      write_timeout: 3002ms
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000ms
+      pool_timeout: 4001ms
+      idle_timeout: 300001ms
+      idle_check_frequency: 60001ms
 frontend:
   listen_port: 57821
   listen_address: test

--- a/testdata/test.redis-standard.conf
+++ b/testdata/test.redis-standard.conf
@@ -17,7 +17,7 @@ caches:
   test:
     provider: redis
     compression: true
-    object_ttl_ms: 39000
+    object_ttl: 39000ms
     redis:
       client_type: standard
       protocol: test_protocol
@@ -28,17 +28,17 @@ caches:
       password: test_password
       db: 42
       max_retries: 6
-      min_retry_backoff_ms: 9
-      max_retry_backoff_ms: 513
-      dial_timeout_ms: 5001
-      read_timeout_ms: 3001
-      write_timeout_ms: 3002
+      min_retry_backoff: 9ms
+      max_retry_backoff: 513ms
+      dial_timeout: 5001ms
+      read_timeout: 3001ms
+      write_timeout: 3002ms
       pool_size: 21
       min_idle_conns: 5
-      max_conn_age_ms: 2000
-      pool_timeout_ms: 4001
-      idle_timeout_ms: 300001
-      idle_check_frequency_ms: 60001
+      max_conn_age: 2000ms
+      pool_timeout: 4001ms
+      idle_timeout: 300001ms
+      idle_check_frequency: 60001ms
 frontend:
   listen_port: 57821
   listen_address: test


### PR DESCRIPTION
Converts tricksters config to utilize `time.Duration` inputs instead of specifying milliseconds in `int` fields.

Resolves #793

~~To Do:~~
- [x] rebase after #792 merges
- [x] review README / docs / examples further for missing updates