### PR TITLE
segments package

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -57,8 +57,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          REPO=${{ github.repository}} TAG=${{ steps.baretag.outputs.baretag }} envsubst < ./hack/release-notes/notes.md > /tmp/notes.md
           gh release create ${{ github.ref_name }} \
             --generate-notes \
+            --notes-file /tmp/notes.md \
             --title "Release v${{ steps.baretag.outputs.baretag }} / ${{ steps.date.outputs.date }}" \
             --draft=${{ env.draft }} \
             --prerelease=${{ env.prerelease }} \

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.dll
 *.so
 *.dylib
+sha256sum.txt
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+-include ci.mk release.mk
+
 DEFAULT: build
 
 PROJECT_DIR    := $(shell pwd)
@@ -65,37 +67,6 @@ rpm: build
 .PHONY: install
 install:
 	$(GO) install -o $(TRICKSTER) $(TAGVER)
-
-.PHONY: release
-release: clean go-mod-tidy go-mod-vendor release-artifacts release-sha256
-
-# generate sha256sum for all release artifacts
-RELEASE_CHECKSUM_FILE=$(BUILD_SUBDIR)/sha256sum.txt
-.PHONY: release-sha256
-release-sha256:
-	./hack/release-sha256.sh $(RELEASE_CHECKSUM_FILE) $(BUILD_SUBDIR) $(TAGVER) $(BIN_DIR)
-
-.PHONY: release-artifacts
-release-artifacts: clean
-
-	mkdir -p $(PACKAGE_DIR)
-	mkdir -p $(BIN_DIR)
-	mkdir -p $(CONF_DIR)
-
-	cp -r ./docs $(PACKAGE_DIR)
-	cp -r ./deploy $(PACKAGE_DIR)
-	cp ./README.md $(PACKAGE_DIR)
-	cp ./CONTRIBUTING.md $(PACKAGE_DIR)
-	cp ./LICENSE $(PACKAGE_DIR)
-	cp ./examples/conf/*.yaml $(CONF_DIR)
-
-	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).darwin-amd64  -v $(TRICKSTER_MAIN)/*.go
-	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).darwin-arm64  -v $(TRICKSTER_MAIN)/*.go
-	GOOS=linux   GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).linux-amd64   -v $(TRICKSTER_MAIN)/*.go
-	GOOS=linux   GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).linux-arm64   -v $(TRICKSTER_MAIN)/*.go
-	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).windows-amd64 -v $(TRICKSTER_MAIN)/*.go
-
-	cd ./$(BUILD_SUBDIR) && tar cvfz ./trickster-$(TAGVER).tar.gz ./trickster-$(TAGVER)/*
 
 # Minikube and helm bootstrapping are done via deploy/helm/Makefile
 .PHONY: helm-local

--- a/ci.mk
+++ b/ci.mk
@@ -1,0 +1,47 @@
+# Copyright 2018 The Trickster Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# Targets for building and releasing Trickster from a CI/CD pipeline
+# Not meant for local usage except for testing
+
+.PHONY: release
+release: clean go-mod-tidy go-mod-vendor release-artifacts release-sha256
+
+# generate sha256sum for all release artifacts
+RELEASE_CHECKSUM_FILE=$(BUILD_SUBDIR)/sha256sum.txt
+.PHONY: release-sha256
+release-sha256:
+	./hack/release-sha256.sh $(RELEASE_CHECKSUM_FILE) $(BUILD_SUBDIR) $(TAGVER) $(BIN_DIR)
+
+.PHONY: release-artifacts
+release-artifacts: clean
+
+	mkdir -p $(PACKAGE_DIR)
+	mkdir -p $(BIN_DIR)
+	mkdir -p $(CONF_DIR)
+
+	cp -r ./docs $(PACKAGE_DIR)
+	cp -r ./deploy $(PACKAGE_DIR)
+	cp ./README.md $(PACKAGE_DIR)
+	cp ./CONTRIBUTING.md $(PACKAGE_DIR)
+	cp ./LICENSE $(PACKAGE_DIR)
+	cp ./examples/conf/*.yaml $(CONF_DIR)
+
+	GOOS=darwin  GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).darwin-amd64  -v $(TRICKSTER_MAIN)/*.go
+	GOOS=darwin  GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).darwin-arm64  -v $(TRICKSTER_MAIN)/*.go
+	GOOS=linux   GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).linux-amd64   -v $(TRICKSTER_MAIN)/*.go
+	GOOS=linux   GOARCH=arm64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).linux-arm64   -v $(TRICKSTER_MAIN)/*.go
+	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) $(GO) build $(LDFLAGS) -o $(BIN_DIR)/trickster-$(TAGVER).windows-amd64 -v $(TRICKSTER_MAIN)/*.go
+
+	cd ./$(BUILD_SUBDIR) && tar cvfz ./trickster-$(TAGVER).tar.gz ./trickster-$(TAGVER)/*

--- a/docs/developer/spinning-new-release.md
+++ b/docs/developer/spinning-new-release.md
@@ -1,8 +1,31 @@
 # Spinning New Trickster Release
 
-Users with push access to trickstercache/trickster (Maintainers and owners) can spin releases.
+Users with push access to trickstercache/trickster (Maintainers and owners) can create new releases.
 
 To spin a new Trickster release, clone the repo, checkout the commit ID for the release, tag it with a release in semantic version format (`vX.Y.Z`), and push the tag back to the GitHub repository.
+
+A makefile target is provided to make this easier:
+```bash
+TAG_VERSION=v1.2.345 make create-tag
+```
+Prompts will ask for confirmation before creating the tag.
+
+<details>
+<summary>Example Output</summary>
+
+```bash
+% TAG_VERSION=v1.2.345 make create-tag
+FYI: the last proper tag was: v0.0.9
+FYI: the last beta tag was: v2.0.0-beta2
+Create tag v1.2.345? [y/N] y
+git tag v1.2.345
+git push origin v1.2.345
+Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
+To github.com:crandles/trickster.git
+ * [new tag]           v1.2.345 -> v1.2.345
+```
+
+</details>
 
 GitHub actions will detect the publishing of the new tag (so long as it's in the proper format) and cut a full release for the tag automatically.
 

--- a/hack/release-notes/notes.md
+++ b/hack/release-notes/notes.md
@@ -1,0 +1,41 @@
+# <img src="https://github.com/${REPO}/raw/v${TAG}/docs/images/logos/trickster-logo.svg" width=60 />&nbsp;&nbsp;&nbsp;&nbsp;<img src="https://github.com/${REPO}/raw/v${TAG}/docs/images/logos/trickster-text.svg" width=280 />
+
+Welcome to Trickster ${TAG}! :tada:
+
+<!-- In this release, we:
+* Summary of high-level changes -->
+
+<!-- Thanks to:
+* @${GITHUB_USER} -->
+
+<details>
+<summary>Run via docker</summary>
+
+```bash
+# via ghcr.io
+docker run --name trickster -d -v /path/to/trickster.yaml:/etc/trickster/trickster.yaml -p 0.0.0.0:8480:8480 ghcr.io/${REPO}:${TAG}
+
+# via docker.io
+docker run --name trickster -d -v /path/to/trickster.yaml:/etc/trickster/trickster.yaml -p 0.0.0.0:8480:8480 docker.io/${REPO}:${TAG}
+```
+</details>
+
+<details>
+<summary>Run via kubernetes/helm</summary>
+
+```bash
+helm install trickster oci://ghcr.io/trickstercache/charts/trickster --version '^2' --set image.tag="${TAG}"
+```
+
+Note:
+
+* The trickster chart version is managed separately from the Trickster version.
+* The latest major version is 2.x, and supports a minimum Trickster version of 2.0.0 (beta3 or later).
+
+</details>
+
+---
+
+For **more information**, see:
+* [Trying Out Trickster](https://github.com/${REPO}/tree/v${TAG}#trying-out-trickster)
+* trickster's [helm chart](https://github.com/trickstercache/helm-charts).

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -284,7 +284,7 @@ func QueryCache(ctx context.Context, c cache.Cache, key string,
 	}
 
 	if len(ranges) > 0 && len(d.Ranges) > 0 {
-		delta = ranges.CalculateDelta(d.Ranges, d.ContentLength)
+		delta = d.Ranges.CalculateDeltas(ranges, d.ContentLength)
 		if len(delta) > 0 {
 			if len(d.Body) > 0 {
 				// If there's delta, we need to treat this as a partial hit; move all of d's content to RangeParts

--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -209,7 +209,7 @@ checkCache:
 		vr = cts.VolatileExtents()
 	}
 	if cacheStatus == status.LookupStatusPartialHit {
-		missRanges = cts.Extents().CalculateDeltas(trq.Extent, trq.Step)
+		missRanges = cts.Extents().CalculateDeltas(timeseries.ExtentList{trq.Extent}, trq.Step)
 		// this is the backfill part of backfill tolerance. if there are any volatile
 		// ranges in the timeseries, this determines if any fall within the client's
 		// requested range and ensures they are re-requested. this only happens if

--- a/pkg/proxy/engines/proxy_request.go
+++ b/pkg/proxy/engines/proxy_request.go
@@ -198,18 +198,17 @@ func (pr *proxyRequest) prepareRevalidationRequest() {
 		cl := d.ContentLength
 
 		rsc := request.GetResources(pr.Request)
-		// revalRanges are the ranges we have in cache that have expired, but the user needs
-		// so we revalidate these ranges in parallel with fetching of the uncached ranges
 
 		var wr byterange.Ranges
-
 		if len(pr.wantedRanges) > 0 {
 			wr = pr.wantedRanges
 		} else {
 			wr = byterange.Ranges{{Start: 0, End: cl}}
 		}
 
-		revalRanges := wr.CalculateDelta(pr.neededRanges, cl)
+		// revalRanges are the ranges we have in cache that have expired, but the user needs
+		// so we revalidate these ranges in parallel with fetching of the uncached ranges
+		revalRanges := pr.neededRanges.CalculateDeltas(wr, cl)
 		l := len(revalRanges)
 		if (l > 1 && rsc.BackendOptions.DearticulateUpstreamRanges) && len(pr.cacheDocument.Ranges) == 1 {
 			rh = pr.cacheDocument.Ranges.String()

--- a/pkg/proxy/ranges/byterange/range.go
+++ b/pkg/proxy/ranges/byterange/range.go
@@ -266,5 +266,5 @@ func (rs Ranges) String() string {
 	for i, v := range rs {
 		s[i] = v.String()
 	}
-	return strings.Join(s, ",")
+	return byteRequestRangePrefix + strings.Join(s, ", ")
 }

--- a/pkg/proxy/ranges/byterange/range.go
+++ b/pkg/proxy/ranges/byterange/range.go
@@ -104,6 +104,8 @@ func (r Range) Copy(dst []byte, src []byte) int {
 
 // CalculateDeltas calculates the delta between two Ranges
 func (rs Ranges) CalculateDeltas(need Ranges, fullContentLength int64) Ranges {
+	sort.Sort(rs)
+	sort.Sort(need)
 	return segments.Diff(rs, need, int64(1), segments.Int64{})
 }
 

--- a/pkg/proxy/ranges/byterange/range.go
+++ b/pkg/proxy/ranges/byterange/range.go
@@ -121,8 +121,8 @@ func (rs Ranges) FilterByteSlice(b []byte) []byte {
 	sort.Sort(rs)
 	out := make([]byte, rs[len(rs)-1].End)
 	for _, r := range rs {
-		content, _ := Range(r).CropByteSlice(b)
-		Range(r).Copy(out, content)
+		content, _ := r.CropByteSlice(b)
+		r.Copy(out, content)
 	}
 	return out
 }

--- a/pkg/proxy/ranges/byterange/range_test.go
+++ b/pkg/proxy/ranges/byterange/range_test.go
@@ -26,110 +26,110 @@ import (
 func TestRanges_CalculateDelta(t *testing.T) {
 
 	tests := []struct {
-		want, have, expected Ranges
+		need, have, expected Ranges
 		cl                   int64
 	}{
 		{
-			// case 0  where we need both outer permiters of the wanted range
-			want:     Ranges{Range{Start: 5, End: 10}},
+			// case 0  where we need both outer permiters of the needed range
+			need:     Ranges{Range{Start: 5, End: 10}},
 			have:     Ranges{Range{Start: 6, End: 9}},
 			expected: Ranges{Range{Start: 5, End: 5}, Range{Start: 10, End: 10}},
 			cl:       62,
 		},
 		{
 			// case 1  where the needed range is out of known bounds
-			want:     Ranges{Range{Start: 100, End: 100}},
+			need:     Ranges{Range{Start: 100, End: 100}},
 			have:     Ranges{Range{Start: 6, End: 9}},
 			expected: Ranges{Range{Start: 100, End: 100}},
 			cl:       62,
 		},
 		{
 			// case 2  where the needed range is identical to have range
-			want:     Ranges{Range{Start: 6, End: 9}},
+			need:     Ranges{Range{Start: 6, End: 9}},
 			have:     Ranges{Range{Start: 6, End: 9}},
 			expected: Ranges{},
 			cl:       62,
 		},
 		{
-			// case 3  where we want a suffix range ("bytes=-50")
-			want:     Ranges{Range{Start: -1, End: 50}},
+			// case 3  where we need a suffix range ("bytes=-50")
+			need:     Ranges{Range{Start: -1, End: 50}},
 			have:     Ranges{Range{Start: 0, End: 30}},
 			expected: Ranges{Range{Start: 31, End: 69}},
 			cl:       70,
 		},
 		{
-			// case 4  where we want a prefix range ("bytes=50-")
-			want:     Ranges{Range{Start: 30, End: -1}},
+			// case 4  where we need a prefix range ("bytes=50-")
+			need:     Ranges{Range{Start: 30, End: -1}},
 			have:     Ranges{Range{Start: 0, End: 40}},
 			expected: Ranges{Range{Start: 41, End: 69}},
 			cl:       70,
 		},
 		{
 			// case 5  where we have a few absolute ranges #1
-			want:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
+			need:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
 			have:     Ranges{Range{Start: 0, End: 25}},
 			expected: Ranges{Range{Start: 26, End: 29}},
 			cl:       70,
 		},
 		{
 			// case 6  where we have a few absolute ranges #2
-			want:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
+			need:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
 			have:     Ranges{Range{Start: 0, End: 6}, Range{Start: 17, End: 32}},
 			expected: Ranges{Range{Start: 7, End: 10}},
 			cl:       70,
 		},
 		{
 			// case 7  where we have a few absolute ranges #3
-			want:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
+			need:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
 			have:     Ranges{Range{Start: 0, End: 6}, Range{Start: 25, End: 32}},
 			expected: Ranges{Range{Start: 7, End: 10}, Range{Start: 20, End: 24}},
 			cl:       70,
 		},
 		{
 			// case 8  where we have a few absolute ranges #4
-			want:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
+			need:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
 			have:     Ranges{Range{Start: 0, End: 6}, Range{Start: 20, End: 27}},
 			expected: Ranges{Range{Start: 7, End: 10}, Range{Start: 28, End: 29}},
 			cl:       70,
 		},
 		{
 			// case 9 where we have all empty ranges
-			want:     Ranges{},
+			need:     Ranges{},
 			have:     Ranges{},
 			expected: Ranges{},
 			cl:       1,
 		},
 		{
 			// case 10 where we have no saved ranges
-			want:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
+			need:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
 			have:     nil,
 			expected: Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 29}},
 			cl:       1,
 		},
 		{
 			// case 11 partial hit between 2 ranges
-			want:     Ranges{Range{Start: 5, End: 20}},
+			need:     Ranges{Range{Start: 5, End: 20}},
 			have:     Ranges{Range{Start: 1, End: 9}},
 			expected: Ranges{Range{Start: 10, End: 20}},
 			cl:       21,
 		},
 		{
 			// case 12 full range miss
-			want:     Ranges{Range{Start: 15, End: 20}},
+			need:     Ranges{Range{Start: 15, End: 20}},
 			have:     Ranges{Range{Start: 1, End: 9}},
 			expected: Ranges{Range{Start: 15, End: 20}},
 			cl:       21,
 		},
 		{
 			// case 13 cache hit
-			want:     Ranges{Range{Start: 29, End: 29}},
+			need:     Ranges{Range{Start: 29, End: 29}},
 			have:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 32}},
 			expected: Ranges{},
 			cl:       70,
 		},
 		// case 14 two separate partial hit areas in the same request
 		{
-			want:     Ranges{Range{Start: 9, End: 22}, Range{Start: 28, End: 60}},
+			need:     Ranges{Range{Start: 9, End: 22}, Range{Start: 28, End: 60}},
 			have:     Ranges{Range{Start: 0, End: 10}, Range{Start: 20, End: 32}},
 			expected: Ranges{Range{Start: 11, End: 19}, Range{Start: 33, End: 60}},
 			cl:       70,
@@ -138,8 +138,8 @@ func TestRanges_CalculateDelta(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			res := test.want.CalculateDelta(test.have, test.cl)
-			if !res.Equal(test.expected) {
+			res := test.have.CalculateDeltas(test.need, test.cl)
+			if !Ranges(res).Equal(Ranges(test.expected)) {
 				t.Errorf("got     : %s\nexpected: %s", res, test.expected)
 			}
 		})
@@ -189,8 +189,8 @@ func TestParseContentRangeHeader(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if er != r {
-		t.Errorf("expected %s, got %s", er.String(), r.String())
+	if Range(er) != r {
+		t.Errorf("expected %s, got %s", er, Range(r))
 	}
 	if cl != el {
 		t.Errorf("expected %d, got %d", el, cl)
@@ -208,8 +208,8 @@ func TestParseContentRangeHeader(t *testing.T) {
 	if err == nil || err.Error() != "invalid input format" {
 		t.Errorf("expected error: %s", "invalid input format")
 	}
-	if er != r {
-		t.Errorf("expected %s, got %s", er.String(), r.String())
+	if Range(er) != r {
+		t.Errorf("expected %s, got %s", er, Range(r))
 	}
 	if cl != el {
 		t.Errorf("expected %d, got %d", el, cl)
@@ -240,14 +240,14 @@ func TestRangesFilter(t *testing.T) {
 
 func TestRangesEqual(t *testing.T) {
 
-	want := Ranges{Range{Start: 0, End: 20}}
-	if want.Equal(nil) {
+	need := Ranges{Range{Start: 0, End: 20}}
+	if need.Equal(nil) {
 		t.Errorf("expected %t got %t", false, true)
 	}
 
 }
 
-func TestRangeSort(t *testing.T) {
+func TestRangesSort(t *testing.T) {
 	r := Ranges{Range{Start: 10, End: 20}, Range{Start: 0, End: 8}}
 	sort.Sort(r)
 	if r[0].Start != 0 || r[1].End != 20 {
@@ -255,7 +255,7 @@ func TestRangeSort(t *testing.T) {
 	}
 }
 
-func TestRangeLess(t *testing.T) {
+func TestRangesLess(t *testing.T) {
 	r1 := Range{Start: 10, End: 20}
 	r2 := Range{Start: 22, End: 30}
 	if !r1.Less(r2) {
@@ -263,7 +263,7 @@ func TestRangeLess(t *testing.T) {
 	}
 }
 
-func TestContentRangeHeader(t *testing.T) {
+func TestContentRangesHeader(t *testing.T) {
 
 	const expected = "bytes 0-20/100"
 
@@ -276,7 +276,7 @@ func TestContentRangeHeader(t *testing.T) {
 
 }
 
-func TestParseRangeHeader_EmptyString(t *testing.T) {
+func TestParseRangesHeader_EmptyString(t *testing.T) {
 	r := ParseRangeHeader("")
 	if r != nil {
 		t.Errorf("expected empty byte range")
@@ -314,7 +314,7 @@ func TestParseRangeHeader_InvalidRange(t *testing.T) {
 	}
 }
 
-func TestParseRangeHeader_SingleRange(t *testing.T) {
+func TestParseRangesHeader_SingleRange(t *testing.T) {
 	byteRange := "bytes=0-50"
 	res := ParseRangeHeader(byteRange)
 	if res == nil {
@@ -325,7 +325,7 @@ func TestParseRangeHeader_SingleRange(t *testing.T) {
 	}
 }
 
-func TestParseRangeHeader_Ends(t *testing.T) {
+func TestParseRangesHeader_Ends(t *testing.T) {
 	byteRange := "bytes=500-"
 	res := ParseRangeHeader(byteRange)
 	if res == nil {
@@ -358,7 +358,7 @@ func TestParseRangeHeader_Ends(t *testing.T) {
 
 }
 
-func TestParseRangeHeader_MultiRange(t *testing.T) {
+func TestParseRangesHeader_MultiRange(t *testing.T) {
 	byteRange := "bytes=0-50, 100-150"
 	res := ParseRangeHeader(byteRange)
 	if res == nil {
@@ -372,7 +372,7 @@ func TestParseRangeHeader_MultiRange(t *testing.T) {
 	}
 }
 
-func TestRangeCrop(t *testing.T) {
+func TestRangesCrop(t *testing.T) {
 	r1 := Range{0, 1}
 	r2 := Range{0, 3}
 	b := []byte{0, 1}

--- a/pkg/proxy/ranges/byterange/range_test.go
+++ b/pkg/proxy/ranges/byterange/range_test.go
@@ -175,7 +175,7 @@ func TestRangesString(t *testing.T) {
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			if test.out != test.expected {
-				t.Errorf("expected: %s\ngot:      %s", test.out, test.expected)
+				t.Errorf("expected: %s\ngot:      %s", test.expected, test.out)
 			}
 		})
 	}

--- a/pkg/proxy/ranges/byterange/range_test.go
+++ b/pkg/proxy/ranges/byterange/range_test.go
@@ -18,6 +18,7 @@ package byterange
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 	"strconv"
 	"testing"
@@ -381,5 +382,113 @@ func TestRangesCrop(t *testing.T) {
 	}
 	if cr, _ := r2.CropByteSlice(b); len(cr) != 2 || cr[0] != 0 || cr[1] != 1 {
 		t.Error(cr)
+	}
+}
+
+func TestCompressRanges(t *testing.T) {
+
+	tests := []struct {
+		uncompressed, compressed Ranges
+	}{
+		{
+			Ranges{},
+			Ranges{},
+		},
+
+		{
+			Ranges{
+				Range{Start: -1, End: 1},
+				Range{Start: 3, End: 4},
+				Range{Start: 4, End: 6},
+				Range{Start: 6, End: 7},
+			},
+			Ranges{
+				Range{Start: -1, End: 1},
+				Range{Start: 3, End: 4},
+				Range{Start: 4, End: 6},
+				Range{Start: 6, End: 7},
+			},
+		},
+
+		{
+			Ranges{
+				Range{Start: 1, End: 1},
+				Range{Start: 3, End: 4},
+				Range{Start: -4, End: 6},
+				Range{Start: 6, End: 7},
+			},
+			Ranges{
+				Range{Start: 1, End: 1},
+				Range{Start: 3, End: 4},
+				Range{Start: -4, End: 6},
+				Range{Start: 6, End: 7},
+			},
+		},
+
+		{
+			Ranges{
+				Range{Start: 1, End: 1},
+				Range{Start: 3, End: 4},
+				Range{Start: 4, End: 6},
+				Range{Start: 6, End: 7},
+			},
+			Ranges{
+				Range{Start: 1, End: 1},
+				Range{Start: 3, End: 7},
+			},
+		},
+
+		{
+			Ranges{
+				Range{Start: 0, End: 1},
+			},
+			Ranges{
+				Range{Start: 0, End: 1},
+			},
+		},
+
+		{
+			Ranges{
+				Range{Start: 0, End: 1},
+				Range{Start: 3, End: 4},
+				Range{Start: 4, End: 6},
+				Range{Start: 9, End: 12},
+				Range{Start: 6, End: 7},
+				Range{Start: 14, End: 16},
+			},
+			Ranges{
+				Range{Start: 0, End: 1},
+				Range{Start: 3, End: 7},
+				Range{Start: 9, End: 12},
+				Range{Start: 14, End: 16},
+			},
+		},
+
+		{
+			Ranges{
+				Range{Start: 3, End: 4},
+				Range{Start: 3, End: 4},
+				Range{Start: 6, End: 6},
+				Range{Start: 6, End: 6},
+			},
+			Ranges{
+				Range{Start: 3, End: 4},
+				Range{Start: 6, End: 6},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		if i != 2 {
+			continue
+		}
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+
+			result := test.uncompressed.Compress()
+
+			if !reflect.DeepEqual(result, test.compressed) {
+				t.Errorf("mismatch in Compress: expected=%s got=%s", test.compressed, result)
+			}
+		})
 	}
 }

--- a/pkg/proxy/ranges/byterange/range_test.go
+++ b/pkg/proxy/ranges/byterange/range_test.go
@@ -248,7 +248,7 @@ func TestRangesEqual(t *testing.T) {
 
 }
 
-func TestRangesSort(t *testing.T) {
+func TestRangeSort(t *testing.T) {
 	r := Ranges{Range{Start: 10, End: 20}, Range{Start: 0, End: 8}}
 	sort.Sort(r)
 	if r[0].Start != 0 || r[1].End != 20 {
@@ -256,7 +256,7 @@ func TestRangesSort(t *testing.T) {
 	}
 }
 
-func TestRangesLess(t *testing.T) {
+func TestRangeLess(t *testing.T) {
 	r1 := Range{Start: 10, End: 20}
 	r2 := Range{Start: 22, End: 30}
 	if !r1.Less(r2) {
@@ -264,7 +264,7 @@ func TestRangesLess(t *testing.T) {
 	}
 }
 
-func TestContentRangesHeader(t *testing.T) {
+func TestContentRangeHeader(t *testing.T) {
 
 	const expected = "bytes 0-20/100"
 
@@ -277,7 +277,7 @@ func TestContentRangesHeader(t *testing.T) {
 
 }
 
-func TestParseRangesHeader_EmptyString(t *testing.T) {
+func TestParseRangeHeader_EmptyString(t *testing.T) {
 	r := ParseRangeHeader("")
 	if r != nil {
 		t.Errorf("expected empty byte range")
@@ -315,7 +315,7 @@ func TestParseRangeHeader_InvalidRange(t *testing.T) {
 	}
 }
 
-func TestParseRangesHeader_SingleRange(t *testing.T) {
+func TestParseRangeHeader_SingleRange(t *testing.T) {
 	byteRange := "bytes=0-50"
 	res := ParseRangeHeader(byteRange)
 	if res == nil {
@@ -326,7 +326,7 @@ func TestParseRangesHeader_SingleRange(t *testing.T) {
 	}
 }
 
-func TestParseRangesHeader_Ends(t *testing.T) {
+func TestParseRangeHeader_Ends(t *testing.T) {
 	byteRange := "bytes=500-"
 	res := ParseRangeHeader(byteRange)
 	if res == nil {
@@ -359,7 +359,7 @@ func TestParseRangesHeader_Ends(t *testing.T) {
 
 }
 
-func TestParseRangesHeader_MultiRange(t *testing.T) {
+func TestParseRangeHeader_MultiRange(t *testing.T) {
 	byteRange := "bytes=0-50, 100-150"
 	res := ParseRangeHeader(byteRange)
 	if res == nil {
@@ -373,7 +373,7 @@ func TestParseRangesHeader_MultiRange(t *testing.T) {
 	}
 }
 
-func TestRangesCrop(t *testing.T) {
+func TestRangeCrop(t *testing.T) {
 	r1 := Range{0, 1}
 	r2 := Range{0, 3}
 	b := []byte{0, 1}

--- a/pkg/segments/ints.go
+++ b/pkg/segments/ints.go
@@ -16,7 +16,7 @@
 
 package segments
 
-// Int64 implements Deltaable for int64 (bytes, IPv4s, etc.)
+// Int64 implements Diffable for int64 (bytes, IPv4s, etc.)
 type Int64 struct{}
 
 func (Int64) Add(a int64, step int64) int64 { return a + step }

--- a/pkg/segments/ints.go
+++ b/pkg/segments/ints.go
@@ -14,4 +14,13 @@
  * limitations under the License.
  */
 
-package timeseries
+package segments
+
+// Int64 implements Deltaable for int64 (bytes, IPv4s, etc.)
+type Int64 struct{}
+
+func (Int64) Add(a int64, step int64) int64 { return a + step }
+func (Int64) Less(a, b int64) bool          { return a < b }
+func (Int64) Equal(a, b int64) bool         { return a == b }
+func (Int64) Zero() int64                   { return 0 }
+func (Int64) Neg(step int64) int64          { return -step }

--- a/pkg/segments/segments.go
+++ b/pkg/segments/segments.go
@@ -37,7 +37,7 @@ type Diffabble[P any, StepT any] interface {
 	Neg(step StepT) StepT
 }
 
-// Diff compares 'have' to 'need' and returns a slice of Segments missing from need
+// Diff compares 'haves' to 'needs' and returns a slice of Segments missing from needs
 func Diff[P any, S Segment[P], StepT comparable, D Diffabble[P, StepT]](
 	haves []S, needs []S, step StepT, diff D) []S {
 	var zero StepT

--- a/pkg/segments/segments.go
+++ b/pkg/segments/segments.go
@@ -51,7 +51,8 @@ func Diff[P any, S Segment[P], StepT comparable, D Diffabble[P, StepT]](
 	var k int
 
 	for _, n := range needs {
-		if !diff.Less(n.StartVal(), n.EndVal()) {
+		if diff.Less(n.EndVal(), n.StartVal()) {
+			// skip ranges where end < start
 			continue
 		}
 		missStart := diff.Zero()

--- a/pkg/segments/segments.go
+++ b/pkg/segments/segments.go
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package segments
+
+// U: point type (time.Time, int64, etc.)
+// S: segment type (Extent, Range, etc.)
+
+// Segment represents a range with inclusive Start/End points of type U.
+type Segment[U any] interface {
+	StartVal() U
+	EndVal() U
+	NewSegment(start, end U) Segment[U]
+	String() string
+}
+
+// Diffabble is a named type of a slice of an implementation of Segment that
+// can be passed into Difference() as diff D
+type Diffabble[P any, StepT any] interface {
+	Add(a P, step StepT) P
+	Less(a, b P) bool
+	Equal(a, b P) bool
+	Zero() P
+	Neg(step StepT) StepT
+}
+
+func Diff[P any, S Segment[P], StepT comparable, D Diffabble[P, StepT]](
+	have []S,
+	need []S,
+	step StepT,
+	diff D,
+) []S {
+	var zero StepT
+	if len(need) == 0 || step == zero {
+		return nil
+	}
+	out := make([]S, (len(have)+1)*len(need))
+	var k int
+
+	for _, n := range need {
+		if !diff.Less(n.StartVal(), n.EndVal()) {
+			continue
+		}
+		missStart := diff.Zero()
+		haveIdx := 0
+		inMiss := false
+
+		for ts := n.StartVal(); !diff.Less(n.EndVal(), ts); ts = diff.Add(ts, step) {
+			for haveIdx < len(have) && diff.Less(have[haveIdx].EndVal(), ts) {
+				haveIdx++
+			}
+			inRange := false
+			if haveIdx < len(have) {
+				s := have[haveIdx].StartVal()
+				e := have[haveIdx].EndVal()
+				inRange = !diff.Less(ts, s) && !diff.Less(e, ts)
+			}
+			if !inRange {
+				if !inMiss {
+					missStart = ts
+					inMiss = true
+				}
+			} else if inMiss {
+				seg := n.NewSegment(missStart, diff.Add(ts, diff.Neg(step)))
+				out[k] = seg.(S)
+				k++
+				inMiss = false
+			}
+		}
+		if inMiss {
+			seg := n.NewSegment(missStart, n.EndVal())
+			out[k] = seg.(S)
+			k++
+		}
+	}
+	return out[:k]
+}

--- a/pkg/segments/times.go
+++ b/pkg/segments/times.go
@@ -14,4 +14,15 @@
  * limitations under the License.
  */
 
-package timeseries
+package segments
+
+import "time"
+
+// Time implements Deltaable for time.Time
+type Time struct{}
+
+func (Time) Add(a time.Time, step time.Duration) time.Time { return a.Add(step) }
+func (Time) Less(a, b time.Time) bool                      { return a.Before(b) }
+func (Time) Equal(a, b time.Time) bool                     { return a.Equal(b) }
+func (Time) Zero() time.Time                               { return time.Time{} }
+func (Time) Neg(step time.Duration) time.Duration          { return -step }

--- a/pkg/segments/times.go
+++ b/pkg/segments/times.go
@@ -18,7 +18,7 @@ package segments
 
 import "time"
 
-// Time implements Deltaable for time.Time
+// Time implements Diffable for time.Time
 type Time struct{}
 
 func (Time) Add(a time.Time, step time.Duration) time.Time { return a.Add(step) }

--- a/pkg/timeseries/extent.go
+++ b/pkg/timeseries/extent.go
@@ -40,7 +40,7 @@ func (e Extent) NewSegment(start, end time.Time) segments.Segment[time.Time] {
 }
 
 // After returns true if the range of the Extent is completely after the provided time
-func (e *Extent) After(t time.Time) bool {
+func (e Extent) After(t time.Time) bool {
 	return t.Before(e.Start)
 }
 

--- a/pkg/timeseries/extent.go
+++ b/pkg/timeseries/extent.go
@@ -21,6 +21,8 @@ package timeseries
 import (
 	"fmt"
 	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/segments"
 )
 
 // Extent describes the start and end times for a given range of data
@@ -30,39 +32,11 @@ type Extent struct {
 	LastUsed time.Time `msg:"lu" json:"-"`
 }
 
-// Includes returns true if the Extent includes the provided Time
-func (e *Extent) Includes(t time.Time) bool {
-	return !t.Before(e.Start) && !t.After(e.End)
-}
-
-// StartsAt returns true if t is equal to the Extent's start time
-func (e *Extent) StartsAt(t time.Time) bool {
-	return t.Equal(e.Start)
-}
-
-// StartsAtOrBefore returns true if t is equal or before to the Extent's start time
-func (e *Extent) StartsAtOrBefore(t time.Time) bool {
-	return t.Equal(e.Start) || e.Start.Before(t)
-}
-
-// StartsAtOrAfter returns true if t is equal to or after the Extent's start time
-func (e *Extent) StartsAtOrAfter(t time.Time) bool {
-	return t.Equal(e.Start) || e.Start.After(t)
-}
-
-// EndsAt returns true if t is equal to the Extent's end time
-func (e *Extent) EndsAt(t time.Time) bool {
-	return t.Equal(e.End)
-}
-
-// EndsAtOrBefore returns true if t is equal to or earlier than the Extent's end time
-func (e *Extent) EndsAtOrBefore(t time.Time) bool {
-	return t.Equal(e.End) || e.End.Before(t)
-}
-
-// EndsAtOrAfter returns true if t is equal to or after the Extent's end time
-func (e *Extent) EndsAtOrAfter(t time.Time) bool {
-	return t.Equal(e.End) || e.End.After(t)
+// Implements segments.Segment[time.Time]
+func (e Extent) StartVal() time.Time { return e.Start }
+func (e Extent) EndVal() time.Time   { return e.End }
+func (e Extent) NewSegment(start, end time.Time) segments.Segment[time.Time] {
+	return Extent{Start: start, End: end}
 }
 
 // After returns true if the range of the Extent is completely after the provided time

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -393,7 +393,11 @@ func (el ExtentList) CalculateDeltas(
 	need ExtentList,
 	step time.Duration,
 ) ExtentList {
-	return segments.Diff(el, need, step, segments.Time{})
+	sort.Sort(el)
+	sort.Sort(need)
+	out := ExtentList(segments.Diff(el, need, step, segments.Time{}))
+	out.Compress(step)
+	return out
 }
 
 // Size returns the approximate memory utilization in bytes of the timeseries

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -23,6 +23,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/segments"
 )
 
 // ExtentList is a type of []Extent used for sorting the slice
@@ -387,50 +389,11 @@ func (el ExtentList) TimestampCount(d time.Duration) int64 {
 // CalculateDeltas provides a list of extents that are not in el based on the
 // needed extent. step is used to determine which absolute timestamps in need
 // will be checked in el.
-func (el ExtentList) CalculateDeltas(need Extent, step time.Duration) ExtentList {
-	if step <= 0 || !need.End.After(need.Start) {
-		return ExtentList{}
-	}
-	if len(el) == 0 {
-		return ExtentList{need}
-	}
-	sort.Sort(el)
-	out := make(ExtentList, len(el)+1)
-	var missStart time.Time
-	var j, k int
-	for ts := need.Start; !ts.After(need.End); ts = ts.Add(step) {
-		// this advances j to the point in el where ts would be if it were
-		// present in el (whether it currently is or not)
-		for j < len(el) && ts.After(el[j].End) {
-			j++
-		}
-		inExisting := false
-		if j < len(el) {
-			s := el[j].Start
-			e := el[j].End
-			inExisting = !ts.Before(s) && !ts.After(e)
-		}
-		if !inExisting {
-			if missStart.IsZero() {
-				missStart = ts
-			}
-		} else if !missStart.IsZero() {
-			out[k] = Extent{
-				Start: missStart,
-				End:   ts.Add(-step),
-			}
-			k++
-			missStart = time.Time{}
-		}
-	}
-	if !missStart.IsZero() {
-		out[k] = Extent{
-			Start: missStart,
-			End:   need.End,
-		}
-		k++
-	}
-	return out[:k]
+func (el ExtentList) CalculateDeltas(
+	need ExtentList,
+	step time.Duration,
+) ExtentList {
+	return segments.Diff(el, need, step, segments.Time{})
 }
 
 // Size returns the approximate memory utilization in bytes of the timeseries

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -389,13 +389,11 @@ func (el ExtentList) TimestampCount(d time.Duration) int64 {
 // CalculateDeltas provides a list of extents that are not in el based on the
 // needed extent. step is used to determine which absolute timestamps in need
 // will be checked in el.
-func (el ExtentList) CalculateDeltas(
-	need ExtentList,
-	step time.Duration,
-) ExtentList {
+func (el ExtentList) CalculateDeltas(needs ExtentList,
+	step time.Duration) ExtentList {
 	sort.Sort(el)
-	sort.Sort(need)
-	out := ExtentList(segments.Diff(el, need, step, segments.Time{}))
+	sort.Sort(needs)
+	out := ExtentList(segments.Diff(el, needs, step, segments.Time{}))
 	out.Compress(step)
 	return out
 }

--- a/pkg/timeseries/extent_list_test.go
+++ b/pkg/timeseries/extent_list_test.go
@@ -883,11 +883,6 @@ func TestSize(t *testing.T) {
 
 func TestCalculateDeltas(t *testing.T) {
 
-	// test when start is after end
-	trq := TimeRangeQuery{Extent: Extent{Start: time.Unix(20, 0),
-		End: time.Unix(10, 0)}, Step: time.Duration(10) * time.Second}
-	ExtentList{Extent{}}.CalculateDeltas(trq.Extent, trq.Step)
-
 	tests := []struct {
 		have                 []Extent
 		expected             []Extent
@@ -918,17 +913,14 @@ func TestCalculateDeltas(t *testing.T) {
 
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-
-			trq := TimeRangeQuery{Statement: "up", Extent: Extent{Start: time.Unix(test.start, 0),
-				End: time.Unix(test.end, 0)}, Step: time.Duration(test.stepSecs) * time.Second}
-			trq.NormalizeExtent()
-			d := ExtentList(test.have).CalculateDeltas(trq.Extent, trq.Step)
-
+			d := ExtentList(test.have).CalculateDeltas(
+				ExtentList{{Start: time.Unix(test.start, 0), End: time.Unix(test.end, 0)}},
+				time.Duration(test.stepSecs)*time.Second,
+			)
 			if len(d) != len(test.expected) {
 				t.Errorf("expected %v got %v", test.expected, d)
 				return
 			}
-
 			for i := range d {
 				if d[i].Start != test.expected[i].Start {
 					t.Errorf("expected %d got %d", test.expected[i].Start.Unix(), d[i].Start.Unix())
@@ -1198,7 +1190,7 @@ func BenchmarkCalculateDeltas(b *testing.B) {
 	b.ResetTimer()
 	var r ExtentList
 	for i := 0; i < b.N; i++ {
-		r = haves[i].CalculateDeltas(wants[i], bmTimeStep)
+		r = haves[i].CalculateDeltas(ExtentList{wants[i]}, bmTimeStep)
 	}
 	res = r
 }

--- a/release.mk
+++ b/release.mk
@@ -1,0 +1,68 @@
+# Copyright 2018 The Trickster Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# -----------------------------------------------------------------------------
+# Targets for building and releasing Trickster to be triggered by Trickster maintainers.
+#
+# Create a new tag and push it to the remote repository
+#
+# Note(s): 
+# The CI/CD workflow is responsible for creating a release for the tag.
+# Recommend to run from the master branch of the upstream trickster repository.
+
+TAG_VERSION ?= 
+.PHONY: create-tag
+create-tag:
+	@if [ -z "$(TAG_VERSION)" ]; then echo "TAG_VERSION is not set"; exit 1; fi
+	@echo "FYI: the last proper tag was: $(shell $(MAKE) last-proper)"
+	@echo "FYI: the last beta tag was: $(shell $(MAKE) last-beta)"
+	@if ! echo $(TAG_VERSION) | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+(-beta[0-9]+)?$$'; then \
+		echo "TAG_VERSION must be a semver (e.g. v1.2.3 or v1.2.3-beta1)"; \
+		exit 1; \
+	fi
+	@if $(MAKE) get-tags | grep -qE "^$(TAG_VERSION)$$"; then \
+		echo "Tag $(TAG_VERSION) already exists"; \
+		exit 1; \
+	fi
+	@read -p "Create tag $(TAG_VERSION)? [y/N] " yn; \
+	if [ "$$yn" != "y" ]; then \
+		echo "Aborting"; \
+		exit 1; \
+	fi
+	git tag $(TAG_VERSION)
+	git push origin $(TAG_VERSION)
+
+# List out all tags in the repository
+.PHONY: get-tags
+get-tags:
+	@git tag -l | sort
+
+# List out all tags in the repository matching the given pattern
+# Example: make get-beta
+.PHONY: get-%
+get-%:
+# special case: return all tags
+	@if [[ "$*" == "all" ]]; then $(MAKE) get-tags; exit 0;	fi
+# special case: return all "proper" (non-beta/rc) tags
+	@if [[ "$*" == "proper" ]]; then $(MAKE) get-tags | grep -vE "beta|rc" || true; exit 0; fi
+# else, beta, rc, etc.
+	@$(MAKE) get-tags | grep "$*" || true
+
+# Get the last tag matching the given pattern (e.g. last beta)
+last-%:
+	@export LAST="$(shell $(MAKE) get-$* | tail -n 1)"; \
+		if [ -z "$$LAST" ]; then \
+			echo "No tags found for $*"; \
+			exit 1; \
+		fi; \
+		echo $$LAST


### PR DESCRIPTION
adds a `segments` package that provides a single generic `Diff` function for all slices that have structs w/ start/ends. `Diff` replaces the difference logic in all the various `CalculateDelta[s]`.

- [x] Segments Package w/ Generic `Diff()`
- [x] time.Time and Int64 Diffable implementations 
- [x] timeseries.ExtentList working / tests passing
- [x] standardize on `CalculateDeltas` (plural) and use` haves.CalculateDeltas(needs)` and not `needs.CalculateDeltas(haves)`
- [x] byterange.Ranges working / tests passing