### PR TITLE
fix: revert default backend timeout to 3 minutes

### DIFF
--- a/pkg/backends/healthcheck/options/options.go
+++ b/pkg/backends/healthcheck/options/options.go
@@ -28,7 +28,7 @@ import (
 )
 
 // MaxProbeWait is the maximum time a health check will wait before timing out
-const MaxProbeWait = 30000 * time.Millisecond
+const MaxProbeWait = 30 * time.Second
 
 // MinProbeWait is the minimum time a health check will wait before timing out
 const MinProbeWait = 100 * time.Millisecond

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -226,7 +226,7 @@ func New() *Options {
 		MaxShardSizeTime:             DefaultTimeseriesShardSize,
 		ShardStep:                    DefaultTimeseriesShardStep,
 		TLS:                          &to.Options{},
-		Timeout:                      DefaultBackendTimeout * time.Millisecond,
+		Timeout:                      DefaultBackendTimeout,
 		TimeseriesEvictionMethod:     DefaultBackendTEM,
 		TimeseriesEvictionMethodName: DefaultBackendTEMName,
 		TimeseriesRetention:          DefaultBackendTRF,


### PR DESCRIPTION
One more fix to the time usage -- follow up to #794.

This fixes the default backend timeout, dropping an unnecessary multiplication.