### PR TITLE
perf: make less WaitGroup.Add calls

### DIFF
--- a/pkg/backends/alb/first_response.go
+++ b/pkg/backends/alb/first_response.go
@@ -50,8 +50,8 @@ func (c *Client) handleFirstResponse(w http.ResponseWriter, r *http.Request) {
 	// otherwise iterate the fanout
 	wc := newResponderClaim(l)
 	var wg sync.WaitGroup
+	wg.Add(l)
 	for i := 0; i < l; i++ {
-		wg.Add(1)
 		// only the one of these i fanouts to respond will be mapped back to the end user
 		// based on the methodology
 		// and the rest will have their contexts canceled

--- a/pkg/backends/alb/first_response.go
+++ b/pkg/backends/alb/first_response.go
@@ -57,6 +57,7 @@ func (c *Client) handleFirstResponse(w http.ResponseWriter, r *http.Request) {
 		// and the rest will have their contexts canceled
 		go func(j int) {
 			if hl[j] == nil {
+				wg.Done()
 				return
 			}
 			wm := newFirstResponseGate(w, wc, j, c.fgr)

--- a/pkg/backends/clickhouse/model/model.go
+++ b/pkg/backends/clickhouse/model/model.go
@@ -650,8 +650,8 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 	}
 
 	var wg sync.WaitGroup
+	wg.Add(len(r.SeriesList))
 	for _, s = range r.SeriesList {
-		wg.Add(1)
 		go func(gs *dataset.Series) {
 			sort.Sort(gs.Points)
 			wg.Done()

--- a/pkg/backends/influxdb/model/unmarshal.go
+++ b/pkg/backends/influxdb/model/unmarshal.go
@@ -163,8 +163,8 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 			var mtx sync.Mutex
 			var wg sync.WaitGroup
 			ume := make(chan error, len(wfd.Results[i].SeriesList[j].Values))
+			wg.Add(len(wfd.Results[i].SeriesList[j].Values))
 			for vi, v := range wfd.Results[i].SeriesList[j].Values {
-				wg.Add(1)
 				go func(vals []interface{}, idx int) {
 					pt, cols, err := pointFromValues(vals, sh.TimestampIndex)
 					if err != nil {

--- a/pkg/backends/prometheus/model/timeseries.go
+++ b/pkg/backends/prometheus/model/timeseries.go
@@ -108,21 +108,21 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 		l := len(pr.Values)
 		var ps int64 = 16
 		if wfd.Data.ResultType == "matrix" && l > 0 {
-			pts = make(dataset.Points, 0, l)
+			pts = make(dataset.Points, l)
 			var wg sync.WaitGroup
 			wg.Add(len(pr.Values))
 			var mtx sync.Mutex
-			for _, v := range pr.Values {
-				go func(vals []interface{}) {
+			for i, v := range pr.Values {
+				go func(index int, vals []interface{}) {
 					pt, _ := pointFromValues(vals)
 					if pt.Epoch > 0 {
 						mtx.Lock()
 						ps += int64(pt.Size)
-						pts = append(pts, pt)
+						pts[index] = pt
 						mtx.Unlock()
 					}
 					wg.Done()
-				}(v)
+				}(i, v)
 			}
 			wg.Wait()
 		} else if wfd.Data.ResultType == "vector" && len(pr.Value) == 2 {

--- a/pkg/backends/prometheus/model/timeseries.go
+++ b/pkg/backends/prometheus/model/timeseries.go
@@ -110,9 +110,9 @@ func UnmarshalTimeseriesReader(reader io.Reader, trq *timeseries.TimeRangeQuery)
 		if wfd.Data.ResultType == "matrix" && l > 0 {
 			pts = make(dataset.Points, 0, l)
 			var wg sync.WaitGroup
+			wg.Add(len(pr.Values))
 			var mtx sync.Mutex
 			for _, v := range pr.Values {
-				wg.Add(1)
 				go func(vals []interface{}) {
 					pt, _ := pointFromValues(vals)
 					if pt.Epoch > 0 {

--- a/pkg/backends/prometheus/model/timeseries_test.go
+++ b/pkg/backends/prometheus/model/timeseries_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/trickstercache/trickster/v2/pkg/errors"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
@@ -57,10 +58,20 @@ func TestUnmarshalTimeseriesReader(t *testing.T) {
 	}
 
 	r = bytes.NewReader([]byte(testMatrix))
-	_, err = UnmarshalTimeseriesReader(r, &timeseries.TimeRangeQuery{})
+	result, err := UnmarshalTimeseriesReader(r, &timeseries.TimeRangeQuery{})
 	if err != nil {
 		t.Error(err)
 	}
+
+	dataset, ok := result.(*dataset.DataSet)
+	require.True(t, ok)
+	require.Len(t, dataset.Results, 1)
+	// verify the first result series are in expected order
+	require.Len(t, dataset.Results[0].SeriesList, 2)
+	require.Len(t, dataset.Results[0].SeriesList[0].Points, 3)
+	require.Equal(t, epoch.Epoch(1435781430000000000), dataset.Results[0].SeriesList[0].Points[0].Epoch)
+	require.Equal(t, epoch.Epoch(1435781445000000000), dataset.Results[0].SeriesList[0].Points[1].Epoch)
+	require.Equal(t, epoch.Epoch(1435781460000000000), dataset.Results[0].SeriesList[0].Points[2].Epoch)
 
 }
 

--- a/pkg/cache/filesystem/filesystem.go
+++ b/pkg/cache/filesystem/filesystem.go
@@ -194,9 +194,8 @@ func (c *Cache) remove(cacheKey string, isBulk bool) {
 // BulkRemove removes a list of objects from the cache
 func (c *Cache) BulkRemove(cacheKeys []string) {
 	wg := &sync.WaitGroup{}
-
+	wg.Add(len(cacheKeys))
 	for _, cacheKey := range cacheKeys {
-		wg.Add(1)
 		go func(key string) {
 			c.remove(key, true)
 			wg.Done()

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -199,8 +199,8 @@ func (c *Cache) remove(cacheKey string, isBulk bool) {
 // BulkRemove removes a list of objects from the cache
 func (c *Cache) BulkRemove(cacheKeys []string) {
 	wg := &sync.WaitGroup{}
+	wg.Add(len(cacheKeys))
 	for _, cacheKey := range cacheKeys {
-		wg.Add(1)
 		go func(key string) {
 			c.remove(key, true)
 			wg.Done()

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -590,8 +590,8 @@ func fetchExtents(el timeseries.ExtentList, rsc *request.Resources, h http.Heade
 	mresp := &http.Response{Header: h}
 
 	// iterate each time range that the client needs and fetch from the upstream origin
+	wg.Add(el.Len())
 	for i := range el {
-		wg.Add(1)
 		// This concurrently fetches gaps from the origin and adds their datasets to the merge list
 		go func(e *timeseries.Extent, rq *proxyRequest) {
 			defer wg.Done()

--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -297,8 +297,8 @@ func (pr *proxyRequest) makeUpstreamRequests() error {
 	if len(pr.originRequests) > 0 {
 		pr.originResponses = make([]*http.Response, len(pr.originRequests))
 		pr.originReaders = make([]io.ReadCloser, len(pr.originRequests))
+		wg.Add(len(pr.originRequests))
 		for i := range pr.originRequests {
-			wg.Add(1)
 			go func(j int) {
 				req := pr.originRequests[j]
 				_, span := tspan.NewChildSpan(req.Context(), rsc.Tracer, "Fetch")
@@ -670,8 +670,8 @@ func (pr *proxyRequest) reconstituteResponses() {
 			}
 		}
 
+		wg.Add(len(pr.originRequests))
 		for i := range pr.originRequests {
-			wg.Add(1)
 			go func(j int) {
 				r := pr.originRequests[j]
 				resp := pr.originResponses[j]


### PR DESCRIPTION
* Prefer adding to a waitgroup once instead of per loop item when we do not skip loop items.
* Fix bug in prometheus timeseries unmarshal code where points were likely to be out of order