### PR TITLE
perf: optimize logging package

### DIFF
--- a/pkg/observability/logging/level/level.go
+++ b/pkg/observability/logging/level/level.go
@@ -16,8 +16,6 @@
 
 package level
 
-import "strings"
-
 type Level string
 type LevelID int
 
@@ -35,17 +33,18 @@ const (
 	TraceID LevelID = 5
 )
 
-var validLevels = map[Level]LevelID{
-	Debug: DebugID,
-	Info:  InfoID,
-	Warn:  WarnID,
-	Error: ErrorID,
-	Fatal: TraceID,
-}
-
 func GetLevelID(logLevel Level) LevelID {
-	if i, ok := validLevels[Level(strings.ToLower(string(logLevel)))]; ok {
-		return i
+	switch logLevel {
+	case Debug:
+		return DebugID
+	case Info:
+		return InfoID
+	case Warn:
+		return WarnID
+	case Error:
+		return ErrorID
+	case Fatal:
+		return TraceID
 	}
 	return 0
 }

--- a/pkg/observability/logging/level/level_test.go
+++ b/pkg/observability/logging/level/level_test.go
@@ -28,3 +28,9 @@ func TestGetLevelID(t *testing.T) {
 		t.Errorf("expected %d got %d", InfoID, id)
 	}
 }
+
+func BenchmarkGetLevelID(b *testing.B) {
+	for b.Loop() {
+		GetLevelID(Info)
+	}
+}

--- a/pkg/observability/logging/logging.go
+++ b/pkg/observability/logging/logging.go
@@ -17,6 +17,7 @@
 package logging
 
 import (
+	"cmp"
 	"fmt"
 	"io"
 	"os"
@@ -79,7 +80,9 @@ type Pairs map[string]any
 // returned Logger will write to files distinguished from other Loggers by the
 // instance string.
 func New(conf *config.Config) Logger {
-	l := &logger{}
+	l := &logger{
+		now: time.Now,
+	}
 	l.logFunc = l.logAsyncronous
 	if conf.Logging.LogFile == "" {
 		l.writer = os.Stdout
@@ -109,6 +112,7 @@ func NoopLogger() Logger {
 		logFunc: func(level.Level, string, Pairs) {},
 		levelID: level.InfoID,
 		level:   level.Info,
+		now:     time.Now,
 	}
 	return l
 }
@@ -116,6 +120,7 @@ func NoopLogger() Logger {
 func StreamLogger(w io.Writer, logLevel level.Level) Logger {
 	l := &logger{
 		writer: w,
+		now:    time.Now,
 	}
 	l.logFunc = l.logAsyncronous
 
@@ -129,6 +134,7 @@ func StreamLogger(w io.Writer, logLevel level.Level) Logger {
 func ConsoleLogger(logLevel level.Level) Logger {
 	l := &logger{
 		writer: os.Stdout,
+		now:    time.Now,
 	}
 	l.logFunc = l.logAsyncronous
 	l.SetLogLevel(logLevel)
@@ -143,6 +149,7 @@ type logger struct {
 	mtx            sync.Mutex
 	onceRanEntries sync.Map
 	logFunc        logFunc
+	now            func() time.Time
 }
 
 func (l *logger) Write(b []byte) (int, error) {
@@ -313,41 +320,69 @@ func (l *logger) logAsyncronous(logLevel level.Level, event string, detail Pairs
 	go l.log(logLevel, event, detail)
 }
 
-const defaultLogItemCount = 4
+type item struct {
+	key string
+	val string
+}
+
+func (i *item) Bytes() []byte {
+	return append([]byte(i.key), append([]byte(equal), []byte(i.val)...)...)
+}
+
+const (
+	space   = " "
+	equal   = "="
+	newline = "\n"
+)
 
 func (l *logger) log(logLevel level.Level, event string, detail Pairs) {
 	if l.writer == nil {
 		return
 	}
-	ts := time.Now()
+	ts := l.now()
 	ld := len(detail)
-	keys := make([]string, defaultLogItemCount, ld+defaultLogItemCount)
-	keys[0] = "time=" + ts.UTC().Format(time.RFC3339Nano)
-	keys[1] = "app=trickster"
-	keys[2] = "level=" + string(logLevel)
-	if strings.HasPrefix(event, " ") || strings.HasSuffix(event, " ") {
+	if strings.HasPrefix(event, space) || strings.HasSuffix(event, space) {
 		event = strings.TrimSpace(event)
 	}
-	keys[3] = "event=" + quoteAsNeeded(event)
-	var i int
+	logLine := []byte(
+		"time=" + ts.UTC().Format(time.RFC3339Nano) + space +
+			"app=trickster" + space +
+			"level=" + string(logLevel) + space +
+			"event=" + quoteAsNeeded(event),
+	)
 	if ld > 0 {
-		sortedKeys := make([]string, ld)
+		logLine = append(logLine, []byte(space)...)
+		keyPairs := make([]item, ld)
+		var i int
 		for k, v := range detail {
-			if s, ok := v.(string); ok {
-				v = quoteAsNeeded(s)
+			var s string
+			var ok bool
+			if s, ok = v.(string); ok {
+				s = quoteAsNeeded(s)
 			} else if stringer, ok := v.(fmt.Stringer); ok {
-				v = quoteAsNeeded(stringer.String())
+				s = quoteAsNeeded(stringer.String())
 			} else if err, ok := v.(error); ok {
-				v = quoteAsNeeded(err.Error())
+				s = quoteAsNeeded(err.Error())
+			} else {
+				s = fmt.Sprintf("%v", v)
 			}
-			sortedKeys[i] = fmt.Sprintf("%s=%v", k, v)
+			keyPairs[i] = item{k, s}
 			i++
 		}
-		slices.Sort(sortedKeys)
-		keys = append(keys, sortedKeys...)
+		slices.SortFunc(keyPairs, func(a, b item) int {
+			return cmp.Compare(a.key, b.key)
+		})
+		i = 0
+		for _, v := range keyPairs {
+			logLine = append(logLine, v.Bytes()...)
+			i++
+			if i < ld {
+				logLine = append(logLine, []byte(space)...)
+			}
+		}
 	}
 	l.mtx.Lock()
-	l.writer.Write([]byte(strings.Join(keys, " ") + "\n"))
+	l.writer.Write(append(logLine, []byte(newline)...))
 	l.mtx.Unlock()
 }
 

--- a/pkg/observability/logging/logging.go
+++ b/pkg/observability/logging/logging.go
@@ -187,32 +187,27 @@ func (l *logger) Log(logLevel level.Level, event string, detail Pairs) {
 	l.logFunc(logLevel, event, detail)
 }
 
-func (l *logger) Debug(event string, detail Pairs) {
-	if l.levelID > level.DebugID {
+func (l *logger) logFuncConditionally(level level.Level, levelID level.LevelID, event string, detail Pairs) {
+	if l.levelID > levelID {
 		return
 	}
-	l.logFunc(level.Debug, event, detail)
+	l.logFunc(level, event, detail)
+}
+
+func (l *logger) Debug(event string, detail Pairs) {
+	l.logFuncConditionally(level.Debug, level.DebugID, event, detail)
 }
 
 func (l *logger) Info(event string, detail Pairs) {
-	if l.levelID > level.InfoID {
-		return
-	}
-	l.logFunc(level.Info, event, detail)
+	l.logFuncConditionally(level.Info, level.InfoID, event, detail)
 }
 
 func (l *logger) Warn(event string, detail Pairs) {
-	if l.levelID > level.WarnID {
-		return
-	}
-	l.logFunc(level.Warn, event, detail)
+	l.logFuncConditionally(level.Warn, level.WarnID, event, detail)
 }
 
 func (l *logger) Error(event string, detail Pairs) {
-	if l.levelID > level.ErrorID {
-		return
-	}
-	l.logFunc(level.Error, event, detail)
+	l.logFuncConditionally(level.Error, level.ErrorID, event, detail)
 }
 
 func (l *logger) LogSynchronous(logLevel level.Level, event string, detail Pairs) {
@@ -224,32 +219,27 @@ func (l *logger) LogSynchronous(logLevel level.Level, event string, detail Pairs
 
 }
 
-func (l *logger) DebugSynchronous(event string, detail Pairs) {
-	if l.levelID > level.DebugID {
+func (l *logger) logConditionally(level level.Level, levelID level.LevelID, event string, detail Pairs) {
+	if l.levelID > levelID {
 		return
 	}
-	l.log(level.Debug, event, detail)
+	l.log(level, event, detail)
+}
+
+func (l *logger) DebugSynchronous(event string, detail Pairs) {
+	l.logConditionally(level.Debug, level.DebugID, event, detail)
 }
 
 func (l *logger) InfoSynchronous(event string, detail Pairs) {
-	if l.levelID > level.InfoID {
-		return
-	}
-	l.log(level.Info, event, detail)
+	l.logConditionally(level.Info, level.InfoID, event, detail)
 }
 
 func (l *logger) WarnSynchronous(event string, detail Pairs) {
-	if l.levelID > level.WarnID {
-		return
-	}
-	l.log(level.Warn, event, detail)
+	l.logConditionally(level.Warn, level.WarnID, event, detail)
 }
 
 func (l *logger) ErrorSynchronous(event string, detail Pairs) {
-	if l.levelID > level.ErrorID {
-		return
-	}
-	l.log(level.Error, event, detail)
+	l.logConditionally(level.Error, level.ErrorID, event, detail)
 }
 
 func (l *logger) Fatal(code int, event string, detail Pairs) {

--- a/pkg/observability/logging/logging_test.go
+++ b/pkg/observability/logging/logging_test.go
@@ -261,3 +261,17 @@ func TestStreamLogger(t *testing.T) {
 	}
 
 }
+
+func Benchmark_logOnce(b *testing.B) {
+	fileName := b.TempDir() + "/out.once.bench.log"
+	conf := config.NewConfig()
+	conf.Main = &config.MainConfig{InstanceID: 0}
+	conf.Logging = &options.Options{LogFile: fileName, LogLevel: "debug"}
+	logger := New(conf)
+	logger.SetLogAsynchronous(false)
+	b.ResetTimer()
+	for b.Loop() {
+		logger.InfoOnce("bench-test-key", "test entry", Pairs{"testKey": "testVal"})
+	}
+
+}

--- a/pkg/observability/logging/logging_test.go
+++ b/pkg/observability/logging/logging_test.go
@@ -20,7 +20,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/require"
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/options"
@@ -64,13 +66,25 @@ func TestNewLogger_LogFile(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 1}
 	conf.Logging = &options.Options{LogFile: fileName, LogLevel: "info"}
-	logger := New(conf)
-	logger.SetLogAsynchronous(false)
-	logger.Info("testEntry ", Pairs{"testKey": "test Val", "testKey2": "testValue2"})
+	log := New(conf)
+	l := log.(*logger)
+	l.now = func() time.Time {
+		return time.Time{}
+	}
+	log.SetLogAsynchronous(false)
+	log.Info("testEntry ", Pairs{
+		"testKey":  "test Val",
+		"testKey2": "testValue2",
+		"testKey3": "testValue3",
+	})
 	if _, err := os.Stat(instanceFileName); err != nil {
 		t.Error(err)
 	}
-	logger.Close()
+	log.Close()
+	// now inspect the file for consistent output
+	b, err := os.ReadFile(instanceFileName)
+	require.NoError(t, err)
+	require.Equal(t, `time=0001-01-01T00:00:00Z app=trickster level=info event=testEntry testKey="test Val" testKey2=testValue2 testKey3=testValue3`+"\n", string(b))
 }
 
 func TestNewLoggerDebug_LogFile(t *testing.T) {
@@ -273,5 +287,17 @@ func Benchmark_logOnce(b *testing.B) {
 	for b.Loop() {
 		logger.InfoOnce("bench-test-key", "test entry", Pairs{"testKey": "testVal"})
 	}
+}
 
+func Benchmark_Info(b *testing.B) {
+	fileName := b.TempDir() + "/out.info.bench.log"
+	conf := config.NewConfig()
+	conf.Main = &config.MainConfig{InstanceID: 0}
+	conf.Logging = &options.Options{LogFile: fileName, LogLevel: "debug"}
+	logger := New(conf)
+	logger.SetLogAsynchronous(false)
+	b.ResetTimer()
+	for b.Loop() {
+		logger.Info("test entry", Pairs{"testKey": "testVal", "testkey2": "testVal2"})
+	}
 }


### PR DESCRIPTION
Scanning the codebase for some simple performance gains -- here's a 5x speedup of log level ID conversion:

---

1. Removes a map lookup in favor of a simple type switch.

```console
BenchmarkGetLevelID-12    	549921196	         2.106 ns/op	       0 B/op	       0 allocs/op
```

vs main
```console
BenchmarkGetLevelID-12    	100000000	        11.45 ns/op	       0 B/op	       0 allocs/op
```

---

2. Replaces a mutex+map with sync.Map

(Only a minor improvement in overall runs / about the same ns/ops)

```console
Benchmark_logOnce-12    	 8518489	       149.9 ns/op	     336 B/op	       2 allocs/op
```

vs main
```console
Benchmark_logOnce-12    	 7707423	       143.7 ns/op	     336 B/op	       2 allocs/op
```

---

3. Reduce allocations in logging package / optimize keypair sorting

```console
Benchmark_Info-12    	  581666	      2044 ns/op	     712 B/op	       9 allocs/op
```

vs main
```console
Benchmark_Info-12    	  490310	      2383 ns/op	     792 B/op	      14 allocs/op
```