### PR TITLE
refactor:  rework backend and proxy health checks

### DIFF
--- a/pkg/backends/healthcheck/healthcheck_test.go
+++ b/pkg/backends/healthcheck/healthcheck_test.go
@@ -69,7 +69,7 @@ func TestRegister(t *testing.T) {
 		t.Error(err)
 	}
 	target := hc.targets["test"]
-	target.Start()
+	target.Start(context.Background())
 	target.Stop()
 	_, err = hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {
@@ -142,36 +142,5 @@ func TestStatuses(t *testing.T) {
 	s := hc.Statuses()
 	if len(s) != 1 {
 		t.Errorf("expected %d got %d", 1, len(s))
-	}
-}
-
-func TestHealthCheckerProbe(t *testing.T) {
-	logger.SetLogger(testLogger)
-	hc := New().(*healthChecker)
-	o := ho.New()
-
-	ts := newTestServer(200, "OK", map[string]string{})
-	r, _ := http.NewRequest("GET", ts.URL+"/", nil)
-
-	_, err := hc.Register("test", "test", o, http.DefaultClient)
-	if err != nil {
-		t.Error(err)
-	}
-
-	target := hc.targets["test"]
-	target.baseRequest = r
-	target.ctx = context.Background()
-
-	s := hc.Probe("")
-	if s != nil {
-		t.Error("expected nil got ", s)
-	}
-	s = hc.Probe("test-missing")
-	if s != nil {
-		t.Error("expected nil got ", s)
-	}
-	s = hc.Probe("test")
-	if s == nil {
-		t.Error("expected non-nil")
 	}
 }

--- a/pkg/backends/healthcheck/target.go
+++ b/pkg/backends/healthcheck/target.go
@@ -47,7 +47,6 @@ type target struct {
 	failConsecutiveCnt    atomic.Int32
 	successConsecutiveCnt atomic.Int32
 	ks                    int // used internally and is not thread safe, do not expose
-	ctx                   context.Context
 	cancel                context.CancelFunc
 	wg                    sync.WaitGroup
 	ceb                   bool

--- a/pkg/backends/healthcheck/target_test.go
+++ b/pkg/backends/healthcheck/target_test.go
@@ -221,7 +221,6 @@ func TestProbe(t *testing.T) {
 	r, _ := http.NewRequest("GET", ts.URL+"/", nil)
 	target := &target{
 		status:      &Status{},
-		ctx:         context.Background(),
 		baseRequest: r,
 		httpClient:  ts.Client(),
 		ec:          []int{200},
@@ -250,7 +249,6 @@ func TestDemandProbe(t *testing.T) {
 	r, _ := http.NewRequest("GET", ts.URL+"/", nil)
 	target := &target{
 		status:      &Status{},
-		ctx:         context.Background(),
 		baseRequest: r,
 		httpClient:  ts.Client(),
 		ec:          []int{200},

--- a/pkg/backends/healthcheck/target_test.go
+++ b/pkg/backends/healthcheck/target_test.go
@@ -226,12 +226,12 @@ func TestProbe(t *testing.T) {
 		httpClient:  ts.Client(),
 		ec:          []int{200},
 	}
-	target.probe()
+	target.probe(context.Background())
 	if v := target.successConsecutiveCnt.Load(); v != 1 {
 		t.Error("expected 1 got ", v)
 	}
 	target.ec[0] = 404
-	target.probe()
+	target.probe(context.Background())
 	if v := target.successConsecutiveCnt.Load(); v != 0 {
 		t.Error("expected 0 got ", v)
 	}


### PR DESCRIPTION
* Another mutex -> atomic change
* Refactoring code to use context for cancellation and remove some unnecessary logic
* removing context from a struct:
> Do not store Contexts inside a struct type
> https://pkg.go.dev/context#pkg-overview