### PR TITLE
use Lookup name types in lieu of bare map[string]Object

### DIFF
--- a/pkg/backends/alb/client.go
+++ b/pkg/backends/alb/client.go
@@ -30,6 +30,7 @@ import (
 	rt "github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/errors"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
@@ -42,8 +43,8 @@ type Client struct {
 }
 
 // Handlers returns a map of the HTTP Handlers the client has registered
-func (c *Client) Handlers() map[string]http.Handler {
-	return map[string]http.Handler{"alb": c.handler}
+func (c *Client) Handlers() handlers.Lookup {
+	return handlers.Lookup{"alb": c.handler}
 }
 
 var _ rt.NewBackendClientFunc = NewClient
@@ -160,9 +161,9 @@ func (c *Client) StopPool() {
 // Boilerplate Interface Functions (to EOF)
 
 // DefaultPathConfigs returns the default PathConfigs for the given Provider
-func (c *Client) DefaultPathConfigs(_ *bo.Options) map[string]*po.Options {
+func (c *Client) DefaultPathConfigs(_ *bo.Options) po.Lookup {
 	m := methods.CacheableHTTPMethods()
-	paths := map[string]*po.Options{
+	paths := po.Lookup{
 		"/" + strings.Join(m, "-"): {
 			Path:          "/",
 			HandlerName:   "alb",

--- a/pkg/backends/alb/mech/fr/first_response.go
+++ b/pkg/backends/alb/mech/fr/first_response.go
@@ -24,7 +24,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/options"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
 	rt "github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
 )
@@ -91,7 +91,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	hl := h.pool.Healthy() // should return a fanout list
 	l := len(hl)
 	if l == 0 {
-		handlers.HandleBadGateway(w, r)
+		failures.HandleBadGateway(w, r)
 		return
 	}
 	// just proxy 1:1 if no folds in the fan

--- a/pkg/backends/alb/mech/nlm/newest_last_modified.go
+++ b/pkg/backends/alb/mech/nlm/newest_last_modified.go
@@ -27,7 +27,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/options"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
 	rt "github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/util/atomicx"
 )
@@ -70,7 +70,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	hl := h.pool.Healthy() // should return a fanout list
 	l := len(hl)
 	if len(hl) == 0 {
-		handlers.HandleBadGateway(w, r)
+		failures.HandleBadGateway(w, r)
 		return
 	}
 	// just proxy 1:1 if no folds in the fan

--- a/pkg/backends/alb/mech/rr/round_robin.go
+++ b/pkg/backends/alb/mech/rr/round_robin.go
@@ -24,7 +24,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/options"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
 	rt "github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 )
 
 const ID types.ID = 0
@@ -58,7 +58,7 @@ func (h *handler) Name() types.Name {
 
 func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if h.pool == nil {
-		handlers.HandleBadGateway(w, r)
+		failures.HandleBadGateway(w, r)
 		return
 	}
 	t := h.nextTarget()
@@ -66,7 +66,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		t.ServeHTTP(w, r)
 		return
 	}
-	handlers.HandleBadGateway(w, r)
+	failures.HandleBadGateway(w, r)
 }
 
 func (h *handler) StopPool() {

--- a/pkg/backends/alb/mech/rr/round_robin_test.go
+++ b/pkg/backends/alb/mech/rr/round_robin_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/pool"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	tu "github.com/trickstercache/trickster/v2/pkg/testutil"
 	"github.com/trickstercache/trickster/v2/pkg/testutil/albpool"
 )
@@ -52,7 +52,7 @@ func TestHandleRoundRobin(t *testing.T) {
 	}
 
 	h.pool, _, hsts = albpool.New(0,
-		[]http.Handler{http.HandlerFunc(handlers.HandleBadGateway)})
+		[]http.Handler{http.HandlerFunc(failures.HandleBadGateway)})
 	hsts[0].Set(-1)
 	time.Sleep(250 * time.Millisecond)
 	w = httptest.NewRecorder()

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -31,7 +31,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	rt "github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
 	tctx "github.com/trickstercache/trickster/v2/pkg/proxy/context"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
@@ -103,7 +103,7 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	hl := h.pool.Healthy() // should return a fanout list
 	l := len(hl)
 	if l == 0 {
-		handlers.HandleBadGateway(w, r)
+		failures.HandleBadGateway(w, r)
 		return
 	}
 	// just proxy 1:1 if no folds in the fan

--- a/pkg/backends/backend_test.go
+++ b/pkg/backends/backend_test.go
@@ -24,6 +24,7 @@ import (
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	cr "github.com/trickstercache/trickster/v2/pkg/cache/registry"
 	"github.com/trickstercache/trickster/v2/pkg/config"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 )
 
 func TestConfiguration(t *testing.T) {
@@ -108,8 +109,8 @@ func TestBaseUpstreamURL(t *testing.T) {
 func TestHandlers(t *testing.T) {
 
 	b := &backend{name: "test"}
-	testRegistrar := func(map[string]http.Handler) {
-		b.RegisterHandlers(map[string]http.Handler{"test": nil})
+	testRegistrar := func(handlers.Lookup) {
+		b.RegisterHandlers(handlers.Lookup{"test": nil})
 	}
 
 	b.registrar = testRegistrar

--- a/pkg/backends/clickhouse/handler_query.go
+++ b/pkg/backends/clickhouse/handler_query.go
@@ -23,7 +23,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/engines"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/urls"
@@ -35,7 +35,7 @@ func (c *Client) QueryHandler(w http.ResponseWriter, r *http.Request) {
 	if methods.HasBody(r.Method) {
 		b, err := request.GetBody(r)
 		if err != nil {
-			handlers.HandleBadRequestResponse(w, r)
+			failures.HandleBadRequestResponse(w, r)
 			return
 		}
 		sqlQuery = string(b)

--- a/pkg/backends/clickhouse/routes.go
+++ b/pkg/backends/clickhouse/routes.go
@@ -20,14 +20,15 @@ import (
 	"net/http"
 
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 )
 
-func (c *Client) RegisterHandlers(map[string]http.Handler) {
+func (c *Client) RegisterHandlers(handlers.Lookup) {
 
 	c.TimeseriesBackend.RegisterHandlers(
-		map[string]http.Handler{
+		handlers.Lookup{
 			// This is the registry of handlers that Trickster supports for ClickHouse,
 			// and are able to be referenced by name (map key) in Config Files
 			"health": http.HandlerFunc(c.HealthHandler),
@@ -38,8 +39,8 @@ func (c *Client) RegisterHandlers(map[string]http.Handler) {
 }
 
 // DefaultPathConfigs returns the default PathConfigs for the given Provider
-func (c *Client) DefaultPathConfigs(_ *bo.Options) map[string]*po.Options {
-	paths := map[string]*po.Options{
+func (c *Client) DefaultPathConfigs(_ *bo.Options) po.Lookup {
+	paths := po.Lookup{
 		"/": {
 			Path:           "/",
 			HandlerName:    "query",

--- a/pkg/backends/influxdb/routes.go
+++ b/pkg/backends/influxdb/routes.go
@@ -21,14 +21,15 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/influxdb/influxql"
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 )
 
-func (c *Client) RegisterHandlers(map[string]http.Handler) {
+func (c *Client) RegisterHandlers(handlers.Lookup) {
 
 	c.TimeseriesBackend.RegisterHandlers(
-		map[string]http.Handler{
+		handlers.Lookup{
 			// This is the registry of handlers that Trickster supports for InfluxDB,
 			// and are able to be referenced by name (map key) in Config Files
 			"health": http.HandlerFunc(c.HealthHandler),
@@ -39,9 +40,9 @@ func (c *Client) RegisterHandlers(map[string]http.Handler) {
 }
 
 // DefaultPathConfigs returns the default PathConfigs for the given Provider
-func (c *Client) DefaultPathConfigs(_ *bo.Options) map[string]*po.Options {
+func (c *Client) DefaultPathConfigs(_ *bo.Options) po.Lookup {
 
-	paths := map[string]*po.Options{
+	paths := po.Lookup{
 		"/" + mnQuery: {
 			Path:            "/" + mnQuery,
 			HandlerName:     mnQuery,

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -88,7 +88,7 @@ type Options struct {
 	// When both are set, the higher of the two values is used
 	BackfillTolerancePoints int `yaml:"backfill_tolerance_points,omitempty"`
 	// PathList is a list of Path Options that control the behavior of the given paths when requested
-	Paths map[string]*po.Options `yaml:"paths,omitempty"`
+	Paths po.Lookup `yaml:"paths,omitempty"`
 	// NegativeCacheName provides the name of the Negative Cache Config to be used by this Backend
 	NegativeCacheName string `yaml:"negative_cache_name,omitempty"`
 	// TimeseriesTTL specifies the cache TTL of timeseries objects
@@ -167,7 +167,7 @@ type Options struct {
 	// Synthesized Configurations
 	// These configurations are parsed versions of those defined above, and are what Trickster uses internally
 	//
-	// Name is the Name of the backend, taken from the Key in the Backends map[string]*BackendOptions
+	// Name is the Name of the backend, taken from the Key in the Backends Lookup Map
 	Name string `yaml:"-"`
 	// Router is a router.Router containing this backend's Path Routes; it is set during route registration
 	Router router.Router `yaml:"-"`
@@ -220,7 +220,7 @@ func New() *Options {
 		MaxTTL:                       DefaultMaxTTL,
 		NegativeCache:                make(map[int]time.Duration),
 		NegativeCacheName:            DefaultBackendNegativeCacheName,
-		Paths:                        make(map[string]*po.Options),
+		Paths:                        make(po.Lookup),
 		RevalidationFactor:           DefaultRevalidationFactor,
 		MaxShardSizePoints:           DefaultTimeseriesShardSize,
 		MaxShardSizeTime:             DefaultTimeseriesShardSize,
@@ -290,7 +290,7 @@ func (o *Options) Clone() *Options {
 		no.CompressibleTypes = maps.Clone(o.CompressibleTypes)
 	}
 
-	no.Paths = make(map[string]*po.Options)
+	no.Paths = make(po.Lookup)
 	for l, p := range o.Paths {
 		no.Paths[l] = p.Clone()
 	}

--- a/pkg/backends/options/options_test.go
+++ b/pkg/backends/options/options_test.go
@@ -39,7 +39,7 @@ import (
 )
 
 type testOptions struct {
-	Backends map[string]*Options `yaml:"backends,omitempty"`
+	Backends Lookup `yaml:"backends,omitempty"`
 	ncl      negative.Lookups
 }
 
@@ -76,7 +76,7 @@ func TestClone(t *testing.T) {
 	o.Hosts = []string{"test"}
 	o.CacheName = "test"
 	o.CompressibleTypes = sets.New([]string{"test"})
-	o.Paths = map[string]*po.Options{"test": p}
+	o.Paths = po.Lookup{"test": p}
 	o.NegativeCache = map[int]time.Duration{1: 1}
 	o.HealthCheck = &ho.Options{}
 	o.FastForwardPath = p

--- a/pkg/backends/prometheus/model/alerts.go
+++ b/pkg/backends/prometheus/model/alerts.go
@@ -29,7 +29,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/checksum/fnv"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
@@ -127,7 +127,7 @@ func MergeAndWriteAlerts(w http.ResponseWriter, r *http.Request, rgs merge.Respo
 			io.Copy(w, bestResp.Body)
 
 		} else {
-			handlers.HandleBadGateway(w, r)
+			failures.HandleBadGateway(w, r)
 		}
 		return
 	}

--- a/pkg/backends/prometheus/model/labels.go
+++ b/pkg/backends/prometheus/model/labels.go
@@ -27,7 +27,7 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
@@ -83,7 +83,7 @@ func MergeAndWriteLabelData(w http.ResponseWriter, r *http.Request, rgs merge.Re
 			io.Copy(w, bestResp.Body)
 
 		} else {
-			handlers.HandleBadGateway(w, r)
+			failures.HandleBadGateway(w, r)
 		}
 		return
 	}

--- a/pkg/backends/prometheus/model/series.go
+++ b/pkg/backends/prometheus/model/series.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
@@ -87,7 +87,7 @@ func MergeAndWriteSeries(w http.ResponseWriter, r *http.Request, rgs merge.Respo
 			io.Copy(w, bestResp.Body)
 
 		} else {
-			handlers.HandleBadGateway(w, r)
+			failures.HandleBadGateway(w, r)
 		}
 		return
 	}

--- a/pkg/backends/prometheus/model/vector.go
+++ b/pkg/backends/prometheus/model/vector.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
@@ -63,7 +63,7 @@ func MergeAndWriteVector(w http.ResponseWriter, r *http.Request, rgs merge.Respo
 	})
 
 	if len(responses) == 0 {
-		handlers.HandleBadGateway(w, r)
+		failures.HandleBadGateway(w, r)
 		return
 	}
 
@@ -75,7 +75,7 @@ func MergeAndWriteVector(w http.ResponseWriter, r *http.Request, rgs merge.Respo
 			io.Copy(w, bestResp.Body)
 
 		} else {
-			handlers.HandleBadGateway(w, r)
+			failures.HandleBadGateway(w, r)
 		}
 		return
 	}

--- a/pkg/backends/prometheus/routes.go
+++ b/pkg/backends/prometheus/routes.go
@@ -22,15 +22,16 @@ import (
 	"time"
 
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 )
 
-func (c *Client) RegisterHandlers(map[string]http.Handler) {
+func (c *Client) RegisterHandlers(handlers.Lookup) {
 	c.TimeseriesBackend.RegisterHandlers(
-		map[string]http.Handler{
+		handlers.Lookup{
 			"health":      http.HandlerFunc(c.HealthHandler),
 			"query_range": http.HandlerFunc(c.QueryRangeHandler),
 			"query":       http.HandlerFunc(c.QueryHandler),
@@ -64,7 +65,7 @@ func (c *Client) MergeablePaths() []string {
 }
 
 // DefaultPathConfigs returns the default PathConfigs for the given Provider
-func (c *Client) DefaultPathConfigs(o *bo.Options) map[string]*po.Options {
+func (c *Client) DefaultPathConfigs(o *bo.Options) po.Lookup {
 
 	var rhts map[string]string
 	if o != nil {

--- a/pkg/backends/reverseproxy/routes.go
+++ b/pkg/backends/reverseproxy/routes.go
@@ -22,29 +22,30 @@ import (
 
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/local"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 )
 
-func (c *Client) RegisterHandlers(map[string]http.Handler) {
+func (c *Client) RegisterHandlers(handlers.Lookup) {
 
 	c.Backend.RegisterHandlers(
-		map[string]http.Handler{
+		handlers.Lookup{
 			"health":        http.HandlerFunc(c.HealthHandler),
 			"proxy":         http.HandlerFunc(c.ProxyHandler),
-			"localresponse": http.HandlerFunc(handlers.HandleLocalResponse),
+			"localresponse": http.HandlerFunc(local.HandleLocalResponse),
 		},
 	)
 
 }
 
 // DefaultPathConfigs returns the default PathConfigs for the given Provider
-func (c *Client) DefaultPathConfigs(_ *bo.Options) map[string]*po.Options {
+func (c *Client) DefaultPathConfigs(_ *bo.Options) po.Lookup {
 
 	am := methods.AllHTTPMethods()
 
-	paths := map[string]*po.Options{
+	paths := po.Lookup{
 		"/-" + strings.Join(am, "-"): {
 			Path:          "/",
 			HandlerName:   "proxy",

--- a/pkg/backends/reverseproxycache/routes.go
+++ b/pkg/backends/reverseproxycache/routes.go
@@ -22,24 +22,25 @@ import (
 
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/local"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 )
 
-func (c *Client) RegisterHandlers(map[string]http.Handler) {
+func (c *Client) RegisterHandlers(handlers.Lookup) {
 	c.Backend.RegisterHandlers(
-		map[string]http.Handler{
+		handlers.Lookup{
 			"health":        http.HandlerFunc(c.HealthHandler),
 			"proxy":         http.HandlerFunc(c.ProxyHandler),
 			"proxycache":    http.HandlerFunc(c.ProxyCacheHandler),
-			"localresponse": http.HandlerFunc(handlers.HandleLocalResponse),
+			"localresponse": http.HandlerFunc(local.HandleLocalResponse),
 		},
 	)
 }
 
 // DefaultPathConfigs returns the default PathConfigs for the given Provider
-func (c *Client) DefaultPathConfigs(_ *bo.Options) map[string]*po.Options {
+func (c *Client) DefaultPathConfigs(_ *bo.Options) po.Lookup {
 
 	cm := methods.CacheableHTTPMethods()
 	um := methods.UncacheableHTTPMethods()

--- a/pkg/backends/rule/client.go
+++ b/pkg/backends/rule/client.go
@@ -25,6 +25,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
@@ -98,9 +99,9 @@ func (rc Clients) validate(rwi map[string]rewriter.RewriteInstructions) error {
 }
 
 // DefaultPathConfigs returns the default PathConfigs for the given Provider
-func (c *Client) DefaultPathConfigs(_ *bo.Options) map[string]*po.Options {
+func (c *Client) DefaultPathConfigs(_ *bo.Options) po.Lookup {
 	m := methods.CacheableHTTPMethods()
-	paths := map[string]*po.Options{
+	paths := po.Lookup{
 		"/" + strings.Join(m, "-"): {
 			Path:          "/",
 			HandlerName:   "rule",
@@ -112,10 +113,10 @@ func (c *Client) DefaultPathConfigs(_ *bo.Options) map[string]*po.Options {
 	return paths
 }
 
-func (c *Client) RegisterHandlers(map[string]http.Handler) {
+func (c *Client) RegisterHandlers(handlers.Lookup) {
 
 	c.Backend.RegisterHandlers(
-		map[string]http.Handler{
+		handlers.Lookup{
 			"rule": http.HandlerFunc(c.Handler),
 		},
 	)

--- a/pkg/backends/rule/options/options.go
+++ b/pkg/backends/rule/options/options.go
@@ -76,7 +76,7 @@ type Options struct {
 	// configured Operation, such as the demonimator when the operation is modulus
 	OperationArg string `yaml:"operation_arg,omitempty"`
 	// RuleCaseOptions is the map of cases to apply to evaluate against this rule
-	CaseOptions map[string]*CaseOptions `yaml:"cases,omitempty"`
+	CaseOptions CaseLookup `yaml:"cases,omitempty"`
 	// RedirectURL provides a URL to redirect the request in the default case, rather than
 	// handing off to the NextRoute
 	RedirectURL string `yaml:"redirect_url,omitempty"`
@@ -101,6 +101,8 @@ type CaseOptions struct {
 
 // Lookup is a map of Options
 type Lookup map[string]*Options
+
+type CaseLookup map[string]*CaseOptions
 
 // Clone returns a perfect copy of the subject *Options
 func (o *Options) Clone() *Options {

--- a/pkg/backends/rule/parse.go
+++ b/pkg/backends/rule/parse.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 
 	ro "github.com/trickstercache/trickster/v2/pkg/backends/rule/options"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/redirect"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request/rewriter"
 )
 
@@ -97,7 +97,7 @@ func (c *Client) parseOptions(o *ro.Options, rwi map[string]rewriter.RewriteInst
 	case o.RedirectURL != "":
 		r.defaultRedirectURL = o.RedirectURL
 		r.defaultRedirectCode = 302
-		nr = http.HandlerFunc(handlers.HandleRedirectResponse)
+		nr = http.HandlerFunc(redirect.HandleRedirectResponse)
 	default:
 		return badDefaultRoute
 	}
@@ -186,7 +186,7 @@ func (c *Client) parseOptions(o *ro.Options, rwi map[string]rewriter.RewriteInst
 			rc := 0
 			if v.RedirectURL != "" {
 				rc = 302
-				nr = http.HandlerFunc(handlers.HandleRedirectResponse)
+				nr = http.HandlerFunc(redirect.HandleRedirectResponse)
 			} else if v.NextRoute != "" {
 				no, ok := c.clients[v.NextRoute]
 				if !ok {

--- a/pkg/backends/rule/rule.go
+++ b/pkg/backends/rule/rule.go
@@ -20,7 +20,8 @@ import (
 	"net/http"
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/context"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/redirect"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request/rewriter"
 )
 
@@ -60,7 +61,7 @@ type caseList []*ruleCase
 
 type evaluatorFunc func(*http.Request) (http.Handler, *http.Request, error)
 
-var badRequestHandler = http.HandlerFunc(handlers.HandleBadRequestResponse)
+var badRequestHandler = http.HandlerFunc(failures.HandleBadRequestResponse)
 
 func (r *rule) EvaluateOpArg(hr *http.Request) (http.Handler, *http.Request, error) {
 
@@ -94,7 +95,7 @@ func (r *rule) EvaluateOpArg(hr *http.Request) (http.Handler, *http.Request, err
 
 		// if it's a redirect response, set the appropriate context
 		if c.redirectCode > 0 {
-			hr = hr.WithContext(handlers.WithRedirects(hr.Context(),
+			hr = hr.WithContext(redirect.WithRedirects(hr.Context(),
 				c.redirectCode, c.redirectURL))
 		}
 	}
@@ -109,7 +110,7 @@ func (r *rule) EvaluateOpArg(hr *http.Request) (http.Handler, *http.Request, err
 	}
 
 	if !nonDefault && r.defaultRedirectCode > 0 {
-		hr = hr.WithContext(handlers.WithRedirects(hr.Context(),
+		hr = hr.WithContext(redirect.WithRedirects(hr.Context(),
 			r.defaultRedirectCode, r.defaultRedirectURL))
 	}
 
@@ -126,7 +127,7 @@ func (r *rule) EvaluateCaseArg(hr *http.Request) (http.Handler, *http.Request, e
 	}
 
 	if currentHops >= maxHops {
-		return http.HandlerFunc(handlers.HandleBadRequestResponse), hr, nil
+		return http.HandlerFunc(failures.HandleBadRequestResponse), hr, nil
 	}
 
 	// if this case includes ingress rewriter instructions, execute those now
@@ -155,7 +156,7 @@ func (r *rule) EvaluateCaseArg(hr *http.Request) (http.Handler, *http.Request, e
 
 			// if it's a redirect response, set the appropriate context
 			if c.redirectCode > 0 {
-				hr = hr.WithContext(handlers.WithRedirects(hr.Context(),
+				hr = hr.WithContext(redirect.WithRedirects(hr.Context(),
 					c.redirectCode, c.redirectURL))
 			}
 		}
@@ -171,7 +172,7 @@ func (r *rule) EvaluateCaseArg(hr *http.Request) (http.Handler, *http.Request, e
 	}
 
 	if !nonDefault && r.defaultRedirectCode > 0 {
-		hr = hr.WithContext(handlers.WithRedirects(hr.Context(),
+		hr = hr.WithContext(redirect.WithRedirects(hr.Context(),
 			r.defaultRedirectCode, r.defaultRedirectURL))
 	}
 

--- a/pkg/backends/rule/rule_test.go
+++ b/pkg/backends/rule/rule_test.go
@@ -34,9 +34,9 @@ var testMux2 = http.NewServeMux()
 
 var testRuleHeader = "Test-Rule-Header"
 
-func newTestRewriterOpts() map[string]*rwo.Options {
+func newTestRewriterOpts() rwo.Lookup {
 
-	return map[string]*rwo.Options{
+	return rwo.Lookup{
 		"test-rewriter-1": {
 			Instructions: [][]string{
 				{
@@ -110,9 +110,9 @@ func newTestRuleOpts() *ro.Options {
 	}
 }
 
-func newTestCaseOpts() map[string]*ro.CaseOptions {
+func newTestCaseOpts() ro.CaseLookup {
 
-	return map[string]*ro.CaseOptions{
+	return ro.CaseLookup{
 		"1": {
 			Matches:   []string{"trickster"},
 			NextRoute: "test-backend-2",

--- a/pkg/backends/timeseries_backend.go
+++ b/pkg/backends/timeseries_backend.go
@@ -24,6 +24,7 @@ import (
 	ho "github.com/trickstercache/trickster/v2/pkg/backends/healthcheck/options"
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
@@ -31,11 +32,11 @@ import (
 // TimeseriesBackend is the primary interface for interoperating with Trickster and upstream TSDB's
 type TimeseriesBackend interface {
 	// RegisterHandlers registers the provided Handlers into the Router
-	RegisterHandlers(map[string]http.Handler)
+	RegisterHandlers(handlers.Lookup)
 	// Handlers returns a map of the HTTP Handlers the Backend has registered
-	Handlers() map[string]http.Handler
+	Handlers() handlers.Lookup
 	// DefaultPathConfigs returns the default PathConfigs for the given Provider
-	DefaultPathConfigs(*bo.Options) map[string]*po.Options
+	DefaultPathConfigs(*bo.Options) po.Lookup
 	// ParseTimeRangeQuery returns a timeseries.TimeRangeQuery based on the provided HTTP Request
 	ParseTimeRangeQuery(*http.Request) (*timeseries.TimeRangeQuery, *timeseries.RequestOptions, bool, error)
 	// Configuration returns the configuration for the Backend

--- a/pkg/cache/redis/redis_test.go
+++ b/pkg/cache/redis/redis_test.go
@@ -70,7 +70,7 @@ func setupRedisCache(ct clientType) (*Cache, func()) {
 		s.Close()
 	}
 	cacheConfig := &co.Options{Provider: "redis", Redis: rcfg}
-	conf.Caches = map[string]*co.Options{"default": cacheConfig}
+	conf.Caches = co.Lookup{"default": cacheConfig}
 
 	return &Cache{Config: cacheConfig}, close
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -60,7 +60,7 @@ func TestClone(t *testing.T) {
 	o.TLS = &to.Options{CertificateAuthorityPaths: []string{"foo"}}
 	o.HealthCheck.Headers = map[string]string{headers.NameAuthorization: expected}
 
-	c1.Rules = map[string]*rule.Options{
+	c1.Rules = rule.Lookup{
 		"test": {},
 	}
 
@@ -160,7 +160,7 @@ func TestSetDefaults(t *testing.T) {
 	}
 
 	c.Main.PprofServer = "both"
-	c.RequestRewriters = make(map[string]*rwo.Options)
+	c.RequestRewriters = make(rwo.Lookup)
 	err = c.setDefaults(nil)
 	if err == nil {
 		t.Error("expected error for invalid pprof server name")

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -20,8 +20,6 @@ import (
 	"net/url"
 	"strings"
 
-	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
-	"github.com/trickstercache/trickster/v2/pkg/cache/negative"
 	"github.com/trickstercache/trickster/v2/pkg/errors"
 )
 
@@ -86,12 +84,12 @@ func Load(args []string) (*Config, error) {
 		return nil, errors.ErrNoValidBackends
 	}
 
-	ncl, err := negative.ConfigLookup(c.NegativeCacheConfigs).Validate()
+	ncl, err := c.NegativeCacheConfigs.Validate()
 	if err != nil {
 		return nil, err
 	}
 
-	err = bo.Lookup(c.Backends).Validate(ncl)
+	err = c.Backends.Validate(ncl)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -42,7 +42,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	tr "github.com/trickstercache/trickster/v2/pkg/observability/tracing/registry"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	pnh "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/ping"
+	ph "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/purge"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/reload"
 	"github.com/trickstercache/trickster/v2/pkg/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
@@ -110,10 +111,10 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 
 	r.RegisterRoute(newConf.Main.PingHandlerPath, nil,
 		[]string{http.MethodGet, http.MethodHead}, false,
-		http.HandlerFunc((handlers.PingHandleFunc(newConf))))
+		http.HandlerFunc((pnh.HandlerFunc(newConf))))
 
 	var caches = applyCachingConfig(si, newConf)
-	rh := reload.ReloadHandleFunc(hupFunc)
+	rh := reload.HandlerFunc(hupFunc)
 	backends, err := routing.RegisterProxyRoutes(newConf, r, mr, caches, tracers, false)
 	if err != nil {
 		handleStartupIssue("route registration failed",
@@ -126,7 +127,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	}
 	r.RegisterRoute(newConf.Main.PurgeKeyHandlerPath, nil,
 		[]string{http.MethodDelete}, true,
-		http.HandlerFunc(handlers.PurgeKeyHandleFunc(newConf, backends)))
+		http.HandlerFunc(ph.KeyHandlerFunc(newConf, backends)))
 
 	if si.Backends != nil {
 		alb.StopPools(si.Backends)

--- a/pkg/observability/tracing/options/options.go
+++ b/pkg/observability/tracing/options/options.go
@@ -46,6 +46,8 @@ type Options struct {
 	attachTagsToSpan bool
 }
 
+type Lookup map[string]*Options
+
 // New returns a new *Options with the default values
 func New() *Options {
 	return &Options{
@@ -76,7 +78,7 @@ func (o *Options) Clone() *Options {
 }
 
 // ProcessTracingOptions enriches the configuration data of the provided Tracing Options collection
-func ProcessTracingOptions(mo map[string]*Options, metadata yamlx.KeyLookup) {
+func ProcessTracingOptions(mo Lookup, metadata yamlx.KeyLookup) {
 	if len(mo) == 0 {
 		return
 	}

--- a/pkg/observability/tracing/options/options_test.go
+++ b/pkg/observability/tracing/options/options_test.go
@@ -38,7 +38,7 @@ func TestProcessTracingConfigs(t *testing.T) {
 	o := New()
 	o.SampleRate = 0
 
-	mo := map[string]*Options{
+	mo := Lookup{
 		"test": o,
 	}
 

--- a/pkg/observability/tracing/providers/providers.go
+++ b/pkg/observability/tracing/providers/providers.go
@@ -32,8 +32,11 @@ const (
 	Zipkin
 )
 
+type ProviderLookup map[string]Provider
+type ProviderReverseLookup map[Provider]string
+
 // Names is a map of tracing providers keyed by name
-var Names = map[string]Provider{
+var Names = ProviderLookup{
 	"none":   None,
 	"stdout": Stdout,
 	"otlp":   OTLP,
@@ -41,7 +44,7 @@ var Names = map[string]Provider{
 }
 
 // Values is a map of tracing providers keyed by internal id
-var Values = make(map[Provider]string)
+var Values = make(ProviderReverseLookup)
 
 func init() {
 	for k, v := range Names {

--- a/pkg/observability/tracing/registry/registry_test.go
+++ b/pkg/observability/tracing/registry/registry_test.go
@@ -50,7 +50,7 @@ func TestRegisterAll(t *testing.T) {
 	cfg := config.NewConfig()
 	tc := options.New()
 
-	cfg.TracingConfigs = make(map[string]*options.Options)
+	cfg.TracingConfigs = make(options.Lookup)
 	cfg.TracingConfigs["test"] = tc
 	cfg.TracingConfigs["test3"] = tc
 	cfg.Backends["default"].TracingConfigName = "test"

--- a/pkg/observability/tracing/span/span_test.go
+++ b/pkg/observability/tracing/span/span_test.go
@@ -45,7 +45,7 @@ func TestNewChildSpan(t *testing.T) {
 
 	// force coverage of tags attachment
 	tr.Options.Provider = "zipkin"
-	options.ProcessTracingOptions(map[string]*options.Options{"default": tr.Options}, nil)
+	options.ProcessTracingOptions(options.Lookup{"default": tr.Options}, nil)
 
 	ctx, span := NewChildSpan(stdcontext.TODO(), tr, "test")
 	if ctx == nil {
@@ -88,7 +88,7 @@ func TestPrepareRequest(t *testing.T) {
 	}
 
 	tr.Options.Provider = "zipkin"
-	options.ProcessTracingOptions(map[string]*options.Options{"default": tr.Options}, nil)
+	options.ProcessTracingOptions(options.Lookup{"default": tr.Options}, nil)
 
 	_, sp = PrepareRequest(r, tr)
 	if sp == nil {

--- a/pkg/proxy/engines/client_test.go
+++ b/pkg/proxy/engines/client_test.go
@@ -31,6 +31,7 @@ import (
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
@@ -82,9 +83,9 @@ func NewTestClient(name string, o *bo.Options, router http.Handler,
 	return c, err
 }
 
-func (c *TestClient) RegisterHandlers(map[string]http.Handler) {
+func (c *TestClient) RegisterHandlers(handlers.Lookup) {
 	c.TimeseriesBackend.RegisterHandlers(
-		map[string]http.Handler{
+		handlers.Lookup{
 			"health":     http.HandlerFunc(c.HealthHandler),
 			mnQueryRange: http.HandlerFunc(c.QueryRangeHandler),
 			mnQuery:      http.HandlerFunc(c.QueryHandler),
@@ -96,9 +97,9 @@ func (c *TestClient) RegisterHandlers(map[string]http.Handler) {
 }
 
 // DefaultPathConfigs returns the default PathConfigs for the given Provider
-func (c *TestClient) DefaultPathConfigs(o *bo.Options) map[string]*po.Options {
+func (c *TestClient) DefaultPathConfigs(o *bo.Options) po.Lookup {
 
-	paths := map[string]*po.Options{
+	paths := po.Lookup{
 
 		APIPath + mnQueryRange: {
 			Path:            APIPath + mnQueryRange,

--- a/pkg/proxy/engines/key_test.go
+++ b/pkg/proxy/engines/key_test.go
@@ -127,7 +127,7 @@ func TestDeriveCacheKey(t *testing.T) {
 	}
 
 	cfg := &bo.Options{
-		Paths: map[string]*po.Options{
+		Paths: po.Lookup{
 			"root": rpath,
 		},
 	}
@@ -218,7 +218,7 @@ func exampleKeyHasher(path string, params url.Values, headers http.Header,
 func TestDeriveCacheKeyAuthHeader(t *testing.T) {
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
 	client, err := NewTestClient("test", &bo.Options{
-		Paths: map[string]*po.Options{
+		Paths: po.Lookup{
 			"root": {
 				Path:            "/",
 				CacheKeyParams:  []string{"query", "step", "time"},
@@ -251,7 +251,7 @@ func TestDeriveCacheKeyAuthHeader(t *testing.T) {
 func TestDeriveCacheKeyNoPathConfig(t *testing.T) {
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
 	client, err := NewTestClient("test", &bo.Options{
-		Paths: map[string]*po.Options{
+		Paths: po.Lookup{
 			"root": {
 				Path:            "/",
 				CacheKeyParams:  []string{"query", "step", "time"},

--- a/pkg/proxy/engines/objectproxycache_chunk_test.go
+++ b/pkg/proxy/engines/objectproxycache_chunk_test.go
@@ -721,7 +721,7 @@ func TestObjectProxyCacheRequestNegativeCacheChunks(t *testing.T) {
 
 	pc := po.New()
 	cfg := rsc.BackendOptions
-	cfg.Paths = map[string]*po.Options{
+	cfg.Paths = po.Lookup{
 		"/": pc,
 	}
 	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(cfg, pc, rsc.CacheConfig,

--- a/pkg/proxy/engines/objectproxycache_test.go
+++ b/pkg/proxy/engines/objectproxycache_test.go
@@ -790,7 +790,7 @@ func TestObjectProxyCacheRequestNegativeCache(t *testing.T) {
 
 	pc := po.New()
 	cfg := rsc.BackendOptions
-	cfg.Paths = map[string]*po.Options{
+	cfg.Paths = po.Lookup{
 		"/": pc,
 	}
 	r = r.WithContext(tc.WithResources(r.Context(), request.NewResources(cfg, pc, rsc.CacheConfig,

--- a/pkg/proxy/handlers/handlers.go
+++ b/pkg/proxy/handlers/handlers.go
@@ -17,3 +17,7 @@
 // Package handlers provides several non-proxy handlers for use internally
 // by other Trickster handlers
 package handlers
+
+import "net/http"
+
+type Lookup map[string]http.Handler

--- a/pkg/proxy/handlers/trickster/config/config.go
+++ b/pkg/proxy/handlers/trickster/config/config.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package handlers
+package config
 
 import (
 	"net/http"
@@ -23,8 +23,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 )
 
-// ConfigHandleFunc responds to the HTTP request with the running configuration
-func ConfigHandleFunc(conf *config.Config) func(http.ResponseWriter, *http.Request) {
+// HandlerFunc responds to the HTTP request with the running configuration
+func HandlerFunc(conf *config.Config) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
 		w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)

--- a/pkg/proxy/handlers/trickster/config/config_test.go
+++ b/pkg/proxy/handlers/trickster/config/config_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package handlers
+package config
 
 import (
 	"io"
@@ -32,7 +32,7 @@ func TestConfigHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
-	configHandler := ConfigHandleFunc(conf)
+	configHandler := HandlerFunc(conf)
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "http://0/trickster/config", nil)

--- a/pkg/proxy/handlers/trickster/failures/failures.go
+++ b/pkg/proxy/handlers/trickster/failures/failures.go
@@ -14,35 +14,9 @@
  * limitations under the License.
  */
 
-package handlers
+package failures
 
-import (
-	"net/http"
-
-	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
-	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
-)
-
-// HandleLocalResponse responds to an HTTP Request based on the local configuration without making any upstream requests
-func HandleLocalResponse(w http.ResponseWriter, r *http.Request) {
-	rsc := request.GetResources(r)
-	if w == nil || rsc == nil {
-		return
-	}
-	p := rsc.PathConfig
-	if p == nil {
-		return
-	}
-	if len(p.ResponseHeaders) > 0 {
-		headers.UpdateHeaders(w.Header(), p.ResponseHeaders)
-	}
-	if p.ResponseCode > 0 {
-		w.WriteHeader(p.ResponseCode)
-	} else {
-		w.WriteHeader(http.StatusOK)
-	}
-	w.Write([]byte(p.ResponseBody))
-}
+import "net/http"
 
 // HandleBadRequestResponse responds to an HTTP Request with 400 Bad Request
 func HandleBadRequestResponse(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/proxy/handlers/trickster/failures/failures_test.go
+++ b/pkg/proxy/handlers/trickster/failures/failures_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package failures
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleBadRequestResponse(t *testing.T) {
+	HandleBadRequestResponse(nil, nil)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "http://0/trickster/", nil)
+	HandleBadRequestResponse(w, r)
+	if w.Result().StatusCode != 400 {
+		t.Errorf("expected %d got %d", 400, w.Result().StatusCode)
+	}
+}
+
+func TestHandleInternalServerError(t *testing.T) {
+	HandleInternalServerError(nil, nil)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "http://0/trickster/", nil)
+	HandleInternalServerError(w, r)
+	if w.Result().StatusCode != 500 {
+		t.Errorf("expected %d got %d", 500, w.Result().StatusCode)
+	}
+}
+
+func TestHandleBadGateway(t *testing.T) {
+	HandleBadGateway(nil, nil)
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "http://0/trickster/", nil)
+	HandleBadGateway(w, r)
+	if w.Result().StatusCode != 502 {
+		t.Errorf("expected %d got %d", 502, w.Result().StatusCode)
+	}
+}

--- a/pkg/proxy/handlers/trickster/local/local_test.go
+++ b/pkg/proxy/handlers/trickster/local/local_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package handlers
+package local
 
 import (
 	"io"
@@ -163,34 +163,4 @@ func TestHandleLocalResponseNoPathConfig(t *testing.T) {
 		t.Errorf("body should be empty")
 	}
 
-}
-
-func TestHandleBadRequestResponse(t *testing.T) {
-	HandleBadRequestResponse(nil, nil)
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "http://0/trickster/", nil)
-	HandleBadRequestResponse(w, r)
-	if w.Result().StatusCode != 400 {
-		t.Errorf("expected %d got %d", 400, w.Result().StatusCode)
-	}
-}
-
-func TestHandleInternalServerError(t *testing.T) {
-	HandleInternalServerError(nil, nil)
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "http://0/trickster/", nil)
-	HandleInternalServerError(w, r)
-	if w.Result().StatusCode != 500 {
-		t.Errorf("expected %d got %d", 500, w.Result().StatusCode)
-	}
-}
-
-func TestHandleBadGateway(t *testing.T) {
-	HandleBadGateway(nil, nil)
-	w := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "http://0/trickster/", nil)
-	HandleBadGateway(w, r)
-	if w.Result().StatusCode != 502 {
-		t.Errorf("expected %d got %d", 502, w.Result().StatusCode)
-	}
 }

--- a/pkg/proxy/handlers/trickster/ping/ping.go
+++ b/pkg/proxy/handlers/trickster/ping/ping.go
@@ -14,28 +14,21 @@
  * limitations under the License.
  */
 
-package handlers
+package ping
 
 import (
-	"context"
-	"net/http/httptest"
-	"testing"
+	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/config"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 )
 
-func TestRedirector(t *testing.T) {
-	ctx := context.Background()
-	ctx = WithRedirects(ctx, 302, "http://trickstercache.org")
-	r := httptest.NewRequest("GET", "http://0/trickster/", nil)
-	w := httptest.NewRecorder()
-	HandleRedirectResponse(w, r)
-	if w.Result().StatusCode != 400 {
-		t.Errorf("expected %d got %d", 400, w.Result().StatusCode)
-	}
-
-	r = r.WithContext(ctx)
-	w = httptest.NewRecorder()
-	HandleRedirectResponse(w, r)
-	if w.Result().StatusCode != 302 {
-		t.Errorf("expected %d got %d", 302, w.Result().StatusCode)
+// HandlerFunc responds to an HTTP Request with 200 OK and "pong"
+func HandlerFunc(_ *config.Config) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
+		w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("pong"))
 	}
 }

--- a/pkg/proxy/handlers/trickster/ping/ping_test.go
+++ b/pkg/proxy/handlers/trickster/ping/ping_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package handlers
+package ping
 
 import (
 	"io"
@@ -32,7 +32,7 @@ func TestPingHandler(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Could not load configuration: %s", err.Error())
 	}
-	pingHandler := PingHandleFunc(conf)
+	pingHandler := HandlerFunc(conf)
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "http://0/trickster/ping", nil)

--- a/pkg/proxy/handlers/trickster/purge/purge.go
+++ b/pkg/proxy/handlers/trickster/purge/purge.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package handlers
+package purge
 
 import (
 	"net/http"
@@ -28,8 +28,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 )
 
-// PurgeHandleFunc purges an object from a cache based on key.
-func PurgeKeyHandleFunc(conf *config.Config,
+// KeyHandlerFunc purges an object from a cache based on key.
+func KeyHandlerFunc(conf *config.Config,
 	from backends.Backends) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		vals := strings.Replace(req.URL.Path, conf.Main.PurgeKeyHandlerPath, "", 1)
@@ -64,7 +64,7 @@ func PurgeKeyHandleFunc(conf *config.Config,
 	}
 }
 
-func PurgePathHandlerFunc(_ *config.Config,
+func HandlerFunc(_ *config.Config,
 	from *backends.Backends) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
 		purgeFrom := req.URL.Query().Get("backend")

--- a/pkg/proxy/handlers/trickster/redirect/redirector.go
+++ b/pkg/proxy/handlers/trickster/redirect/redirector.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package handlers
+package redirect
 
 import (
 	"context"

--- a/pkg/proxy/handlers/trickster/reload/reload_test.go
+++ b/pkg/proxy/handlers/trickster/reload/reload_test.go
@@ -54,7 +54,7 @@ func TestReloadHandleFunc(t *testing.T) {
 	w := httptest.NewRecorder()
 	r, _ := http.NewRequest("GET", "/", nil)
 
-	f := ReloadHandleFunc(emptyFunc)
+	f := HandlerFunc(emptyFunc)
 	f(w, r)
 	os.Remove(testFile)
 	time.Sleep(time.Millisecond * 500)

--- a/pkg/proxy/handlers/trickster/switcher/switch.go
+++ b/pkg/proxy/handlers/trickster/switcher/switch.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package handlers
+package switcher
 
 import (
 	"net/http"

--- a/pkg/proxy/handlers/trickster/switcher/switch_test.go
+++ b/pkg/proxy/handlers/trickster/switcher/switch_test.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package handlers
+package switcher
 
 import (
 	"net/http"

--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -31,7 +31,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/errors"
-	ph "github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/switcher"
 	sw "github.com/trickstercache/trickster/v2/pkg/proxy/tls"
 
 	"golang.org/x/net/netutil"
@@ -42,7 +42,7 @@ type Listener struct {
 	net.Listener
 	tlsConfig    *tls.Config
 	tlsSwapper   sw.CertSwapper
-	routeSwapper *ph.SwitchHandler
+	routeSwapper *switcher.SwitchHandler
 	server       *http.Server
 	exitOnError  bool
 }
@@ -86,7 +86,7 @@ func (l *Listener) CertSwapper() sw.CertSwapper {
 }
 
 // RouteSwapper returns the RouteSwapper reference from the Listener
-func (l *Listener) RouteSwapper() *ph.SwitchHandler {
+func (l *Listener) RouteSwapper() *switcher.SwitchHandler {
 	return l.routeSwapper
 }
 
@@ -167,7 +167,7 @@ func (lg *Group) Get(name string) *Listener {
 func (lg *Group) StartListener(listenerName, address string, port int, connectionsLimit int,
 	tlsConfig *tls.Config, router http.Handler, tracers tracing.Tracers,
 	f func(), drainTimeout, readHeaderTimeout time.Duration) error {
-	l := &Listener{routeSwapper: ph.NewSwitchHandler(router), exitOnError: f != nil}
+	l := &Listener{routeSwapper: switcher.NewSwitchHandler(router), exitOnError: f != nil}
 	if tlsConfig != nil && len(tlsConfig.Certificates) > 0 {
 		l.tlsConfig = tlsConfig
 		l.tlsSwapper = sw.NewSwapper(tlsConfig.Certificates)

--- a/pkg/proxy/request/rewriter/options/options.go
+++ b/pkg/proxy/request/rewriter/options/options.go
@@ -28,6 +28,8 @@ type Options struct {
 	Instructions RewriteList `yaml:"instructions,omitempty"`
 }
 
+type Lookup map[string]*Options
+
 // Clone returns an exact copy of the subject *Options
 func (o *Options) Clone() *Options {
 	o2 := &Options{}

--- a/pkg/proxy/request/rewriter/rewrite_instructions.go
+++ b/pkg/proxy/request/rewriter/rewrite_instructions.go
@@ -37,6 +37,8 @@ type rewriteInstruction interface {
 // RewriteInstructions is a list of type []rewriteInstruction
 type RewriteInstructions []rewriteInstruction
 
+type InstructionsLookup map[string]RewriteInstructions
+
 var rewriters = map[string]func() rewriteInstruction{
 	"scheme-set":       func() rewriteInstruction { return &rwiBasicSetter{} },
 	"header-set":       func() rewriteInstruction { return &rwiKeyBasedSetter{} },

--- a/pkg/proxy/request/rewriter/rewriter.go
+++ b/pkg/proxy/request/rewriter/rewriter.go
@@ -27,7 +27,7 @@ var errInvalidRewriterOptions = errors.New("invalid rewriter options")
 
 // ProcessConfigs validates and compiles rewriter instructions from
 // the provided configuration map
-func ProcessConfigs(rwl map[string]*options.Options) (map[string]RewriteInstructions, error) {
+func ProcessConfigs(rwl options.Lookup) (map[string]RewriteInstructions, error) {
 	if rwl == nil {
 		return nil, errInvalidRewriterOptions
 	}

--- a/pkg/proxy/request/rewriter/rewriter_test.go
+++ b/pkg/proxy/request/rewriter/rewriter_test.go
@@ -32,14 +32,14 @@ func TestProcessConfig(t *testing.T) {
 	}
 
 	o := &options.Options{Instructions: testRL0}
-	_, err = ProcessConfigs(map[string]*options.Options{"test": o})
+	_, err = ProcessConfigs(options.Lookup{"test": o})
 	if err != errInvalidRewriterOptions {
 		t.Error("expected error for invalid rewriter options", err)
 	}
 
 	o2 := &options.Options{Instructions: testRLW1}
 
-	ri, err := ProcessConfigs(map[string]*options.Options{"test": o, "rewriter1": o2})
+	ri, err := ProcessConfigs(options.Lookup{"test": o, "rewriter1": o2})
 	if err != nil {
 		t.Error(err)
 	}
@@ -55,7 +55,7 @@ func TestProcessConfig(t *testing.T) {
 	}
 
 	o = &options.Options{Instructions: options.RewriteList{[]string{"method", "invalid", "POST"}}}
-	_, err = ProcessConfigs(map[string]*options.Options{"test": o})
+	_, err = ProcessConfigs(options.Lookup{"test": o})
 	if err == nil {
 		t.Error("expected error for invalid instruction")
 	}

--- a/pkg/proxy/response/merge/timeseries.go
+++ b/pkg/proxy/response/merge/timeseries.go
@@ -21,7 +21,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
@@ -78,7 +78,7 @@ func Timeseries(w http.ResponseWriter, r *http.Request, rgs ResponseGates) {
 			w.WriteHeader(bestResp.StatusCode)
 			io.Copy(w, bestResp.Body)
 		} else {
-			handlers.HandleBadGateway(w, r)
+			failures.HandleBadGateway(w, r)
 		}
 		return
 	}

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -37,6 +37,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/health"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
@@ -208,9 +209,9 @@ func registerBackendRoutes(r router.Router, metricsRouter router.Router,
 // RegisterPathRoutes will take the provided default paths map,
 // merge it with any path data in the provided backend options, and then register
 // the path routes to the appropriate handler from the provided handlers map
-func RegisterPathRoutes(r router.Router, handlers map[string]http.Handler,
+func RegisterPathRoutes(r router.Router, handlers handlers.Lookup,
 	client backends.Backend, o *bo.Options, c cache.Cache,
-	paths map[string]*po.Options, tracers tracing.Tracers) {
+	paths po.Lookup, tracers tracing.Tracers) {
 	if o == nil {
 		return
 	}

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing/exporters/zipkin"
 	to "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
@@ -82,7 +83,7 @@ func TestRegisterProxyRoutes(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	tr := map[string]*tracing.Tracer{"test": z}
+	tr := tracing.Tracers{"test": z}
 	o := conf.Backends["default"]
 	o.TracingConfigName = "test"
 
@@ -413,7 +414,7 @@ func TestRegisterMultipleBackendsPlusDefault(t *testing.T) {
 
 func TestRegisterPathRoutes(t *testing.T) {
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	p := map[string]*po.Options{"test": {}}
+	p := po.Lookup{"test": {}}
 	RegisterPathRoutes(nil, nil, nil, nil, nil, p, nil)
 
 	conf, err := config.Load([]string{"-log-level", "debug", "-origin-url",
@@ -428,7 +429,7 @@ func TestRegisterPathRoutes(t *testing.T) {
 	dpc["/-GET-HEAD"].Methods = nil
 
 	testHandler := http.HandlerFunc(testutil.BasicHTTPHandler)
-	handlers := map[string]http.Handler{"testHandler": testHandler}
+	handlers := handlers.Lookup{"testHandler": testHandler}
 
 	RegisterPathRoutes(nil, handlers, rpc, oo, nil, dpc, nil)
 
@@ -492,7 +493,7 @@ func TestRegisterDefaultBackendRoutes(t *testing.T) {
 	po1.MatchType = matching.PathMatchTypePrefix
 
 	oo.TracingConfigName = "testTracer"
-	oo.Paths = map[string]*po.Options{"root": po1}
+	oo.Paths = po.Lookup{"root": po1}
 	oo.IsDefault = true
 	rpc, _ := reverseproxycache.NewClient("default", oo, lm.NewRouter(), nil, nil, nil)
 	b := backends.Backends{"default": rpc}

--- a/pkg/testutil/testing.go
+++ b/pkg/testutil/testing.go
@@ -99,7 +99,7 @@ func NewTestWebClient() *http.Client {
 // NewTestInstance will start a trickster
 func NewTestInstance(
 	configFile string,
-	defaultPathConfigs func(*bo.Options) map[string]*po.Options,
+	defaultPathConfigs func(*bo.Options) po.Lookup,
 	respCode int, respBody string, respHeaders map[string]string,
 	backendProvider, urlPath, logLevel string,
 ) (*httptest.Server, *httptest.ResponseRecorder, *http.Request, *http.Client, error) {
@@ -172,10 +172,10 @@ func NewTestInstance(
 // NewTestPathConfig returns a path config based on the provided parameters
 func NewTestPathConfig(
 	o *bo.Options,
-	defaultPathConfigs func(*bo.Options) map[string]*po.Options,
+	defaultPathConfigs func(*bo.Options) po.Lookup,
 	urlPath string,
 ) *po.Options {
-	var paths map[string]*po.Options
+	var paths po.Lookup
 	if defaultPathConfigs != nil {
 		paths = defaultPathConfigs(o)
 	}

--- a/pkg/testutil/testing_test.go
+++ b/pkg/testutil/testing_test.go
@@ -79,8 +79,8 @@ func TestNewTestInstance(t *testing.T) {
 
 	// cover promsim conditional and path generation
 
-	f := func(*bo.Options) map[string]*po.Options {
-		return map[string]*po.Options{
+	f := func(*bo.Options) po.Lookup {
+		return po.Lookup{
 			"path1": {},
 			"path2": {},
 		}


### PR DESCRIPTION
This replaces all instances of `map[string]*InternalType` with the corresponding `Lookup` type. Cosmetic only. In the Handlers directory, each handler has been moved into its own package for clarity, but no new features.