### PR TITLE
fix: inject application version into dockerfile

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -75,6 +75,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             GIT_LATEST_COMMIT_ID=${{ github.sha }}
+            TAG_VER=${{ github.ref_name }}
           tags: ${{ steps.meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk update && apk add ca-certificates
 ARG BUILDPLATFORM=linux/amd64
 FROM --platform=${BUILDPLATFORM} golang:1.24 as builder
 ARG GIT_LATEST_COMMIT_ID
+ARG TAGVER
 
 COPY . /go/src/github.com/trickstercache/trickster
 WORKDIR /go/src/github.com/trickstercache/trickster

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ docker:
 		--build-arg GIT_LATEST_COMMIT_ID=$(GIT_LATEST_COMMIT_ID) \
 		--target $(DOCKER_TARGET) \
 		--build-arg GOARCH=$(GOARCH) \
+		--build-arg TAGVER=$(TAGVER) \
 		-f ./Dockerfile \
 		-t trickster:$(TAGVER) \
 		--platform linux/$(IMAGE_ARCH) \


### PR DESCRIPTION
The Dockerfile doesn't include the `.git` directory, so inject the tag version while building:
```
TAGVER=va.b.c make docker
 docker run ...:va.b.c
...
time=2025-05-29T23:20:28.00332067Z app=trickster level=info event="application loaded from configuration" buildTime=2025-05-29T23:18:55+0000 commitID=9ddfa17cf6d5356a500f43682800218420fe5c7b config=/etc/trickster/trickster.yaml goArch=arm64 goOS=linux goVersion=go1.24.2 logLevel=INFO name=trickster pid=1 version=va.b.c
```