### PR TITLE
fix: omit index load warning for memory client

### DIFF
--- a/pkg/cache/index/client.go
+++ b/pkg/cache/index/client.go
@@ -53,7 +53,6 @@ type IndexedClientOptions struct {
 
 func NewIndexedClient(
 	cacheName, cacheProvider string,
-	_ []byte,
 	o *options.Options,
 	client cache.Client,
 	opts ...func(*IndexedClientOptions),

--- a/pkg/cache/index/client.go
+++ b/pkg/cache/index/client.go
@@ -75,7 +75,7 @@ func NewIndexedClient(
 	if options.NeedsFlushInterval || o.FlushInterval > 0 {
 		// check to see if an index was cached already from a previous run
 		b, s, err := client.Retrieve(IndexKey)
-		if err != nil {
+		if err != nil && options.NeedsFlushInterval {
 			logger.Warn("cache index was not loaded",
 				logging.Pairs{"cacheName": cacheName, "error": err.Error()})
 		} else if len(b) > 0 && s == status.LookupStatusHit {
@@ -88,7 +88,7 @@ func NewIndexedClient(
 		}
 		if o.FlushInterval > 0 {
 			go idx.flusher(ctx)
-		} else {
+		} else if options.NeedsFlushInterval {
 			logger.Warn("cache index flusher was not started, recommended for provider",
 				logging.Pairs{"cacheName": idx.name, "cacheProvider": idx.cacheProvider, "flushInterval": o.FlushInterval})
 		}

--- a/pkg/cache/index/client_test.go
+++ b/pkg/cache/index/client_test.go
@@ -39,7 +39,7 @@ func TestIndexedClient(t *testing.T) {
 
 	t.Run("basic", func(t *testing.T) {
 		// init indexed client
-		ic := NewIndexedClient("test", provider, []byte{}, &options.Options{
+		ic := NewIndexedClient("test", provider, &options.Options{
 			ReapInterval:          time.Second * time.Duration(10),
 			FlushInterval:         time.Second * time.Duration(10),
 			MaxSizeObjects:        5,
@@ -95,7 +95,7 @@ func TestIndexedClient(t *testing.T) {
 	t.Run("atime", func(t *testing.T) {
 
 		// init indexed client
-		ic := NewIndexedClient("test", provider, []byte{}, &options.Options{
+		ic := NewIndexedClient("test", provider, &options.Options{
 			ReapInterval:          time.Second * time.Duration(10),
 			FlushInterval:         time.Second * time.Duration(10),
 			MaxSizeObjects:        5,
@@ -137,7 +137,7 @@ func TestIndexedClient(t *testing.T) {
 			},
 		}
 		fs := filesystem.NewCache("test", &cacheConfig)
-		ic := NewIndexedClient("test", provider, []byte{}, &options.Options{
+		ic := NewIndexedClient("test", provider, &options.Options{
 			ReapInterval:          time.Second * time.Duration(10),
 			FlushInterval:         time.Second * time.Duration(10),
 			MaxSizeObjects:        5,
@@ -169,7 +169,7 @@ func TestIndexedClient(t *testing.T) {
 		ic.Close()
 
 		// start a new cache, verify it reuses the index
-		ic = NewIndexedClient("test", provider, []byte{}, &options.Options{
+		ic = NewIndexedClient("test", provider, &options.Options{
 			ReapInterval:          time.Second * time.Duration(10),
 			FlushInterval:         time.Second * time.Duration(10),
 			MaxSizeObjects:        5,
@@ -200,7 +200,7 @@ func TestIndexedClient(t *testing.T) {
 
 	/* converting */
 	// init indexed client
-	ic := NewIndexedClient("test", provider, []byte{}, &options.Options{
+	ic := NewIndexedClient("test", provider, &options.Options{
 		ReapInterval:          time.Second * time.Duration(10),
 		FlushInterval:         time.Second * time.Duration(10),
 		MaxSizeObjects:        5,

--- a/pkg/cache/manager/manager.go
+++ b/pkg/cache/manager/manager.go
@@ -137,7 +137,6 @@ func (cm *Manager) Connect() error {
 		cm.Client = index.NewIndexedClient(
 			cm.config.Name,
 			cm.config.Provider,
-			nil,
 			cm.config.Index,
 			cm.originalCli,
 			func(ico *index.IndexedClientOptions) {


### PR DESCRIPTION
- drop unused param
- omit log warning on index cache missing for memory client