### PR TITLE
ALB and Timeseries Patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -323,4 +323,4 @@ developer-seed-data:
 
 .PHONY: serve-dev
 serve-dev:
-	@go run cmd/trickster/main.go -config docs/developer/environment/trickster-config/trickster.yaml
+	@go run cmd/trickster/main.go -config $(if $(TRK_CONFIG),$(TRK_CONFIG),docs/developer/environment/trickster-config/trickster.yaml)

--- a/Makefile
+++ b/Makefile
@@ -305,6 +305,10 @@ get-msgpack:
 developer-start:
 	@cd docs/developer/environment && docker compose up -d
 	
+.PHONY: developer-stop
+developer-stop:
+	@cd docs/developer/environment && docker compose stop
+
 .PHONY: developer-delete
 developer-delete:
 	@cd docs/developer/environment && docker compose down

--- a/docs/developer/environment/README.md
+++ b/docs/developer/environment/README.md
@@ -28,5 +28,6 @@ you can test out Trickster acceleration features. You can change the Data Source
 selector to go between various Trickster configs, or bypass Trickster altogether
 for verification purposes.
 
-You can stop the developer environment by running `make developer-delete`.
-This will run `docker compose down` which will destroy all data.
+You can stop the developer environment by running `make developer-stop`. To
+delete the developer environment, run `make developer-stop` which will destroy
+all data.

--- a/docs/developer/environment/README.md
+++ b/docs/developer/environment/README.md
@@ -29,5 +29,5 @@ selector to go between various Trickster configs, or bypass Trickster altogether
 for verification purposes.
 
 You can stop the developer environment by running `make developer-stop`. To
-delete the developer environment, run `make developer-stop` which will destroy
+delete the developer environment, run `make developer-delete` which will destroy
 all data.

--- a/docs/developer/environment/docker-compose.yml
+++ b/docs/developer/environment/docker-compose.yml
@@ -143,6 +143,7 @@ services:
 
   telegraf:
     image: telegraf:1.34-alpine
+    restart: always
     volumes:
       - ./docker-compose-data/telegraf-config/telegraf.conf:/etc/telegraf/telegraf.conf
     depends_on:

--- a/pkg/backends/influxdb/flux/marshal_csv.go
+++ b/pkg/backends/influxdb/flux/marshal_csv.go
@@ -128,6 +128,9 @@ func printCsvHeaderRow(w *csv.Writer, fds timeseries.FieldDefinitions) error {
 }
 
 func processSeriesHeader(st *state) {
+	if st == nil || st.s == nil {
+		return
+	}
 	st.fds = st.s.Header.FieldDefinitions()
 	if st.prev == nil { // TODO: also if schema has changed between s and prev
 		if st.t {

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -182,7 +182,7 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 			}
 			// Wait on queries
 			wg.Wait()
-			d.timeseries = ress.Merge()
+			d.timeseries = ress.Merge(true)
 			if d.timeseries != nil {
 				d.timeseries.SetExtents(d.timeseries.Extents().Compress(trq.Step))
 			}

--- a/pkg/proxy/response/merge/timeseries.go
+++ b/pkg/proxy/response/merge/timeseries.go
@@ -30,7 +30,6 @@ import (
 // and writes it to the provided responsewriter
 func Timeseries(w http.ResponseWriter, r *http.Request, rgs ResponseGates) {
 
-	var ts timeseries.Timeseries
 	var f timeseries.MarshalWriterFunc
 	var rlo *timeseries.RequestOptions
 
@@ -58,10 +57,6 @@ func Timeseries(w http.ResponseWriter, r *http.Request, rgs ResponseGates) {
 			if rlo == nil {
 				rlo = rg.Resources.TSReqestOptions
 			}
-			if ts == nil {
-				ts = rg.Resources.TS
-				continue
-			}
 			tsm[k] = rg.Resources.TS
 			k++
 		}
@@ -71,7 +66,7 @@ func Timeseries(w http.ResponseWriter, r *http.Request, rgs ResponseGates) {
 		}
 	}
 
-	if ts == nil || f == nil {
+	if k == 0 || f == nil {
 		if bestResp != nil {
 			h := w.Header()
 			headers.Merge(h, bestResp.Header)
@@ -88,10 +83,6 @@ func Timeseries(w http.ResponseWriter, r *http.Request, rgs ResponseGates) {
 		statusCode = bestResp.StatusCode
 	}
 
-	if k > 0 {
-		ts.Merge(true, tsm[:k]...)
-	}
-
 	headers.StripMergeHeaders(h)
-	f(ts, rlo, statusCode, w)
+	f(tsm.Merge(false), rlo, statusCode, w)
 }

--- a/pkg/timeseries/dataset/series_header.go
+++ b/pkg/timeseries/dataset/series_header.go
@@ -91,7 +91,6 @@ func (sh *SeriesHeader) Clone() SeriesHeader {
 		TimestampField:      sh.TimestampField,
 		QueryStatement:      sh.QueryStatement,
 		Size:                sh.Size,
-		hash:                sh.hash,
 	}
 	copy(clone.ValueFieldsList, sh.ValueFieldsList)
 	copy(clone.TagFieldsList, sh.TagFieldsList)

--- a/pkg/timeseries/dataset/series_list.go
+++ b/pkg/timeseries/dataset/series_list.go
@@ -50,7 +50,7 @@ func (sl SeriesList) Merge(sl2 SeriesList, sortPoints bool) SeriesList {
 		if s == nil {
 			continue
 		}
-		h := s.Header.CalculateHash()
+		h := s.Header.CalculateHash(true)
 		if _, ok := m[h]; ok {
 			continue
 		}
@@ -64,7 +64,7 @@ func (sl SeriesList) Merge(sl2 SeriesList, sortPoints bool) SeriesList {
 		if s == nil {
 			continue
 		}
-		h := s.Header.CalculateHash()
+		h := s.Header.CalculateHash(true)
 		if seen.Contains(h) {
 			continue
 		}

--- a/pkg/timeseries/timeseries.go
+++ b/pkg/timeseries/timeseries.go
@@ -101,15 +101,19 @@ func (t List) Compress() List {
 }
 
 // Merge combines all Timesseries in t into a single Timeseries
-func (t List) Merge() Timeseries {
+func (t List) Merge(useClone bool) Timeseries {
 	cts := t.Compress()
 	if len(cts) == 0 {
 		return nil
 	}
-	if len(cts) == 1 {
-		return cts[0]
+	var out Timeseries
+	if useClone {
+		out = cts[0].Clone()
+	} else {
+		out = cts[0]
 	}
-	out := cts[0].Clone()
-	out.Merge(true, cts[1:]...)
+	if len(cts) > 1 {
+		out.Merge(true, cts[1:]...)
+	}
 	return out
 }


### PR DESCRIPTION
This fixes a few defects affecting the ALB Timeseries Merge mechanism, and  makes a few adjustments to the Developer Environment to help with general testing.

* Adds a `developer-stop` Makefile action that will stop the docker compose without destroying it
* Allows the `serve-dev` action to read a `TRK_CONFIG` environment variable to load an alternate config file (e.g., one crafted for specific test cases)
* Adds `restart: always` to containers in the Dev Env that needed it
* Fixes #845 by skipping over nil series when present
* Fixes #844 by ensuring that Series Header Hashes are recalculated before merging, in case they were altered since the hash was last calculated.
* unDRY merging a slice of Timeseries by consolidating into timeseries.List.Merge() everywhere.
