### PR TITLE
replace mutex w/ atomic.Value in CertSwapper

### DIFF
--- a/pkg/proxy/tls/swapper.go
+++ b/pkg/proxy/tls/swapper.go
@@ -19,53 +19,54 @@ package tls
 import (
 	"crypto/tls"
 	"errors"
-	"sync"
+	"sync/atomic"
 )
 
 // CertSwapper is used by a TLSConfig to dynamically update the running Listener's Certificate list
 // This allows Trickster to load and unload TLS certificate configs without restarting the process
 type CertSwapper struct {
-	*sync.Mutex
-	Certificates []tls.Certificate
+	Certificates atomic.Value
+	hasCerts     bool
 }
 
 var errNoCertificates = errors.New("tls: no certificates configured")
 
 // NewSwapper returns a new *CertSwapper based on the provided certList
 func NewSwapper(certList []tls.Certificate) *CertSwapper {
-	return &CertSwapper{
-		Mutex:        &sync.Mutex{},
-		Certificates: certList,
-	}
+	sw := &CertSwapper{}
+	sw.SetCerts(certList)
+	return sw
 }
 
 // GetCert returns the best-matching certificate for the provided clientHello
 func (c *CertSwapper) GetCert(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	c.Lock()
-	defer c.Unlock()
-
-	if len(c.Certificates) == 0 {
+	if !c.hasCerts {
+		return nil, errNoCertificates
+	}
+	certs, ok := c.Certificates.Load().([]tls.Certificate)
+	if !ok || len(certs) == 0 {
 		return nil, errNoCertificates
 	}
 
-	if len(c.Certificates) == 1 {
+	if len(certs) == 1 {
 		// There's only one choice, so no point doing any work.
-		return &c.Certificates[0], nil
+		return &certs[0], nil
 	}
 
-	for _, cert := range c.Certificates {
+	for _, cert := range certs {
 		if err := clientHello.SupportsCertificate(&cert); err == nil {
 			return &cert, nil
 		}
 	}
 
 	// If nothing matches, return the first certificate.
-	return &c.Certificates[0], nil
+	return &certs[0], nil
 }
 
 // SetCerts safely updates the certs list for the subject *CertSwapper
 func (c *CertSwapper) SetCerts(certs []tls.Certificate) {
-	c.Lock()
-	defer c.Unlock()
-	c.Certificates = certs
+	var v atomic.Value
+	v.Store(certs)
+	c.Certificates = v
+	c.hasCerts = len(certs) > 0
 }

--- a/pkg/proxy/tls/swapper_test.go
+++ b/pkg/proxy/tls/swapper_test.go
@@ -59,13 +59,16 @@ func TestGetSetCert(t *testing.T) {
 	if closer2 != nil {
 		defer closer2()
 	}
-	sw.Certificates = append(sw.Certificates, cfg2.Certificates...)
+
+	certs := sw.Certificates.Load().([]tls.Certificate)
+	certs = append(certs, cfg2.Certificates...)
+	sw.Certificates.Store(certs)
 	_, err = sw.GetCert(chi)
 	if err != nil {
 		t.Error(err)
 	}
 
-	sw.Certificates = nil
+	sw.Certificates.Store([]tls.Certificate{})
 	_, err = sw.GetCert(chi)
 	if err == nil || err.Error() != "tls: no certificates configured" {
 		t.Errorf("expected error for no certificates configured. %s", err.Error())


### PR DESCRIPTION
This change swaps out a deferred `sync.Mutex` for an `atomic.Value` in `CertSwapper.GetCert()` to shave some nanoseconds off of every frontend TLS handshake.

```
BenchmarkAtomicValueLoadAndCast-16        1000000000   0.7823 ns/op  0 B/op  0 allocs/op
BenchmarkMutexedRead-16                    443751698    2.700 ns/op  0 B/op  0 allocs/op
BenchmarkMutexedReadDeferredUnlock-16      304530106    3.939 ns/op  0 B/op  0 allocs/op
```
