### PR TITLE
fix: [backend/rules] rmatch is operation not input type

### DIFF
--- a/pkg/backends/rule/parse.go
+++ b/pkg/backends/rule/parse.go
@@ -148,7 +148,7 @@ func (c *Client) parseOptions(o *ro.Options, rwi rewriter.InstructionsLookup) er
 		r.evaluatorFunc = r.EvaluateOpArg
 	}
 
-	if o.InputType == "rmatch" {
+	if o.Operation == "rmatch" {
 		if r.operationArg == "" {
 			return ErrInvalidRegularExpression
 		}


### PR DESCRIPTION
This resolves #677, which points out what looks to be a bug in the rules option parsing code.

`rmatch` is not an `InputType`, it is an `Operation`.

This is causing a panic and needs investigating.