### PR TITLE
wip: convert the time series extent list to a generic implementation

### DIFF
--- a/pkg/proxy/ranges/ranges.go
+++ b/pkg/proxy/ranges/ranges.go
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ranges
+
+import (
+	"strings"
+	"time"
+)
+
+type Datumv2[d Datum, i Interval] interface {
+	Add(i) d
+	Sub(d) i
+}
+
+type Int64datumn int64
+
+func (i Int64datumn) Add(d int64) Int64datumn {
+	return Int64datumn(int64(i) + int64(d))
+}
+
+func (i Int64datumn) Sub(o Int64datumn) int64 {
+	return int64(i) - int64(o)
+}
+
+/// ^^^ wip
+
+type Interval interface {
+	time.Duration | int64
+}
+
+type Datum interface {
+	Int64datumn | time.Time | int64
+}
+
+type Extent[d Datum] interface {
+	// Includes returns true if the Extent includes the provided Time
+	Includes(d) bool
+	// After returns true if the range of the Extent is completely after the provided time
+	After(d) bool
+	// Before returns true if the range of the Extent is completely before the provided time
+	Before(d) bool
+
+	// Crop returns a new Extent with the provided start and end times
+	Crop(d, d) Extent[d]
+
+	// StartIndex returns the start time of the Extent
+	StartIndex() d
+	// StartsAt returns true if t is equal to the Extent's start time
+	StartsAt(d) bool
+	// StartsAfter returns true if t is after the Extent's start time
+	StartsAfter(d) bool
+	// StartsBefore returns true if t is before the Extent's start time
+	StartsBefore(d) bool
+	// StartsAtOrBefore returns true if t is equal or before to the Extent's start time
+	StartsAtOrBefore(d) bool
+	// StartsAtOrAfter returns true if t is equal to or after the Extent's start time
+	StartsAtOrAfter(d) bool
+
+	// EndIndex returns the end time of the Extent
+	EndIndex() d
+	// EndsAt returns true if t is equal to the Extent's end time
+	EndsAt(d) bool
+	// EndsAfter returns true if t is after the Extent's end time
+	EndsAfter(d) bool
+	// EndsBefore returns true if t is before the Extent's end time
+	EndsBefore(d) bool
+	// EndsAtOrBefore returns true if t is equal to or earlier than the Extent's end time
+	EndsAtOrBefore(d) bool
+	// EndsAtOrAfter returns true if t is equal to or after the Extent's end time
+	EndsAtOrAfter(d) bool
+
+	// String returns the string representation of the Extent
+	String() string
+}
+
+type ExtentList[d Datum] []Extent[d]
+
+func (el ExtentList[d]) String() string {
+	if len(el) == 0 {
+		return ""
+	}
+	lines := make([]string, len(el))
+	for i, e := range el {
+		lines[i] = e.String()
+	}
+	return strings.Join(lines, ",")
+}
+
+// Encompasses returns true if the provided extent is contained
+// completely within boundaries of the subject ExtentList
+func (el ExtentList[d]) Encompasses(e Extent[d]) bool {
+	x := len(el)
+	if x == 0 {
+		return false
+	}
+	return el[0].StartsAtOrBefore(e.StartIndex()) && el[x-1].EndsAtOrAfter(e.EndIndex())
+}
+
+// EncompassedBy returns true if the provided extent completely
+// surrounds the boundaries of the subject ExtentList
+func (el ExtentList[d]) EncompassedBy(e Extent[d]) bool {
+	x := len(el)
+	if x == 0 {
+		return false
+	}
+	return e.StartsAtOrBefore(el[0].StartIndex()) && e.EndsAtOrAfter(el[x-1].EndIndex())
+}
+
+// OutsideOf returns true if the provided extent falls completely
+// outside of the boundaries of the subject extent list
+func (el ExtentList[d]) OutsideOf(e Extent[d]) bool {
+	x := len(el)
+	if x == 0 {
+		return true
+	}
+	return e.After(el[x-1].EndIndex()) || el[0].After(e.EndIndex())
+}
+
+// Crop reduces the ExtentList to the boundaries defined by the provided Extent
+func (el ExtentList[d]) Crop(ex Extent[d]) ExtentList[d] {
+	if len(el) == 0 {
+		return ExtentList[d]{}
+	}
+	out := make(ExtentList[d], len(el))
+	var k int
+	for _, e := range el {
+		if e.Before(ex.StartIndex()) || e.After(ex.EndIndex()) {
+			continue
+		}
+		start := e.StartIndex()
+		end := e.EndIndex()
+		if ex.StartsAfter(start) && ex.StartsBefore(end) {
+			start = ex.StartIndex()
+		} else if ex.StartsAt(end) {
+			start = ex.StartIndex()
+			end = ex.StartIndex()
+		}
+		if ex.Before(end) && ex.EndsAfter(start) {
+			end = ex.EndIndex()
+		} else if ex.EndsAt(start) {
+			start = ex.EndIndex()
+			end = ex.EndIndex()
+		}
+		out[k] = e.Crop(start, end) // FIXME: last used not set / exposed
+		k++
+	}
+	return out[:k]
+}
+
+// Clone returns a true copy of the ExtentList
+func (el ExtentList[d]) Clone() ExtentList[d] {
+	out := make(ExtentList[d], len(el))
+	// this is safe because all fields in an Extent are by value
+	copy(out, el)
+	return out
+}
+
+// Merge returns an Extentlist of el2 appended to el, sorted, and compressed
+func (el ExtentList[d]) Merge(el2 ExtentList[d]) ExtentList[d] {
+	if len(el2) == 0 {
+		return el.Clone()
+	}
+	if len(el) == 0 {
+		return el2.Clone()
+	}
+	out := make(ExtentList[d], len(el)+len(el2))
+	copy(out, el)
+	copy(out[len(el):], el2)
+
+	// slices.Sort(out)
+	// return out.Compress(step)
+	return out
+}

--- a/pkg/proxy/ranges/ranges_test.go
+++ b/pkg/proxy/ranges/ranges_test.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ranges_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/ranges"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+)
+
+func TestExtent(t *testing.T) {
+	var e ranges.Extent[time.Time]
+	e = timeseries.Extent{Start: time.Unix(100, 0), End: time.Unix(1000, 0)}
+	require.True(t, e.StartsAt(time.Unix(100, 0)))
+
+	t.Run("Extentlist", func(t *testing.T) {
+		list := ranges.ExtentList[time.Time]{e}
+		require.True(t, list.Encompasses(e))
+	})
+
+	// v2 wip
+	var d ranges.Datumv2[time.Time, time.Duration]
+	d = time.Time{}
+	d = d.Add(time.Second)
+	d = d.Add(time.Second)
+	require.Equal(t, time.Time{}.Add(2*time.Second), d)
+
+	var d2 ranges.Datumv2[ranges.Int64datumn, int64]
+	d2 = ranges.Int64datumn(0)
+	d2 = d2.Add(1)
+	d2 = d2.Add(1)
+}

--- a/pkg/timeseries/extent.go
+++ b/pkg/timeseries/extent.go
@@ -21,6 +21,8 @@ package timeseries
 import (
 	"fmt"
 	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/ranges"
 )
 
 // Extent describes the start and end times for a given range of data
@@ -30,44 +32,93 @@ type Extent struct {
 	LastUsed time.Time `msg:"lu" json:"-"`
 }
 
+// Crop returns a new Extent with the provided start and end times
+func (e Extent) Crop(start, end time.Time) ranges.Extent[time.Time] {
+	e.Start = start
+	e.End = end
+	return e
+}
+
+// ContainsE returns true if the Extent contains the provided Extent (e2 is a subset of e)
+func (e Extent) ContainsE(e2 Extent) bool {
+	return e.StartsAtOrBefore(e2.StartIndex()) && e.EndsAtOrAfter(e2.EndIndex())
+}
+
+// StartIndex returns the start time of the Extent
+func (e Extent) StartIndex() time.Time {
+	return e.Start
+}
+
+// EndIndex returns the end time of the Extent
+func (e Extent) EndIndex() time.Time {
+	return e.End
+}
+
 // Includes returns true if the Extent includes the provided Time
-func (e *Extent) Includes(t time.Time) bool {
+func (e Extent) Includes(t time.Time) bool {
 	return !t.Before(e.Start) && !t.After(e.End)
 }
 
 // StartsAt returns true if t is equal to the Extent's start time
-func (e *Extent) StartsAt(t time.Time) bool {
+func (e Extent) StartsAt(t time.Time) bool {
 	return t.Equal(e.Start)
 }
 
+// StartsBefore returns true if t is before the Extent's start time
+func (e Extent) StartsBefore(t time.Time) bool {
+	return e.Start.Before(t)
+}
+
+// StartsAfter returns true if t is after the Extent's start time
+func (e Extent) StartsAfter(t time.Time) bool {
+	return e.Start.After(t)
+}
+
 // StartsAtOrBefore returns true if t is equal or before to the Extent's start time
-func (e *Extent) StartsAtOrBefore(t time.Time) bool {
+func (e Extent) StartsAtOrBefore(t time.Time) bool {
 	return t.Equal(e.Start) || e.Start.Before(t)
 }
 
 // StartsAtOrAfter returns true if t is equal to or after the Extent's start time
-func (e *Extent) StartsAtOrAfter(t time.Time) bool {
+func (e Extent) StartsAtOrAfter(t time.Time) bool {
 	return t.Equal(e.Start) || e.Start.After(t)
 }
 
 // EndsAt returns true if t is equal to the Extent's end time
-func (e *Extent) EndsAt(t time.Time) bool {
+func (e Extent) EndsAt(t time.Time) bool {
 	return t.Equal(e.End)
 }
 
 // EndsAtOrBefore returns true if t is equal to or earlier than the Extent's end time
-func (e *Extent) EndsAtOrBefore(t time.Time) bool {
+func (e Extent) EndsAtOrBefore(t time.Time) bool {
 	return t.Equal(e.End) || e.End.Before(t)
 }
 
 // EndsAtOrAfter returns true if t is equal to or after the Extent's end time
-func (e *Extent) EndsAtOrAfter(t time.Time) bool {
+func (e Extent) EndsAtOrAfter(t time.Time) bool {
 	return t.Equal(e.End) || e.End.After(t)
 }
 
+// FIXME: deprecate in favor of StartsAfter
 // After returns true if the range of the Extent is completely after the provided time
-func (e *Extent) After(t time.Time) bool {
-	return t.Before(e.Start)
+func (e Extent) After(t time.Time) bool {
+	return e.Start.After(t)
+}
+
+// FIXME: deprecate in favor of EndsBefore
+// Before returns true if the range of the Extent is completely before the provided time
+func (e Extent) Before(t time.Time) bool {
+	return e.End.Before(t)
+}
+
+// EndsBefore returns true if the Extent's end time is before the provided time
+func (e Extent) EndsBefore(t time.Time) bool {
+	return e.End.Before(t)
+}
+
+// EndsAfter returns true if the Extent's end time is after the provided time
+func (e Extent) EndsAfter(t time.Time) bool {
+	return e.End.After(t)
 }
 
 // String returns the string representation of the Extent

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -48,8 +48,7 @@ func (el ExtentList) Encompasses(e Extent) bool {
 	if x == 0 {
 		return false
 	}
-	return (!e.Start.Before(el[0].Start)) &&
-		(!e.End.After(el[x-1].End))
+	return el[0].StartsAtOrBefore(e.StartIndex()) && el[x-1].EndsAtOrAfter(e.EndIndex())
 }
 
 // EncompassedBy returns true if the provided extent completely
@@ -59,8 +58,8 @@ func (el ExtentList) EncompassedBy(e Extent) bool {
 	if x == 0 {
 		return false
 	}
-	return (!el[0].Start.Before(e.Start)) &&
-		(!el[x-1].End.After(e.End))
+
+	return e.StartsAtOrBefore(el[0].StartIndex()) && e.EndsAtOrAfter(el[x-1].EndIndex())
 }
 
 // OutsideOf returns true if the provided extent falls completely
@@ -70,7 +69,7 @@ func (el ExtentList) OutsideOf(e Extent) bool {
 	if x == 0 {
 		return true
 	}
-	return e.After(el[x-1].End) || el[0].After(e.End)
+	return e.After(el[x-1].EndIndex()) || el[0].After(e.EndIndex())
 }
 
 // Crop reduces the ExtentList to the boundaries defined by the provided Extent
@@ -81,22 +80,22 @@ func (el ExtentList) Crop(ex Extent) ExtentList {
 	out := make(ExtentList, len(el))
 	var k int
 	for _, e := range el {
-		if e.End.Before(ex.Start) || e.Start.After(ex.End) {
+		if e.Before(ex.StartIndex()) || e.After(ex.EndIndex()) {
 			continue
 		}
-		start := e.Start
-		end := e.End
-		if ex.Start.After(start) && ex.Start.Before(end) {
-			start = ex.Start
-		} else if ex.Start.Equal(end) {
-			start = ex.Start
-			end = ex.Start
+		start := e.StartIndex()
+		end := e.EndIndex()
+		if ex.StartsAfter(start) && ex.StartsBefore(end) {
+			start = ex.StartIndex()
+		} else if ex.StartsAt(end) {
+			start = ex.StartIndex()
+			end = ex.StartIndex()
 		}
-		if ex.End.Before(end) && ex.End.After(start) {
-			end = ex.End
-		} else if ex.End.Equal(start) {
-			start = ex.End
-			end = ex.End
+		if ex.Before(end) && ex.EndsAfter(start) {
+			end = ex.EndIndex()
+		} else if ex.EndsAt(start) {
+			start = ex.EndIndex()
+			end = ex.EndIndex()
 		}
 		out[k] = Extent{Start: start, End: end, LastUsed: e.LastUsed}
 		k++


### PR DESCRIPTION
- [x] POC extent list conversion
  - should support: time.Time, int64 or arbitrary types  
- [ ] "in-place" rewrite of the existing extent_list code
  - [ ] avoid field access in favor of functions
  - [ ] add necessary helper functions to extent type
- [ ] convert refactored extent list to generic
  -  TBD on whether I'll save the byterange conversion to another PR

---

```go
        // working
	var e ranges.Extent[time.Time]
	e = timeseries.Extent{Start: time.Unix(100, 0), End: time.Unix(1000, 0)}
	require.True(t, e.StartsAt(time.Unix(100, 0)))
	list := ranges.ExtentList[time.Time]{e}
...
        // goal -- support the byterange.Range type
	var e2 ranges.Extent[int64]
	e = byterange.Range{Start:5, End: 5}
	require.True(t, e.StartsAt(5))
```