### PR TITLE
Add Oracle to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -7,3 +7,4 @@ As the Trickster community grows, we'd like to keep track of who is using it in 
 3. [swarmstack](https://github.com/swarmstack) [[@mh720](https://github.com/mh720)]
 4. [Hostinger](https://www.hostinger.com/) [[@ton31337](https://github.com/ton31337)]
 5. [The Remote Company (MailerLite, MailerSend, MailerCheck, YCode)](https://www.remotecompany.com) [[@aorfanos]](https://github.com/aorfanos)
+6. [Oracle](https://oracle.com) [[@tonychoe](https://github.com/tonychoe)]


### PR DESCRIPTION
Thanks for the effort to release v2.

At Oracle, we're looking into using Trickster for the following use cases:

-     Federate query results from Mimir backends in tens of cloud regions.
-     Leverage caching to accelerate dashboards and reduce read queries to Mimir backends.
-     Experiment with new backends such as Clickhouse.

We believe there would be more use cases in near future.
