### PR TITLE
add authenticator feature w/ basic auth

### DIFF
--- a/docs/authenticator.md
+++ b/docs/authenticator.md
@@ -1,0 +1,125 @@
+# Authenticator
+
+Trickster 2.0 provides a new Authenticator capability that allows you to protect Backends with an Authentication layer.
+
+Authenticator resources are defined globally by name, and then mapped into any Backend and/or Path configuration as needed. Authenticators can be loaded from `htpasswd` or `csv` files, or directly in the Trickster config file.
+
+When embedding in the config file, you can include credentials in plaintext or pre-encrypted with bcrypt; but you must specify `users_format: bcrypt` when credentials are pre-encrypted. See `example_auth_3` in the blob below.
+
+If you are loading Users into the same Authenticator from both a CSV and the embedded manifest, you must use the same format of credential (plaintext or bcrypt) for both. If the credentials are already encrypted, you must provide the encryption format in `users_format: bcrypt`. If no `users_format` value is supplied, credential are assumed to be provided in plaintext. Trickster will internally bcrypt any plaintext credential upon loading into the Authenticator. However, any plaintext credentials provided will persist in any Environment Variables or files from which they are sourced via configuration.
+
+Authenticators work with all Backend provider types. Requests are handled by their respective Authenticators before all other Handlers (e.g., Caches, Rules, Request Rewrites, ALB Routes, etc.).
+
+If a request is routed via a Trickster ALB or Rule Backend through to multiple other Backends - each having different Authenticator configurations - the authentication behavior is currently undefined. In an upcoming Beta release, we will define this use case to either use the Authenticator config (if set) of the very first Backend that handled the request; or to use the first defined Authenticator regardless of how deep into the Backend chain it is.
+
+By default, when an Authenticator handles and successfully authenticates a request, the request's Auth credentials (e.g., Authorization Header for Basic Auth) are stripped before the request is cloned for any necessary proxying. Setting `proxy_preserve: true` will preserve these headers instead of stripping them.
+
+## Path Protection
+
+When you map an Authenticator to a Backend, all Paths defined for that Backend are protected by the Authenticator. However, you can override the Authenticator on a per-Path basis by including the `authenticator_name` in a Path config. To bypass a Backend-wide Authenticator in a Path config, use `authenticator_name: none`. This allows for a few possibilities:
+  
+  * A Backend config with a default / Backend-wide Authenticator that has:
+    * specific Paths that do not require Authentication
+    * specific Paths mapped to different Authenticators than the default
+  
+  * A Backend config with no Authenticator defined (so all Paths by default are unprotected) that has:
+    * specific Paths mapped to different Authenticators than the default
+
+See the example Backend configs below for more details.
+
+## Basic Auth Provider
+
+Currently, Trickster supports Basic Authorization, but was designed with extensibility in mind should there be value in adding additional Authentication providers.
+
+By setting the `showLoginForm: true` config (see `example_auth_1` in the blob below), Trickster will return a `WWW-Authenticate: Basic realm="custom-realm-name"` header on any request that requires but fails authentication, causing the login form to pop up. When `showLoginForm` is not present or non-true, Trickster responds with a `401 Unauthorized` but does not ask the Basic Auth login form to show.
+
+The `realm` attribute value defaults to the Authenticator name (e.g., `example_auth_1`) but can be overridden with the `realm` config as in the example.
+
+If the user data changes (e.g. updated users_file contents or updated embedded users list), you must send a SIGHUP or other means to reload the Trickster config before the new user pool is processed.
+
+## Example Authenticator Configs
+
+```yaml
+# NOTE: Required options unrelated to Authenticators have been omitted from this
+# example. It does not represent a fully-functioning Trickster Config.
+# See the 'examples' directory for working copy/paste config examples.
+
+backends:
+  backend01:
+    provider: reverseproxy # authenticators work with all backend providers
+    authenticator_name: example_auth_1 # protects backend01 with example_auth_1 authenticator
+    origin_url: https://example.com
+    paths:
+      root:
+        path: / # all requests are protected by example_auth_1 
+        match_type: prefix
+        handler: proxy
+
+  backend02:
+    provider: reverseproxy # no backend-wide authenticator
+    origin_url: https://example.com
+    paths:
+      root:
+        path: / # requests will be allowed without auth except the 2 Paths below
+        match_type: prefix
+        handler: proxy
+      protected_a:
+        path: /private/
+        authenticator_name: example_auth_2 # example_auth_2 protects this path only
+        handler: proxy
+      protected_b:
+        path: /admin/
+        authenticator_name: example_auth_3 # example_auth_3 protects this path only
+        handler: proxy
+
+  backend03:
+    provider: reverseproxycache
+    authenticator_name: example_auth_1 # protects backend03 with example_auth_1 authenticator
+    origin_url: https://example.com
+    paths:
+      path: / # requests will be challenged by example_auth_1 except the 2 Paths below
+        match_type: prefix
+        handler: proxy
+      unprotected:
+        path: /public/
+        authenticator_name: none # requests to /public will be allowed without auth
+        handler: proxy
+      protected_a:
+        path: /app/admin/
+        authenticator_name: example_auth_2 # example_auth_2 protects this path, not auth_1
+        handler: proxy
+
+authenticators:
+  # example_auth_1 loads users from a CSV and embeds a supplemental plaintext manifest
+  # It also shows the login form to client browsers when login has failed
+  example_auth_1:
+    provider: basic # http basic auth (required)
+    proxy_preserve: true # don't strip auth headers when proxying this request upstream
+    users_file: /path/to/user-manifest.csv # optional users source file
+    users_file_format: csv # required when users_file is set
+    users: # optional embedded users manifest (username: credential)
+      user1: red123
+    users_format: plaintext # plaintext is the default format if this value is omitted
+    config: # optional provider-specific configs
+      showLoginForm: true # with basic auth, causes the browser to show the login form
+      realm: custom-realm-name # realm would be example_auth_1 if not overridden here
+
+  # example_auth_2 loads users from an htpasswd file (assumed bcrypted credentials)
+  example_auth_2:
+    provider: basic
+    users_file: /path/to/user-manifest.htpasswd # optional users source file
+    users_file_format: htpasswd # required when users_file is set
+
+  # example_auth_3 loads users from the embedded users manifest, credentials already bcrypted
+  example_auth_3:
+    provider: basic
+    users:
+      user1: asf;j2ihj0h8vabjkwdqbv29hq
+    users_format: bcrypt # credentials are already bcrypted
+
+  # example_auth_4 loads users from the embedded manifest, credentials injected from Env Var
+  example_auth_4:
+    provider: basic
+    users:
+      user1: ${USER1_PASSWORD_ENV} # ${ENV_NAME} substitution is supported
+```

--- a/docs/new-changed-2.0.md
+++ b/docs/new-changed-2.0.md
@@ -46,9 +46,10 @@
 - We've switched from Regular Expression matches for SQL-based Time Series Backends to an extensible lexer/parser solution
   - ClickHouse backend providers now use the new SQL Parser
 - We now support [Simulated Latency](./simulated-latency.md) if you want to use Trickster for that purpose in a test harness.
+- We've added a new [Authenticator](authenticator.md) feature so you can guard backends with Basic Auth
 - We now support Environment variable substitution in configuration files where sensitive information is expected.
   - Supported via the following fields:
-    - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].request_params`, `backends[*].paths[*].response_headers`
+    - `caches[*].redis.password`, `backends[*].healthcheck.headers`, `backends[*].paths[*].request_headers`, `backends[*].paths[*].request_params`, `backends[*].paths[*].response_headers`, `authenticators[*].users`
   - Usage: `password: ${MY_SECRET_VAR}`
 - Previous Trickster 2.0 Betas used millisecond config values like `timeout_ms: 1500`. These have changed to `timeout: 1500ms`. See more details in the Configuration section below.
 - We no longer include the `vendor` directory in the project repository and `vendor` is now in `.gitignore`. `vendor` will continue to be included in Release source tarballs.

--- a/examples/conf/example.auth.yaml
+++ b/examples/conf/example.auth.yaml
@@ -23,6 +23,7 @@ authenticators:
     users_file_format: csv
     users: # optional embedded users list (name: credential)
       user1: red123
+      user2: ${USER2_PASS} # password for user2 is sourced from the ENV
     users_format: plaintext
     config: # optional provider-specific configs
       showLoginForm: true # show the login form on missing or invalid creds

--- a/examples/conf/example.auth.yaml
+++ b/examples/conf/example.auth.yaml
@@ -1,0 +1,42 @@
+backends:
+  backend01:
+    provider: reverseproxy
+    authenticator_name: example_auth_1 # <-- protects backend01 with example_auth_1 authenticator
+    origin_url: https://example.com/
+
+  backend02:
+    provider: reverseproxy
+    authenticator_name: example_auth_2 # <-- protects backend02 with example_auth_2 authenticator
+    origin_url: https://example.com/
+
+  backend03:
+    provider: reverseproxy
+    authenticator_name: example_auth_3 # <-- protects backend03 with example_auth_3 authenticator
+    origin_url: https://example.com/
+
+authenticators:
+  # loads users from a CSV and an embedded plaintext manifest, causes the browser to show the login form
+  example_auth_1:
+    provider: basic # http basic auth (required)
+    proxy_preserve: true # the authenticator will preserve auth headers instead of stripping them
+    users_file: /path/to/user-manifest.csv # optional users source file
+    users_file_format: csv
+    users: # optional embedded users list (name: credential)
+      user1: red123
+    users_format: plaintext
+    config: # optional provider-specific configs
+      showLoginForm: true # show the login form on missing or invalid creds
+      realm: custom-realm-name # realm name defaults to the authenticator name
+
+  # loads users from an htpasswd file (assumed bcrypted passwords)
+  example_auth_2:
+    provider: basic # http basic auth (required)
+    users_file: /path/to/user-manifest.htpasswd # optional users source file
+    users_file_format: htpasswd
+
+  # loads users from the embedded users list only, passwords are pre-bcrypted
+  example_auth_3:
+    provider: basic # http basic auth (required)
+    users: # optional embedded users list (name: credential)
+      user1: asf;j2ihj0h8vabjkwdqbv29hq
+    users_format: bcrypt

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -665,6 +665,34 @@ backends:
 #     endpoint: https://zipkin.example.com:9411/api/v2/spans
 #     sample_rate: 0.1
 
+# # Configuration Options for Authentication
+# authenticators:
+#   example_auth_1:
+#     # provider (required) is the type of Authenticator. Currently supported: basic (basic auth)
+#     provider: basic
+#     # proxy_preserve, when true, will pass the Authentication headers through on proxied requests.
+#     # The default value (false) will cause Authentication headers to be stripped from proxied requests
+#     # when an inbound request is permitted by this Authenticator.
+#     proxy_preserve: false
+#     # users_file is the optional users source file
+#     users_file: /path/to/user-manifest.csv
+#     # users_file_format is the source file format. Required when users_file is set. Valid options: csv, htpasswd
+#     users_file_format: csv
+#     # users is an optional embedded users list (format is: name: credential)
+#     users: 
+#       user1: red123
+#     # users_format provides the format of the passwords in both the users_file CSVs and the embedded users list.
+#     # Valid options are: plaintext (default), bcrypt.
+#     users_format: plaintext 
+#     # config holds optional provider-specific configs
+#     config:
+#       # basic auth optional configs:
+#       # showLoginForm (default: false) will cause the user's browser to show the Basic Auth Login modal when
+#       # required credentials are not provided or are invalid
+#       showLoginForm: true 
+#       # realm is the realm valid shown to on the Basic Auth Login modal. If not set, the realm will default
+#       # to the authenticator name (e.g., example_auth_1)
+#       realm: custom-realm-name
 
 # # Configuration Options for Metrics Instrumentation
 # metrics:

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	go.opentelemetry.io/otel/exporters/zipkin v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0
+	golang.org/x/crypto v0.38.0
 	golang.org/x/net v0.40.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,8 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
+golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=

--- a/pkg/backends/options/errors.go
+++ b/pkg/backends/options/errors.go
@@ -96,6 +96,19 @@ func NewErrInvalidCacheName(cacheName, backendName string) error {
 	}
 }
 
+// ErrInvalidAuthenticatorName is an error type for invalid cache name
+type ErrInvalidAuthenticatorName struct {
+	error
+}
+
+// NewErrInvalidAuthenticatorName returns a new invalid authenticator name error
+func NewErrInvalidAuthenticatorName(authenticatorName, backendName string) error {
+	return &ErrInvalidAuthenticatorName{
+		error: fmt.Errorf(`invalid authenticator_name "%s" provided in backend options "%s"`,
+			authenticatorName, backendName),
+	}
+}
+
 // ErrInvalidTracingName is an error type for invalid tracing name
 type ErrInvalidTracingName struct {
 	error

--- a/pkg/backends/options/options_test.go
+++ b/pkg/backends/options/options_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/cache/negative"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	tro "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
+	autho "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	rwopts "github.com/trickstercache/trickster/v2/pkg/proxy/request/rewriter/options"
@@ -113,7 +114,7 @@ func TestValidateConfigMappings(t *testing.T) {
 	ol["frontend"] = o
 
 	err = ol.ValidateConfigMappings(co.Lookup{}, negative.Lookups{},
-		ro.Lookup{}, rwopts.Lookup{}, tro.Lookup{})
+		ro.Lookup{}, rwopts.Lookup{}, autho.Lookup{}, tro.Lookup{})
 	if err == nil {
 		t.Error("expected error for invalid cache name")
 	}
@@ -122,13 +123,13 @@ func TestValidateConfigMappings(t *testing.T) {
 	o.Provider = providers.Rule
 	o.RuleName = "test"
 	err = ol.ValidateConfigMappings(co.Lookup{"test": nil}, negative.Lookups{},
-		ro.Lookup{}, rwopts.Lookup{}, tro.Lookup{})
+		ro.Lookup{}, rwopts.Lookup{}, autho.Lookup{}, tro.Lookup{})
 	if err == nil {
 		t.Error("expected error for invalid rule name")
 	}
 
 	err = ol.ValidateConfigMappings(co.Lookup{"test": nil}, negative.Lookups{},
-		ro.Lookup{"test": new(ro.Options)}, rwopts.Lookup{}, tro.Lookup{})
+		ro.Lookup{"test": new(ro.Options)}, rwopts.Lookup{}, autho.Lookup{}, tro.Lookup{})
 	if err == nil {
 		t.Error("expected error for invalid tracing name")
 	}
@@ -137,7 +138,8 @@ func TestValidateConfigMappings(t *testing.T) {
 
 	o.Name = ""
 	err = ol.ValidateConfigMappings(co.Lookup{"test": nil}, negative.Lookups{},
-		ro.Lookup{"test": new(ro.Options)}, rwopts.Lookup{}, tro.Lookup{})
+		ro.Lookup{"test": new(ro.Options)}, rwopts.Lookup{}, autho.Lookup{},
+		tro.Lookup{})
 	if err == nil {
 		t.Error("expected error for invalid backend name")
 	}
@@ -146,7 +148,7 @@ func TestValidateConfigMappings(t *testing.T) {
 	o.Provider = providers.ALB
 	o.RuleName = ""
 	err = ol.ValidateConfigMappings(co.Lookup{"test": nil}, negative.Lookups{},
-		ro.Lookup{"test": new(ro.Options)}, rwopts.Lookup{}, tro.Lookup{})
+		ro.Lookup{"test": new(ro.Options)}, rwopts.Lookup{}, autho.Lookup{}, tro.Lookup{})
 	if err == nil {
 		t.Error("expected error for invalid negative cache name")
 	}
@@ -154,7 +156,8 @@ func TestValidateConfigMappings(t *testing.T) {
 	o.NegativeCacheName = ""
 
 	err = ol.ValidateConfigMappings(co.Lookup{"test": nil}, negative.Lookups{},
-		ro.Lookup{"test": new(ro.Options)}, rwopts.Lookup{}, tro.Lookup{})
+		ro.Lookup{"test": new(ro.Options)}, rwopts.Lookup{}, autho.Lookup{},
+		tro.Lookup{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ import (
 	lo "github.com/trickstercache/trickster/v2/pkg/observability/logging/options"
 	mo "github.com/trickstercache/trickster/v2/pkg/observability/metrics/options"
 	tracing "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
+	auth "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request/rewriter"
 	rwopts "github.com/trickstercache/trickster/v2/pkg/proxy/request/rewriter/options"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
@@ -67,6 +68,8 @@ type Config struct {
 	RequestRewriters rwopts.Lookup `yaml:"request_rewriters,omitempty"`
 	// ReloadConfig provides configurations for in-process config reloading
 	ReloadConfig *reload.Options `yaml:"reloading,omitempty"`
+	// Authenticators provides configurations for Authenticating users
+	Authenticators auth.Lookup `yaml:"authenticators,omitempty"`
 
 	// Flags contains a compiled version of the CLI flags
 	Flags *Flags `yaml:"-"`
@@ -333,6 +336,13 @@ func (c *Config) Clone() *Config {
 		nc.RequestRewriters = make(rwopts.Lookup, len(c.RequestRewriters))
 		for k, v := range c.RequestRewriters {
 			nc.RequestRewriters[k] = v.Clone()
+		}
+	}
+
+	if len(c.Authenticators) > 0 {
+		nc.Authenticators = make(auth.Lookup, len(c.Authenticators))
+		for k, v := range c.Authenticators {
+			nc.Authenticators[k] = v.Clone()
 		}
 	}
 

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	"github.com/trickstercache/trickster/v2/pkg/errors"
 	tr "github.com/trickstercache/trickster/v2/pkg/observability/tracing/registry"
+	ar "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/registry"
 	"github.com/trickstercache/trickster/v2/pkg/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
 )
@@ -50,6 +51,9 @@ func Validate(c *config.Config) error {
 		return err
 	}
 	if err := Rules(c); err != nil {
+		return err
+	}
+	if err := Authenticators(c); err != nil {
 		return err
 	}
 	if err := Caches(c); err != nil {
@@ -109,12 +113,22 @@ func NegativeCaches(c *config.Config) error {
 	return nil
 }
 
+func Authenticators(c *config.Config) error {
+	if len(c.Authenticators) == 0 {
+		return nil
+	}
+	if err := c.Authenticators.Validate(ar.IsRegistered); err != nil {
+		return err
+	}
+	return nil
+}
+
 func Backends(c *config.Config) error {
 	if len(c.Backends) == 0 {
 		return errors.ErrNoValidBackends
 	}
 	if err := c.Backends.ValidateConfigMappings(c.Caches, c.CompiledNegativeCaches,
-		c.Rules, c.RequestRewriters, c.TracingConfigs); err != nil {
+		c.Rules, c.RequestRewriters, c.Authenticators, c.TracingConfigs); err != nil {
 		return err
 	}
 	serveTLS, err := c.Backends.ValidateTLSConfigs()

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -117,10 +117,7 @@ func Authenticators(c *config.Config) error {
 	if len(c.Authenticators) == 0 {
 		return nil
 	}
-	if err := c.Authenticators.Validate(ar.IsRegistered); err != nil {
-		return err
-	}
-	return nil
+	return c.Authenticators.Validate(ar.IsRegistered)
 }
 
 func Backends(c *config.Config) error {

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -42,6 +42,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	tr "github.com/trickstercache/trickster/v2/pkg/observability/tracing/registry"
+	ar "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/registry"
 	pnh "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/ping"
 	ph "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/purge"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/reload"
@@ -95,6 +96,10 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 
 	if newConf.ReloadConfig == nil {
 		newConf.ReloadConfig = ro.New()
+	}
+
+	if err := buildAuthenticators(newConf); err != nil {
+		return err
 	}
 
 	applyLoggingConfig(newConf, si.Config)
@@ -153,6 +158,20 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	si.Config = newConf
 	si.Caches = caches
 	si.Backends = backends
+	return nil
+}
+
+func buildAuthenticators(c *config.Config) error {
+	if c == nil || len(c.Authenticators) == 0 {
+		return nil
+	}
+	for _, ao := range c.Authenticators {
+		ac, err := ar.New(ao.Provider, map[string]any{"options": ao})
+		if err != nil {
+			return err
+		}
+		ao.Authenticator = ac
+	}
 	return nil
 }
 

--- a/pkg/proxy/authenticator/authenticator.go
+++ b/pkg/proxy/authenticator/authenticator.go
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package authenticator provides implementations of Authenticators
+package authenticator

--- a/pkg/proxy/authenticator/cred/cred.go
+++ b/pkg/proxy/authenticator/cred/cred.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cred
+
+import (
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// ProcessRawPassword converts the input from plaintext or other format to the
+// encryption format used by the Authenticator
+func ProcessRawCredential(input string, cf types.CredentialsFormat) (string, error) {
+	if cf == types.PlainText || cf == types.Unknown {
+		hash, err := bcrypt.GenerateFromPassword([]byte(input), bcrypt.DefaultCost)
+		if err != nil {
+			return "", err
+		}
+		return string(hash), nil
+	}
+	return input, nil
+}

--- a/pkg/proxy/authenticator/errors/errors.go
+++ b/pkg/proxy/authenticator/errors/errors.go
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package errors
+
+import "errors"
+
+var ErrInvalidCredentials = errors.New("invalid credentials")
+var ErrInvalidCredentialsFormat = errors.New("invalid credentials format")
+var ErrInvalidName = errors.New("invalid authenticator name")
+var ErrInvalidProvider = errors.New("invalid authenticator provider name")
+var ErrInvalidUsersFile = errors.New("users does not exist or is not readable")

--- a/pkg/proxy/authenticator/handler/handler.go
+++ b/pkg/proxy/authenticator/handler/handler.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handler
+
+import (
+	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/unauthorized"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+)
+
+// Middleware returns a handler that authenticates the request and passes to
+// the next handler on success, else responds with unauthorized and aborts
+func Middleware(a types.Authenticator, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		res, err := a.Authenticate(r)
+		if err != nil || res == nil ||
+			res.Status != types.AuthSuccess {
+			if res != nil && res.ResponseHeaders != nil {
+				for k, v := range res.ResponseHeaders {
+					w.Header().Set(k, v)
+				}
+			}
+			unauthorized.ServeHTTP(w, r)
+			return
+		}
+		rsc := request.GetResources(r)
+		rsc.AuthResult = res
+		a.Sanitize(r)
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/proxy/authenticator/loaders/csv/csv.go
+++ b/pkg/proxy/authenticator/loaders/csv/csv.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package csv
+
+import (
+	"encoding/csv"
+	"os"
+	"strings"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/cred"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+)
+
+func LoadCSV(path string, ff types.CredentialsFileFormat,
+	cf types.CredentialsFormat) (types.CredentialsManifest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	matrix, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	var start int
+	if ff == types.CSV {
+		start = 1
+	}
+	out := make(types.CredentialsManifest, len(matrix)-start)
+	for i, row := range matrix {
+		if i < start || len(row) < 2 {
+			continue
+		}
+		p, err := cred.ProcessRawCredential(strings.TrimSpace(row[1]), cf)
+		if err != nil {
+			return nil, err
+		}
+		out[strings.TrimSpace(row[0])] = p
+	}
+	return out, nil
+}

--- a/pkg/proxy/authenticator/loaders/htpasswd/htpasswd.go
+++ b/pkg/proxy/authenticator/loaders/htpasswd/htpasswd.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package htpasswd
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+)
+
+func LoadHtpasswdBcrypt(path string) (types.CredentialsManifest, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	users := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		users[parts[0]] = parts[1]
+	}
+	return users, scanner.Err()
+}

--- a/pkg/proxy/authenticator/loaders/htpasswd/htpasswd_test.go
+++ b/pkg/proxy/authenticator/loaders/htpasswd/htpasswd_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package htpasswd
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func bcryptHash(pass string) string {
+	h, _ := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
+	return string(h)
+}
+
+func TestLoadHtpasswdBcrypt(t *testing.T) {
+	// Invalid file
+	_, err := LoadHtpasswdBcrypt("/no/such/file")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+	tempDir := t.TempDir()
+
+	// Write a temp .htpasswd file
+	htpasswd1 := filepath.Join(tempDir, "htpasswd")
+	f, err := os.Create(htpasswd1)
+	if err != nil {
+		t.Fatalf("failed to create temp htpasswd: %v", err)
+	}
+	defer os.Remove(f.Name())
+	users := []string{
+		"foo:" + bcryptHash("bar"),
+		"# comment",
+		"badline",
+		"baz:" + bcryptHash("quux"),
+	}
+	for _, l := range users {
+		f.WriteString(l + "\n")
+	}
+	f.Close()
+
+	m, err := LoadHtpasswdBcrypt(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := slices.Collect(maps.Keys(m))
+	if !slices.Contains(keys, "foo") || !slices.Contains(keys, "baz") {
+		t.Errorf("missing users from htpasswd file: %#v", maps.Keys(m))
+	}
+}

--- a/pkg/proxy/authenticator/loaders/loaders.go
+++ b/pkg/proxy/authenticator/loaders/loaders.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loaders
+
+import (
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/loaders/csv"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/loaders/htpasswd"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func LoadData(path string, ff types.CredentialsFileFormat,
+	cf types.CredentialsFormat) (types.CredentialsManifest, error) {
+	switch ff {
+	case types.HTPasswd:
+		return htpasswd.LoadHtpasswdBcrypt(path)
+	case types.CSV, types.CSVNoHeader:
+		return csv.LoadCSV(path, ff, cf)
+	}
+	return nil, nil
+}
+
+func LoadMap(users types.CredentialsManifest,
+	cf types.CredentialsFormat) types.CredentialsManifest {
+	out := make(types.CredentialsManifest, len(users))
+	for username, password := range users {
+		switch cf {
+		case types.PlainText, types.Unknown:
+			hash, err := bcrypt.GenerateFromPassword([]byte(password),
+				bcrypt.DefaultCost)
+			if err != nil {
+				continue
+			}
+			out[username] = string(hash)
+		default:
+			out[username] = password
+		}
+	}
+	return out
+}

--- a/pkg/proxy/authenticator/options/options.go
+++ b/pkg/proxy/authenticator/options/options.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"maps"
+
+	ct "github.com/trickstercache/trickster/v2/pkg/config/types"
+	ae "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/errors"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+	"github.com/trickstercache/trickster/v2/pkg/util/files"
+	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+)
+
+var restrictedNames = sets.New([]string{"", "none"})
+
+type Options struct {
+	Name            string                      `yaml:"-"` // populated from the Lookup key
+	Provider        types.Provider              `yaml:"provider"`
+	ProxyPreserve   bool                        `yaml:"proxy_preserve"`
+	UsersFile       string                      `yaml:"users_file"`
+	UsersFileFormat types.CredentialsFileFormat `yaml:"users_file_format"`
+	Users           map[string]ct.EnvString     `yaml:"users,omitempty"`
+	UsersFormat     types.CredentialsFormat     `yaml:"users_format"`
+	ProviderData    map[string]any              `yaml:"config"`
+	Authenticator   types.Authenticator
+}
+
+// Lookup is a map of Options keyed by Options Name
+type Lookup map[string]*Options
+
+func (o *Options) Clone() *Options {
+	out := &Options{
+		Name:            o.Name,
+		Provider:        o.Provider,
+		UsersFile:       o.UsersFile,
+		UsersFileFormat: o.UsersFileFormat,
+		UsersFormat:     o.UsersFormat,
+		Authenticator:   o.Authenticator,
+		Users:           maps.Clone(o.Users),
+		ProviderData:    maps.Clone(o.ProviderData),
+		ProxyPreserve:   o.ProxyPreserve,
+	}
+	return out
+}
+
+func (o *Options) Validate(f types.IsRegisteredFunc) error {
+	if restrictedNames.Contains(o.Name) {
+		return ae.ErrInvalidName
+	}
+	if !f(o.Provider) {
+		return ae.ErrInvalidProvider
+	}
+	if o.UsersFile != "" {
+		if !files.FileExistsAndReadable(o.UsersFile) {
+			return ae.ErrInvalidUsersFile
+		}
+	}
+	if len(o.Users) > 0 && o.UsersFormat == "" {
+		o.UsersFormat = types.Unknown
+	}
+	return nil
+}
+
+func (l Lookup) Validate(f types.IsRegisteredFunc) error {
+	for k, o := range l {
+		o.Name = k
+		if err := o.Validate(f); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/proxy/authenticator/providers/basic/basic.go
+++ b/pkg/proxy/authenticator/providers/basic/basic.go
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package basic
+
+import (
+	"fmt"
+	"maps"
+	"net/http"
+
+	ct "github.com/trickstercache/trickster/v2/pkg/config/types"
+	"github.com/trickstercache/trickster/v2/pkg/errors"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/cred"
+	ae "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/errors"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/loaders"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const ID types.Provider = "basic"
+
+const showLoginFormField = "showLoginForm"
+const optionsField = "options"
+const realmField = "realm"
+
+type Authenticator struct {
+	users            types.CredentialsManifest
+	extractCredsFunc types.ExtractCredsFunc
+	showLoginForm    bool
+	realm            string
+	proxyPreserve    bool
+}
+
+func RegistryEntry() types.RegistryEntry {
+	return types.RegistryEntry{Provider: ID, New: New}
+}
+
+func New(data map[string]any) (types.Authenticator, error) {
+	var opts *options.Options
+	if data != nil {
+		if v, ok := data[optionsField]; ok && v != nil {
+			opts, _ = v.(*options.Options)
+		}
+	}
+	if opts == nil {
+		return nil, errors.ErrInvalidOptions
+	}
+	a := &Authenticator{realm: opts.Name, proxyPreserve: opts.ProxyPreserve}
+	if len(opts.ProviderData) > 0 {
+		if v, ok := opts.ProviderData[showLoginFormField]; ok {
+			if t, ok := v.(bool); ok && t {
+				a.showLoginForm = true
+			}
+		}
+		if a.showLoginForm {
+			if v, ok := opts.ProviderData[realmField]; ok {
+				if s, ok := v.(string); ok && s != "" {
+					a.realm = s
+				}
+			}
+		}
+	}
+	if opts.UsersFile != "" {
+		err := a.LoadUsers(opts.UsersFile, opts.UsersFileFormat, opts.UsersFormat, true)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(opts.Users) > 0 {
+		a.AddUsersFromMap(opts.Users, opts.UsersFormat)
+	}
+	return a, nil
+}
+
+func failureHeader(showLoginForm bool, realm string) map[string]string {
+	if !showLoginForm {
+		return nil
+	}
+	return map[string]string{
+		headers.NameWWWAuthenticate: fmt.Sprintf(`Basic realm="%s"`, realm)}
+}
+
+func failedResult(showLoginForm bool, realm string) *types.AuthResult {
+	return &types.AuthResult{
+		Status:          types.AuthFailed,
+		ResponseHeaders: failureHeader(showLoginForm, realm),
+	}
+}
+
+// Authenticate checks the BasicAuth credentials
+func (a *Authenticator) Authenticate(r *http.Request) (*types.AuthResult, error) {
+	u, p, f, err := a.ExtractCredentials(r)
+	if err != nil {
+		return failedResult(a.showLoginForm, a.realm), err
+	}
+	if f != types.PlainText {
+		return failedResult(a.showLoginForm, a.realm), ae.ErrInvalidCredentialsFormat
+	}
+	hash, ok := a.users[u]
+	if !ok {
+		return failedResult(a.showLoginForm, a.realm), ae.ErrInvalidCredentials
+	}
+	if bcrypt.CompareHashAndPassword([]byte(hash), []byte(p)) != nil {
+		return failedResult(a.showLoginForm, a.realm), ae.ErrInvalidCredentials
+	}
+	return &types.AuthResult{Username: u, Status: types.AuthSuccess}, nil
+}
+
+// Clone clones a new Authenticator (i) from a
+func (a *Authenticator) Clone() types.Authenticator {
+	return a.ClonePtr()
+}
+
+// Clone returns a new, completely independent clone of the Authenticator
+func (a *Authenticator) ClonePtr() *Authenticator {
+	out := &Authenticator{}
+	if a.users != nil {
+		out.users = make(types.CredentialsManifest, len(a.users))
+		maps.Copy(out.users, a.users)
+	}
+	if a.extractCredsFunc != nil {
+		out.extractCredsFunc = a.extractCredsFunc
+	}
+	out.showLoginForm = a.showLoginForm
+	out.realm = a.realm
+	return out
+}
+
+func (a *Authenticator) ProxyPreserve() bool {
+	return a.proxyPreserve
+}
+
+func (a *Authenticator) Sanitize(r *http.Request) {
+	if a.proxyPreserve {
+		return
+	}
+	r.Header.Del(headers.NameAuthorization)
+}
+
+func (a *Authenticator) ExtractCredentials(r *http.Request) (string, string,
+	types.CredentialsFormat, error) {
+	if a.extractCredsFunc != nil {
+		return a.extractCredsFunc(r)
+	}
+	u, p, ok := r.BasicAuth()
+	if !ok {
+		return "", "", "", ae.ErrInvalidCredentials
+	}
+	return u, p, types.PlainText, nil
+}
+
+func (a *Authenticator) SetExtractCredentialsFunc(f types.ExtractCredsFunc) {
+	a.extractCredsFunc = f
+}
+
+// LoadUsers resets the users list, then loads from the htpasswd-formatted file
+func (a *Authenticator) LoadUsers(path string, ff types.CredentialsFileFormat,
+	cf types.CredentialsFormat, replace bool) error {
+	users, err := loaders.LoadData(path, ff, cf)
+	if err != nil {
+		return err
+	}
+	if replace || a.users == nil {
+		a.users = users
+	} else {
+		maps.Copy(a.users, users)
+	}
+	return nil
+}
+
+// AddUser adds a new user to the users list
+func (a *Authenticator) AddUser(username, password string,
+	cf types.CredentialsFormat) error {
+	p, err := cred.ProcessRawCredential(password, cf)
+	if err != nil {
+		return err
+	}
+	if a.users == nil {
+		a.users = make(types.CredentialsManifest)
+	}
+	a.users[username] = p
+	return nil
+}
+
+// RemoveUser removes a user from the users list
+func (a *Authenticator) RemoveUser(username string) {
+	if a.users == nil {
+		return
+	}
+	delete(a.users, username)
+}
+
+// AddUsersFromMap merges in users from a map[string]any
+func (a *Authenticator) AddUsersFromMap(users esLookup,
+	cf types.CredentialsFormat) {
+	loaded := loaders.LoadMap(users.ToCredentialsManifest(), cf)
+	if a.users == nil {
+		a.users = loaded
+	} else {
+		maps.Copy(a.users, loaded)
+	}
+}
+
+// LoadUsersFromMap resets the users list, then loads from a map[string]any
+// via AddUsersFromMap
+func (a *Authenticator) LoadUsersFromMap(users esLookup,
+	cf types.CredentialsFormat) {
+	a.users = loaders.LoadMap(users.ToCredentialsManifest(), cf)
+}
+
+type esLookup map[string]ct.EnvString
+
+func (l esLookup) ToCredentialsManifest() types.CredentialsManifest {
+	out := make(types.CredentialsManifest, len(l))
+	for k, v := range l {
+		out[k] = string(v)
+	}
+	return out
+}

--- a/pkg/proxy/authenticator/providers/basic/basic_test.go
+++ b/pkg/proxy/authenticator/providers/basic/basic_test.go
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package basic
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"maps"
+
+	ct "github.com/trickstercache/trickster/v2/pkg/config/types"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const testUser1 = "testUser1"
+const testUser1p = "testUser1p"
+
+const testUser2 = "testUser2"
+const testUser2p = "testUser2p"
+
+const testUser3 = "testUser3"
+const testUser3p = "testUser3p"
+
+func bcryptHash(pass string) string {
+	h, _ := bcrypt.GenerateFromPassword([]byte(pass), bcrypt.DefaultCost)
+	return string(h)
+}
+
+func TestAddUserAndAuthenticate(t *testing.T) {
+	a := &Authenticator{}
+	user, pass := testUser1, testUser1p
+	if err := a.AddUser(user, pass, types.PlainText); err != nil {
+		t.Fatalf("AddUser: %v", err)
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.SetBasicAuth(user, pass)
+	ar, err := a.Authenticate(req)
+	if err != nil {
+		t.Error(err)
+	}
+	if ar == nil || ar.Username != user {
+		t.Errorf("expected %s got %s", user, ar.Username)
+	}
+
+	// Bad password
+	req.SetBasicAuth(user, "wrong")
+	_, err = a.Authenticate(req)
+	if err == nil {
+		t.Error("expected unauthorized error")
+	}
+
+	// Non-existent user
+	req.SetBasicAuth("invalid", "invalid")
+	_, err = a.Authenticate(req)
+	if err == nil {
+		t.Error("expected unauthorized error")
+	}
+
+	// No credentials
+	req = httptest.NewRequest("GET", "/", nil)
+	_, err = a.Authenticate(req)
+	if err == nil {
+		t.Error("expected unauthorized error")
+	}
+}
+
+func TestRemoveUser(t *testing.T) {
+	a := &Authenticator{}
+	a.AddUser(testUser1, testUser1p, types.PlainText)
+	a.RemoveUser(testUser1)
+	req := httptest.NewRequest("GET", "/", nil)
+	req.SetBasicAuth(testUser1, testUser1p)
+	_, err := a.Authenticate(req)
+	if err == nil {
+		t.Error("expected unauthorized error")
+	}
+}
+
+func TestAddUsersFromMapLoadUsersFromMap(t *testing.T) {
+	a := &Authenticator{}
+	users := map[string]ct.EnvString{
+		testUser1: testUser1p,
+		testUser2: testUser2p,
+	}
+	a.AddUsersFromMap(users, types.PlainText) // not encrypted
+
+	// Should authenticate both
+	for user, pass := range users {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.SetBasicAuth(user, string(pass))
+		_, err := a.Authenticate(req)
+		if err != nil {
+			t.Errorf("Authenticate failed for %s: %v", user, err)
+		}
+	}
+
+	// Now replace with LoadUsersFromMap and test
+	newUsers := map[string]ct.EnvString{
+		testUser3: testUser3p,
+	}
+	a.LoadUsersFromMap(newUsers, types.PlainText)
+	// Only linus should work
+	req := httptest.NewRequest("GET", "/", nil)
+	req.SetBasicAuth(testUser3, testUser3p)
+	_, err := a.Authenticate(req)
+	if err != nil {
+		t.Errorf("Authenticate linus after LoadUsersFromMap: %v", err)
+	}
+	req.SetBasicAuth(testUser1, testUser1p)
+	_, err = a.Authenticate(req)
+	if err == nil {
+		t.Error("Authenticate charlie after LoadUsersFromMap should fail")
+	}
+}
+
+func TestAddUsersFromMap_Encrypted(t *testing.T) {
+	a := &Authenticator{}
+	hash := bcryptHash(testUser1p)
+	users := map[string]ct.EnvString{
+		testUser1: ct.EnvString(hash),
+	}
+	a.AddUsersFromMap(users, types.BCrypt) // already encrypted
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.SetBasicAuth(testUser1, testUser1p)
+	_, err := a.Authenticate(req)
+	if err != nil {
+		t.Errorf("Authenticate schroeder with encrypted: %v", err)
+	}
+}
+
+func TestLoadUsersAndAddUsers_File(t *testing.T) {
+	tempDir := t.TempDir()
+
+	// Write a temp .htpasswd file
+	htpasswd1 := filepath.Join(tempDir, "htpasswd")
+	f, err := os.Create(htpasswd1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f.WriteString(fmt.Sprintf("%s:%s\n", testUser1, bcryptHash(testUser1p)))
+	f.Close()
+
+	a := &Authenticator{}
+	if err := a.LoadUsers(htpasswd1, types.HTPasswd, types.BCrypt, true); err != nil {
+		t.Fatal(err)
+	}
+	// testUser1 should work
+	req := httptest.NewRequest("GET", "/", nil)
+	req.SetBasicAuth(testUser1, testUser1p)
+	_, err = a.Authenticate(req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Add another user via AddUsers (merge)
+	htpasswd2 := filepath.Join(tempDir, "htpasswd2")
+	f2, err := os.Create(htpasswd2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = f2.WriteString(fmt.Sprintf("%s:%s\n", testUser2, bcryptHash(testUser2p)))
+	f2.Close()
+	if err := a.LoadUsers(htpasswd2, types.HTPasswd, types.BCrypt, false); err != nil {
+		t.Fatal(err)
+	}
+	req.SetBasicAuth(testUser2, testUser2p)
+	_, err = a.Authenticate(req)
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestAddUsers_MergeLogic(t *testing.T) {
+	a := &Authenticator{}
+	_ = a.AddUser(testUser1, testUser1p, types.PlainText)
+	// Simulate AddUsers merges and updates
+	users := map[string]string{
+		testUser1: bcryptHash("updated"), // should replace
+		testUser2: bcryptHash(testUser2p),
+	}
+	if a.users == nil {
+		a.users = make(map[string]string)
+	}
+	maps.Copy(a.users, users)
+	req := httptest.NewRequest("GET", "/", nil)
+	req.SetBasicAuth(testUser1, "updated")
+	_, err := a.Authenticate(req)
+	if err != nil {
+		t.Error(err)
+	}
+	// old password should fail
+	req.SetBasicAuth(testUser1, testUser1p)
+	_, err = a.Authenticate(req)
+	if err == nil {
+		t.Error("expected unauthorized error")
+	}
+	// user 2 patty should work
+	req.SetBasicAuth(testUser2, testUser2p)
+	_, err = a.Authenticate(req)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/pkg/proxy/authenticator/registry/registry.go
+++ b/pkg/proxy/authenticator/registry/registry.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package registry
+
+import (
+	"errors"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/providers/basic"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
+)
+
+var ErrUnsupportedAuthenticator = errors.New("unsupported authenticator")
+
+// this slice is the one and only place to aggregate all registered Authenticators
+var registry = []types.RegistryEntry{
+	basic.RegistryEntry(), // ID 0, BasicAuth
+}
+
+var registryByName = compileSupportedByName()
+
+func compileSupportedByName() map[types.Provider]types.NewAuthenticatorFunc {
+	out := make(map[types.Provider]types.NewAuthenticatorFunc, len(registry)*2)
+	for _, entry := range registry {
+		out[entry.Provider] = entry.New
+	}
+	return out
+}
+
+func New(name types.Provider, data map[string]any) (types.Authenticator, error) {
+	if f, ok := registryByName[name]; ok && f != nil {
+		return f(data)
+	}
+	return nil, ErrUnsupportedAuthenticator
+}
+
+func IsRegistered(name types.Provider) bool {
+	_, ok := registryByName[name]
+	return ok
+}

--- a/pkg/proxy/authenticator/types/auth_result.go
+++ b/pkg/proxy/authenticator/types/auth_result.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+type AuthResult struct {
+	Status          AuthResultStatus
+	StatusDetail    string
+	Username        string
+	ResponseHeaders map[string]string
+	// Claims, etc. would go here in the future as needed
+}
+
+type AuthResultStatus int
+
+const (
+	AuthUnknown AuthResultStatus = iota
+	AuthSuccess
+	AuthFailed
+	AuthMissing
+)

--- a/pkg/proxy/authenticator/types/creds_format.go
+++ b/pkg/proxy/authenticator/types/creds_format.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+// CredentialsFormat is a defined type for the format of the handled credentials
+type CredentialsFormat string
+
+const (
+	Unknown   CredentialsFormat = "unknown"
+	PlainText CredentialsFormat = "plaintext"
+	BCrypt    CredentialsFormat = "bcrypt"
+
+	DefaultCredentialsMapFormat = PlainText
+)
+
+func IsValidCredentialsMapFormat(f CredentialsFormat) bool {
+	return f == PlainText || f == BCrypt
+}

--- a/pkg/proxy/authenticator/types/file_format.go
+++ b/pkg/proxy/authenticator/types/file_format.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+// CredentialsFileFormat is a defined type for format of the credentials file
+type CredentialsFileFormat string
+
+const (
+	HTPasswd    CredentialsFileFormat = "htpasswd"
+	CSV         CredentialsFileFormat = "csv"
+	CSVNoHeader CredentialsFileFormat = "csvNoHeader"
+)
+
+func IsValidCredentialsFileFormat(f CredentialsFileFormat) bool {
+	return f == HTPasswd || f == CSV || f == CSVNoHeader
+}

--- a/pkg/proxy/authenticator/types/types.go
+++ b/pkg/proxy/authenticator/types/types.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package types
+
+import (
+	"net/http"
+)
+
+// Authenticator represents a specific auth implementation (e.g., Basic Auth)
+type Authenticator interface {
+	// Authenticate performs authentication against the provided request
+	Authenticate(*http.Request) (*AuthResult, error)
+	// ExtractCredentials returns the username, credentials and format (as
+	// applicable) from the request.
+	ExtractCredentials(*http.Request) (string, string, CredentialsFormat, error)
+	// SetExtractCredentialsFunc allows the Authenticator to use a custom (e.g,
+	// Backend-provider-specific) Credentials Extractor in lieu of the
+	// Authenticator implementation's built-in Extractor.
+	SetExtractCredentialsFunc(ExtractCredsFunc)
+	// LoadUsers loads the provided users into the Authenticator. If the bool is
+	// true, the existing list will be replaced, otherwise appended.
+	LoadUsers(string, CredentialsFileFormat, CredentialsFormat, bool) error
+	// AddUser adds the provided user to the Authenticator's users list
+	AddUser(string, string, CredentialsFormat) error
+	// RemoveUser removes the provided user from the Authenticator's users list
+	RemoveUser(string)
+	// Clone returns a new / independent duplicate of the Authenticator
+	Clone() Authenticator
+	// ProxyPreserve is true when the Authenticator will not strip Auth headers
+	ProxyPreserve() bool
+	// Sanitize must strip Auth headers from r only when ProxyPreserve is true
+	Sanitize(*http.Request)
+}
+
+type Lookup map[string]Authenticator
+
+// Provider is a defined type for the Authenticator Provider's name
+type Provider string
+
+type ExtractCredsFunc func(*http.Request) (string, string, CredentialsFormat, error)
+
+// NewAuthenticatorFunc defines a function that returns a new Authenticator
+type NewAuthenticatorFunc func(map[string]any) (Authenticator, error)
+
+// RegistryEntry defines an entry in the ALB Registry
+type RegistryEntry struct {
+	Provider Provider
+	New      NewAuthenticatorFunc
+}
+
+type IsRegisteredFunc func(Provider) bool
+
+type CredentialsManifest map[string]string

--- a/pkg/proxy/handlers/trickster/unauthorized/unauthorized.go
+++ b/pkg/proxy/handlers/trickster/unauthorized/unauthorized.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unauthorized
+
+import (
+	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+)
+
+// ServeHTTP responds to an HTTP Request with a 401 Unauthorized
+func ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
+	w.WriteHeader(http.StatusUnauthorized)
+	w.Write([]byte("Unauthorized"))
+}

--- a/pkg/proxy/request/resources.go
+++ b/pkg/proxy/request/resources.go
@@ -26,6 +26,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
+	auth "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
 	tctx "github.com/trickstercache/trickster/v2/pkg/proxy/context"
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
@@ -53,6 +54,7 @@ type Resources struct {
 	TS                timeseries.Timeseries
 	TSReqestOptions   *timeseries.RequestOptions
 	Response          *http.Response
+	AuthResult        *auth.AuthResult
 }
 
 // Clone returns an exact copy of the subject Resources collection
@@ -75,6 +77,7 @@ func (r *Resources) Clone() *Resources {
 		TSTransformer:     r.TSTransformer,
 		TS:                r.TS,
 		TSReqestOptions:   r.TSReqestOptions,
+		AuthResult:        r.AuthResult, // shallow copy of the auth result
 	}
 }
 
@@ -126,4 +129,5 @@ func (r *Resources) Merge(r2 *Resources) {
 	r.AlternateCacheTTL = r2.AlternateCacheTTL
 	r.TimeRangeQuery = r2.TimeRangeQuery
 	r.Tracer = r2.Tracer
+	r.AuthResult = r2.AuthResult
 }

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -35,6 +35,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/handler"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/health"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
@@ -222,6 +223,13 @@ func RegisterPathRoutes(r router.Router, handlers handlers.Lookup,
 		if tr != nil {
 			h = middleware.Trace(tr, h)
 		}
+		// attach authenticator
+		if po1.AuthOptions != nil && po1.AuthOptions.Authenticator != nil {
+			h = handler.Middleware(po1.AuthOptions.Authenticator, (h))
+		} else if po1.AuthenticatorName != "none" && o.AuthOptions != nil &&
+			o.AuthOptions.Authenticator != nil {
+			h = handler.Middleware(o.AuthOptions.Authenticator, (h))
+		}
 		// attach compression handler
 		h = encoding.HandleCompression(h, o.CompressibleTypes)
 		// add Backend, Cache, and Path Configs to the HTTP Request's context
@@ -315,6 +323,13 @@ func RegisterDefaultBackendRoutes(r router.Router, bknds backends.Backends,
 		// attach distributed tracer
 		if tr != nil {
 			h = middleware.Trace(tr, h)
+		}
+		// attach authenticator
+		if po.AuthOptions != nil && po.AuthOptions.Authenticator != nil {
+			h = handler.Middleware(po.AuthOptions.Authenticator, (h))
+		} else if po.AuthenticatorName != "none" && o.AuthOptions != nil &&
+			o.AuthOptions.Authenticator != nil {
+			h = handler.Middleware(o.AuthOptions.Authenticator, (h))
 		}
 		// add Backend, Cache, and Path Configs to the HTTP Request's context
 		h = middleware.WithResourcesContext(client, o, c, po, tr, h)

--- a/pkg/util/files/files.go
+++ b/pkg/util/files/files.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package files
+
+import "os"
+
+// FileExistsAndReadable returns true if the provided filename can be opened for
+// reading by the Trickster process.
+func FileExistsAndReadable(filename string) bool {
+	f, err := os.Open(filename)
+	if err != nil {
+		return false
+	}
+	f.Close()
+	return true
+}


### PR DESCRIPTION
This PR adds an `Authenticator` capability to Trickster that allows any Backend to be protected with an Authentication wall. It initially supports Basic Auth. User Pool data can be loaded from an `htpasswd`-formatted file, a csv, or embedded directly into the Trickster config yaml. Embedded user manifests support env injection.