### PR TITLE
ci: add extra detail to release notes & document process

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -57,7 +57,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          REPO=${{ github.repository}} TAG=v${{ steps.baretag.outputs.baretag }} envsubst < ./hack/release-notes/notes.md > /tmp/notes.md
+          REPO=${{ github.repository}} TAG=${{ steps.baretag.outputs.baretag }} envsubst < ./hack/release-notes/notes.md > /tmp/notes.md
           gh release create ${{ github.ref_name }} \
             --generate-notes \
             --notes-file /tmp/notes.md \

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -57,8 +57,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          REPO=${{ github.repository}} TAG=v${{ steps.baretag.outputs.baretag }} envsubst < ./hack/release-notes/notes.md > /tmp/notes.md
           gh release create ${{ github.ref_name }} \
             --generate-notes \
+            --notes-file /tmp/notes.md \
             --title "Release v${{ steps.baretag.outputs.baretag }} / ${{ steps.date.outputs.date }}" \
             --draft=${{ env.draft }} \
             --prerelease=${{ env.prerelease }} \

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.dll
 *.so
 *.dylib
+sha256sum.txt
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+-include ci.mk release.mk
+
 DEFAULT: build
 
 PROJECT_DIR    := $(shell pwd)
@@ -65,37 +67,6 @@ rpm: build
 .PHONY: install
 install:
 	$(GO) install -o $(TRICKSTER) $(TAGVER)
-
-.PHONY: release
-release: clean go-mod-tidy go-mod-vendor release-artifacts release-sha256
-
-# generate sha256sum for all release artifacts
-RELEASE_CHECKSUM_FILE=$(BUILD_SUBDIR)/sha256sum.txt
-.PHONY: release-sha256
-release-sha256:
-	./hack/release-sha256.sh $(RELEASE_CHECKSUM_FILE) $(BUILD_SUBDIR) $(TAGVER) $(BIN_DIR)
-
-.PHONY: release-artifacts
-release-artifacts: clean
-
-	mkdir -p $(PACKAGE_DIR)
-	mkdir -p $(BIN_DIR)
-	mkdir -p $(CONF_DIR)
-
-	cp -r ./docs $(PACKAGE_DIR)
-	cp -r ./deploy $(PACKAGE_DIR)
-	cp ./README.md $(PACKAGE_DIR)
-	cp ./CONTRIBUTING.md $(PACKAGE_DIR)
-	cp ./LICENSE $(PACKAGE_DIR)
-	cp ./examples/conf/*.yaml $(CONF_DIR)
-
-	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).darwin-amd64  -v $(TRICKSTER_MAIN)/*.go
-	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).darwin-arm64  -v $(TRICKSTER_MAIN)/*.go
-	GOOS=linux   GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).linux-amd64   -v $(TRICKSTER_MAIN)/*.go
-	GOOS=linux   GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).linux-arm64   -v $(TRICKSTER_MAIN)/*.go
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).windows-amd64 -v $(TRICKSTER_MAIN)/*.go
-
-	cd ./$(BUILD_SUBDIR) && tar cvfz ./trickster-$(TAGVER).tar.gz ./trickster-$(TAGVER)/*
 
 # Minikube and helm bootstrapping are done via deploy/helm/Makefile
 .PHONY: helm-local

--- a/ci.mk
+++ b/ci.mk
@@ -1,0 +1,47 @@
+# Copyright 2018 The Trickster Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# Targets for building and releasing Trickster from a CI/CD pipeline
+# Not meant for local usage except for testing
+
+.PHONY: release
+release: clean go-mod-tidy go-mod-vendor release-artifacts release-sha256
+
+# generate sha256sum for all release artifacts
+RELEASE_CHECKSUM_FILE=$(BUILD_SUBDIR)/sha256sum.txt
+.PHONY: release-sha256
+release-sha256:
+	./hack/release-sha256.sh $(RELEASE_CHECKSUM_FILE) $(BUILD_SUBDIR) $(TAGVER) $(BIN_DIR)
+
+.PHONY: release-artifacts
+release-artifacts: clean
+
+	mkdir -p $(PACKAGE_DIR)
+	mkdir -p $(BIN_DIR)
+	mkdir -p $(CONF_DIR)
+
+	cp -r ./docs $(PACKAGE_DIR)
+	cp -r ./deploy $(PACKAGE_DIR)
+	cp ./README.md $(PACKAGE_DIR)
+	cp ./CONTRIBUTING.md $(PACKAGE_DIR)
+	cp ./LICENSE $(PACKAGE_DIR)
+	cp ./examples/conf/*.yaml $(CONF_DIR)
+
+	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).darwin-amd64  -v $(TRICKSTER_MAIN)/*.go
+	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).darwin-arm64  -v $(TRICKSTER_MAIN)/*.go
+	GOOS=linux   GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).linux-amd64   -v $(TRICKSTER_MAIN)/*.go
+	GOOS=linux   GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).linux-arm64   -v $(TRICKSTER_MAIN)/*.go
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).windows-amd64 -v $(TRICKSTER_MAIN)/*.go
+
+	cd ./$(BUILD_SUBDIR) && tar cvfz ./trickster-$(TAGVER).tar.gz ./trickster-$(TAGVER)/*

--- a/docs/developer/spinning-new-release.md
+++ b/docs/developer/spinning-new-release.md
@@ -4,6 +4,29 @@ Users with push access to trickstercache/trickster (Maintainers and owners) can 
 
 To spin a new Trickster release, clone the repo, checkout the commit ID for the release, tag it with a release in semantic version format (`vX.Y.Z`), and push the tag back to the GitHub repository.
 
+A makefile target is provided to make this easier:
+```bash
+TAG_VERSION=v1.2.345 make create-tag
+```
+Prompts will ask for confirmation before creating the tag.
+
+<details>
+<summary>Example Output</summary>
+
+```bash
+% TAG_VERSION=v1.2.345 make create-tag
+FYI: the last proper tag was: v0.0.9
+FYI: the last beta tag was: v2.0.0-beta2
+Create tag v1.2.345? [y/N] y
+git tag v1.2.345
+git push origin v1.2.345
+Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
+To github.com:crandles/trickster.git
+ * [new tag]           v1.2.345 -> v1.2.345
+```
+
+</details>
+
 GitHub actions will detect the publishing of the new tag (so long as it's in the proper format) and cut a full release for the tag automatically.
 
 The cut release will be published as a Draft, giving the Maintainer the opportunity to craft release notes in advance of the actual release.

--- a/docs/developer/spinning-new-release.md
+++ b/docs/developer/spinning-new-release.md
@@ -1,6 +1,6 @@
 # Spinning New Trickster Release
 
-Users with push access to trickstercache/trickster (Maintainers and owners) can spin releases.
+Users with push access to trickstercache/trickster (Maintainers and owners) can create new releases.
 
 To spin a new Trickster release, clone the repo, checkout the commit ID for the release, tag it with a release in semantic version format (`vX.Y.Z`), and push the tag back to the GitHub repository.
 

--- a/hack/release-notes/notes.md
+++ b/hack/release-notes/notes.md
@@ -1,6 +1,6 @@
 # <img src="https://github.com/${REPO}/raw/${TAG}/docs/images/logos/trickster-logo.svg" width=60 />&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://github.com/${REPO}/raw/${TAG}/docs/images/logos/trickster-text.svg" width=280 />
 
-Welcome to ${TAG}! :tada:
+Welcome to Trickster ${TAG}! :tada:
 
 <!-- In this release, we:
 * Summary of high-level changes -->

--- a/hack/release-notes/notes.md
+++ b/hack/release-notes/notes.md
@@ -1,0 +1,41 @@
+# <img src="https://github.com/${REPO}/raw/${TAG}/docs/images/logos/trickster-logo.svg" width=60 />&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://github.com/${REPO}/raw/${TAG}/docs/images/logos/trickster-text.svg" width=280 />
+
+Welcome to ${TAG}! :tada:
+
+<!-- In this release, we:
+* Summary of high-level changes -->
+
+<!-- Thanks to:
+* @${GITHUB_USER} -->
+
+<details>
+<summary>Run via docker</summary>
+
+```bash
+# via ghcr.io
+docker run --name trickster -d -v /path/to/trickster.yaml:/etc/trickster/trickster.yaml -p 0.0.0.0:8480:8480 ghcr.io/${REPO}:${TAG}
+
+# via docker.io
+docker run --name trickster -d -v /path/to/trickster.yaml:/etc/trickster/trickster.yaml -p 0.0.0.0:8480:8480 docker.io/${REPO}:${TAG}
+```
+</details>
+
+<details>
+<summary>Run via kubernetes/helm</summary>
+
+```bash
+helm install trickster oci://ghcr.io/trickstercache/charts/trickster --version '^2' --set image.tag="${TAG}"
+```
+
+Note:
+
+* The trickster chart version is managed separately from the Trickster version.
+* The latest major version is 2.x, and supports a minimum Trickster version of 2.0.0 (beta3 or later).
+
+</details>
+
+---
+
+For **more information**, see:
+* [Trying Out Trickster](https://github.com/${REPO}/tree/${TAG}#trying-out-trickster)
+* trickster's [helm chart](https://github.com/trickstercache/helm-charts).

--- a/hack/release-notes/notes.md
+++ b/hack/release-notes/notes.md
@@ -1,4 +1,4 @@
-# <img src="https://github.com/${REPO}/raw/${TAG}/docs/images/logos/trickster-logo.svg" width=60 />&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://github.com/${REPO}/raw/${TAG}/docs/images/logos/trickster-text.svg" width=280 />
+# <img src="https://github.com/${REPO}/raw/v${TAG}/docs/images/logos/trickster-logo.svg" width=60 />&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://github.com/${REPO}/raw/v${TAG}/docs/images/logos/trickster-text.svg" width=280 />
 
 Welcome to Trickster ${TAG}! :tada:
 
@@ -37,5 +37,5 @@ Note:
 ---
 
 For **more information**, see:
-* [Trying Out Trickster](https://github.com/${REPO}/tree/${TAG}#trying-out-trickster)
+* [Trying Out Trickster](https://github.com/${REPO}/tree/v${TAG}#trying-out-trickster)
 * trickster's [helm chart](https://github.com/trickstercache/helm-charts).

--- a/release.mk
+++ b/release.mk
@@ -1,0 +1,68 @@
+# Copyright 2018 The Trickster Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# Targets for building and releasing Trickster to be triggered by Trickster maintainers.
+#
+# Create a new tag and push it to the remote repository
+#
+# Note(s): 
+# The CI/CD workflow is responsible for creating a release for the tag.
+# Recommend to run from the master branch of the upstream trickster repository.
+
+TAG_VERSION ?= 
+.PHONY: create-tag
+create-tag:
+	@if [ -z "$(TAG_VERSION)" ]; then echo "TAG_VERSION is not set"; exit 1; fi
+	@echo "FYI: the last proper tag was: $(shell $(MAKE) last-proper)"
+	@echo "FYI: the last beta tag was: $(shell $(MAKE) last-beta)"
+	@if ! echo $(TAG_VERSION) | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-beta[0-9]+)?$$'; then \
+		echo "TAG_VERSION must be a semver (e.g. v1.2.3 or v1.2.3-beta1)"; \
+		exit 1; \
+	fi
+	@if $(MAKE) get-tags | grep -qE "^$(TAG_VERSION)$$"; then \
+		echo "Tag $(TAG_VERSION) already exists"; \
+		exit 1; \
+	fi
+	@read -p "Create tag $(TAG_VERSION)? [y/N] " yn; \
+	if [ "$$yn" != "y" ]; then \
+		echo "Aborting"; \
+		exit 1; \
+	fi
+	git tag $(TAG_VERSION)
+	git push origin $(TAG_VERSION)
+
+# List out all tags in the repository
+.PHONY: get-tags
+get-tags:
+	@git tag -l | sort
+
+# List out all tags in the repository matching the given pattern
+# Example: make get-beta
+.PHONY: get-%
+get-%:
+# special case: return all tags
+	@if [[ "$*" == "all" ]]; then $(MAKE) get-tags; exit 0;	fi
+# special case: return all "proper" (non-beta/rc) tags
+	@if [[ "$*" == "proper" ]]; then $(MAKE) get-tags | grep -vE "beta|rc" || true; exit 0; fi
+# else, beta, rc, etc.
+	@$(MAKE) get-tags | grep "$*" || true
+
+# Get the last tag matching the given pattern (e.g. last beta)
+last-%:
+	@export LAST="$(shell $(MAKE) get-$* | tail -n 1)"; \
+		if [ -z "$$LAST" ]; then \
+			echo "No tags found for $*"; \
+			exit 1; \
+		fi; \
+		echo $$LAST


### PR DESCRIPTION
Documenting the release process & adding some extra content to the release notes.

Examples:

1. latest example: [link](https://github.com/crandles/trickster/releases/tag/v1.2.3456)
<details>
<summary>Example</summary>

<img width="1199" alt="Screenshot 2025-05-30 at 12 37 09 AM" src="https://github.com/user-attachments/assets/f709dc73-29a2-4ea1-b4f4-b2308143557e" />

</details>

2.  beta tag example: [link](https://github.com/crandles/trickster/releases/tag/v1.2.3-beta10) (content is a few revisions behind 1)
3. An example with a "What's Changed" from merged PRs

The above two are missing this since I didn't fake any PRs:
<details>
<summary>Example</summary>

<img width="910" alt="Screenshot 2025-05-30 at 12 32 48 AM" src="https://github.com/user-attachments/assets/d434ded3-9935-4c87-a24f-262a923f70f7" />

</details>