### PR TITLE
add Request Body Size Limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Trickster is a fully-featured HTTP Reverse Proxy Cache for HTTP applications lik
 * Best-in-class [Byte Range Request caching and acceleration](./docs/range_request.md).
 * [Distributed Tracing](./docs/tracing.md) via OpenTelemetry, supporting OTLP and Zipkin
 * Rules engine for custom request routing and rewriting
+* Configurable [maximum request body size](./docs/body.md).
 
 ## Time Series Database Accelerator
 

--- a/docs/body.md
+++ b/docs/body.md
@@ -1,0 +1,20 @@
+# Request Body Handling Customizations
+
+## Request Body Size Limiter
+
+By default, the max allowed Request Body size is 10 MB. If the client request
+body in a POST, PUT or PATCH are over 10 MB, the request will receive a
+response of `413 Request Payload is too large`
+
+You can change (or bypass) this limit in Frontend Config Section:
+
+```yaml
+frontend:
+    max_request_body_size_bytes: 5000 # request bodies must be <= 5kb or returns 413
+```
+
+```yaml
+frontend:
+    max_request_body_size_bytes: 5000 # request bodies > 5kb truncated to 5kb
+    truncate_request_body_too_large: true
+```

--- a/docs/body.md
+++ b/docs/body.md
@@ -10,11 +10,11 @@ You can change (or bypass) this limit in Frontend Config Section:
 
 ```yaml
 frontend:
-    max_request_body_size_bytes: 5000 # request bodies must be <= 5kb or returns 413
+  max_request_body_size_bytes: 5120 # request bodies must be <= 5kb or returns 413
 ```
 
 ```yaml
 frontend:
-    max_request_body_size_bytes: 5000 # request bodies > 5kb truncated to 5kb
-    truncate_request_body_too_large: true
+  max_request_body_size_bytes: 5120 # request bodies > 5kb truncated to 5kb
+  truncate_request_body_too_large: true # truncate request bodies that are too large
 ```

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -46,8 +46,17 @@ frontend:
 #   # 0 by default, unlimited.
 #   connections_limit: 0
 
-#  # reader_header_timeout defines is the amount of time allowed to read request headers by the frontend http proxy server
+#  # reader_header_timeout defines the amount of time allowed to read request headers by the frontend http proxy server
 #  # read_header_timeout: 10s
+
+#  # max_request_body_size_bytes indicates the maximum allowed size of the request body. If the body is too large,
+#  # Trickster responds with 413 Payload Too Large. Use 0 for no body allowed, and < 0 for no maximum. Default: 10MB
+#  # max_request_body_size_bytes: 10485760
+
+#  # truncate_request_body_too_large, when true, will truncate the request body to
+#  # max_request_body_size_bytes when larger, without returning a 413 Payload Too Large
+#  # Default: false
+#  # truncate_request_body_too_large: false
 
 # caches:
 #   default:

--- a/pkg/backends/alb/mech/fr/first_response.go
+++ b/pkg/backends/alb/mech/fr/first_response.go
@@ -26,6 +26,7 @@ import (
 	rt "github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
 )
 
@@ -113,7 +114,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			wm := newFirstResponseGate(w, wc, j, h.fgr)
-			r2 := r.Clone(wc.contexts[j])
+			r2, _ := request.Clone(r)
+			r2 = r2.WithContext(wc.contexts[j])
 			hl[j].ServeHTTP(wm, r2)
 			wg.Done()
 		}(i)

--- a/pkg/backends/alb/mech/nlm/newest_last_modified.go
+++ b/pkg/backends/alb/mech/nlm/newest_last_modified.go
@@ -29,6 +29,7 @@ import (
 	rt "github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/util/atomicx"
 )
 
@@ -91,7 +92,8 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 			nrg := newNewestResponseGate(w, j, nrm)
-			r2 := r.Clone(nrm.contexts[j])
+			r2, _ := request.Clone(r)
+			r2 = r2.WithContext(nrm.contexts[j])
 			hl[j].ServeHTTP(nrg, r2)
 			wg.Done()
 		}(i)

--- a/pkg/backends/alb/mech/tsm/time_series_merge.go
+++ b/pkg/backends/alb/mech/tsm/time_series_merge.go
@@ -126,6 +126,10 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	mgs := GetResponseGates(w, r, hl)
+	if len(mgs) == 0 {
+		failures.HandleBadGateway(w, r)
+		return
+	}
 	SetStatusHeader(w, mgs)
 
 	rsc := request.GetResources(mgs[0].Request)
@@ -158,7 +162,7 @@ func GetResponseGates(w http.ResponseWriter, r *http.Request, hl []http.Handler)
 		}(i)
 	}
 	wg.Wait()
-	return mgs
+	return mgs.Compress()
 }
 
 // SetStatusHeader inspects the X-Trickster-Result header value crafted for each mergeable response

--- a/pkg/backends/options/defaults.go
+++ b/pkg/backends/options/defaults.go
@@ -58,8 +58,8 @@ const (
 	DefaultMaxIdleConns = 20
 	// DefaultForwardedHeaders defines which class of 'Forwarded' headers are attached to upstream requests
 	DefaultForwardedHeaders = "standard"
-	// DefaullALBMechansimName defines the default ALB Mechanism Name
-	DefaullALBMechansimName = "rr" // round robin
+	// DefaultALBMechansimName defines the default ALB Mechanism Name
+	DefaultALBMechansimName = "rr" // round robin
 	// DefaultTimeseriesShardSize defines the default shard size of 0 (no sharding)
 	DefaultTimeseriesShardSize = 0
 	// DefaultTimeseriesShardStep defines the default shard step of 0 (no sharding)

--- a/pkg/backends/options/defaults.go
+++ b/pkg/backends/options/defaults.go
@@ -58,8 +58,8 @@ const (
 	DefaultMaxIdleConns = 20
 	// DefaultForwardedHeaders defines which class of 'Forwarded' headers are attached to upstream requests
 	DefaultForwardedHeaders = "standard"
-	// DefaultALBMechansimName defines the default ALB Mechanism Name
-	DefaultALBMechansimName = "rr" // round robin
+	// DefaultALBMechanismName defines the default ALB Mechanism Name
+	DefaultALBMechanismName = "rr" // round robin
 	// DefaultTimeseriesShardSize defines the default shard size of 0 (no sharding)
 	DefaultTimeseriesShardSize = 0
 	// DefaultTimeseriesShardStep defines the default shard step of 0 (no sharding)

--- a/pkg/backends/prometheus/url.go
+++ b/pkg/backends/prometheus/url.go
@@ -17,12 +17,12 @@
 package prometheus
 
 import (
-	"context"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/params"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
@@ -38,7 +38,7 @@ func (c *Client) SetExtent(r *http.Request, _ *timeseries.TimeRangeQuery,
 // FastForwardRequest returns an *http.Request crafted to collect Fast Forward
 // data from the Origin, based on the provided HTTP Request
 func (c *Client) FastForwardRequest(r *http.Request) (*http.Request, error) {
-	nr := r.Clone(context.Background())
+	nr, _ := request.Clone(r)
 	if strings.HasSuffix(nr.URL.Path, "/query_range") {
 		nr.URL.Path = nr.URL.Path[0 : len(nr.URL.Path)-6]
 	}

--- a/pkg/backends/prometheus/url_test.go
+++ b/pkg/backends/prometheus/url_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	"github.com/trickstercache/trickster/v2/pkg/config"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/urls"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
@@ -99,6 +100,7 @@ func TestFastForwardURL(t *testing.T) {
 
 	u := &url.URL{Path: "/query_range", RawQuery: "q=up&start=1&end=1&step=1"}
 	r, _ := http.NewRequest(http.MethodGet, u.String(), nil)
+	r = request.SetResources(r, &request.Resources{})
 
 	r2, err := pc.FastForwardRequest(r)
 	if err != nil {
@@ -112,6 +114,7 @@ func TestFastForwardURL(t *testing.T) {
 	r2.URL.RawQuery = ""
 	b := bytes.NewBufferString(expected)
 	r, _ = http.NewRequest(http.MethodPost, r2.URL.String(), b)
+	r = request.SetResources(r, &request.Resources{})
 
 	_, err = pc.FastForwardRequest(r)
 	if err != nil {

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -38,6 +38,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/validate"
 	"github.com/trickstercache/trickster/v2/pkg/daemon/instance"
 	te "github.com/trickstercache/trickster/v2/pkg/errors"
+	"github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
@@ -150,7 +151,11 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 		return err
 	}
 	alb.StartALBPools(backends, si.HealthChecker.Statuses())
-	routing.RegisterDefaultBackendRoutes(r, backends, tracers)
+	maxRequestBodySizeBytes := options.DefaultMaxRequestBodySizeBytes
+	if newConf.Frontend.MaxRequestBodySizeBytes != nil {
+		maxRequestBodySizeBytes = *newConf.Frontend.MaxRequestBodySizeBytes
+	}
+	routing.RegisterDefaultBackendRoutes(r, backends, tracers, maxRequestBodySizeBytes)
 	routing.RegisterHealthHandler(mr, newConf.MgmtConfig.HealthHandlerPath, si.HealthChecker)
 	applyListenerConfigs(newConf, si.Config, r, rh, mr, tracers, backends, errorFunc)
 

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -38,7 +38,6 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/validate"
 	"github.com/trickstercache/trickster/v2/pkg/daemon/instance"
 	te "github.com/trickstercache/trickster/v2/pkg/errors"
-	"github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
@@ -151,11 +150,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 		return err
 	}
 	alb.StartALBPools(backends, si.HealthChecker.Statuses())
-	maxRequestBodySizeBytes := options.DefaultMaxRequestBodySizeBytes
-	if newConf.Frontend.MaxRequestBodySizeBytes != nil {
-		maxRequestBodySizeBytes = *newConf.Frontend.MaxRequestBodySizeBytes
-	}
-	routing.RegisterDefaultBackendRoutes(r, backends, tracers, maxRequestBodySizeBytes)
+	routing.RegisterDefaultBackendRoutes(r, newConf, backends, tracers)
 	routing.RegisterHealthHandler(mr, newConf.MgmtConfig.HealthHandlerPath, si.HealthChecker)
 	applyListenerConfigs(newConf, si.Config, r, rh, mr, tracers, backends, errorFunc)
 

--- a/pkg/frontend/options/defaults.go
+++ b/pkg/frontend/options/defaults.go
@@ -38,8 +38,3 @@ const (
 	DefaultMaxRequestBodySizeBytes int64 = 10 * 1024 * 1024 // 10 MB
 
 )
-
-func DefaultMaxRequestBodySizeBytesRef() *int64 {
-	i := DefaultMaxRequestBodySizeBytes
-	return &i
-}

--- a/pkg/frontend/options/defaults.go
+++ b/pkg/frontend/options/defaults.go
@@ -33,4 +33,10 @@ const (
 
 	// DefaultReadHeaderTimeout is the default amount of time allowed to read request headers by the frontend proxy server
 	DefaultReadHeaderTimeout = 10 * time.Second
+
+	// DefaultMaxRequestBodySizeBytes is the default maximum body size permitted by clients in a POST, PUT or PATCH request
+	DefaultMaxRequestBodySizeBytes int64 = 10 * 1024 * 1024 // 10 MB
+
 )
+
+var defaultMaxRequestBodySizeBytes = DefaultMaxRequestBodySizeBytes

--- a/pkg/frontend/options/defaults.go
+++ b/pkg/frontend/options/defaults.go
@@ -39,4 +39,7 @@ const (
 
 )
 
-var defaultMaxRequestBodySizeBytes = DefaultMaxRequestBodySizeBytes
+func DefaultMaxRequestBodySizeBytesRef() *int64 {
+	i := DefaultMaxRequestBodySizeBytes
+	return &i
+}

--- a/pkg/frontend/options/options.go
+++ b/pkg/frontend/options/options.go
@@ -34,9 +34,14 @@ type Options struct {
 	TLSListenPort int `yaml:"tls_listen_port,omitempty"`
 	// ConnectionsLimit indicates how many concurrent front end connections trickster will handle at any time
 	ConnectionsLimit int `yaml:"connections_limit,omitempty"`
-	// MaxRequestBodySize indicates the maximum allowed size of the request body. If the body is too large,
-	// Trickster will return a 413 Payload Too Large response. Use 0 for no body allowed, and < 0 for no maximum.
+	// MaxRequestBodySize indicates the maximum allowed size of the request body.
+	// If the body is too large. Trickster will truncate the payload or return a
+	// 413 Payload Too Large response depending upon truncate_request_body_too_big.
+	// Use 0 for no body allowed, and < 0 for no maximum.
 	MaxRequestBodySizeBytes *int64 `yaml:"max_request_body_size_bytes"`
+	// TruncateRequestBodyTooLarge, when true, will truncate the request body to
+	// MaxRequestBodySizeBytes when larger, without returning a 413 Payload Too Large
+	TruncateRequestBodyTooLarge bool `yaml:"truncate_request_body_too_large"`
 	// ReadHeaderTimeout is the amount of time allowed to read request headers.
 	ReadHeaderTimeout time.Duration `yaml:"read_header_timeout,omitempty"`
 	// ServeTLS indicates whether to listen and serve on the TLS port, meaning
@@ -54,7 +59,7 @@ func New() *Options {
 		TLSListenPort:           DefaultTLSProxyListenPort,
 		TLSListenAddress:        DefaultTLSProxyListenAddress,
 		ReadHeaderTimeout:       DefaultReadHeaderTimeout,
-		MaxRequestBodySizeBytes: &defaultMaxRequestBodySizeBytes,
+		MaxRequestBodySizeBytes: DefaultMaxRequestBodySizeBytesRef(),
 	}
 }
 
@@ -85,7 +90,7 @@ func (o *Options) Validate(f TLSConfigFunc) error {
 		return err
 	}
 	if o.MaxRequestBodySizeBytes == nil {
-		o.MaxRequestBodySizeBytes = &defaultMaxRequestBodySizeBytes
+		o.MaxRequestBodySizeBytes = DefaultMaxRequestBodySizeBytesRef()
 	}
 	return nil
 }

--- a/pkg/frontend/options/options.go
+++ b/pkg/frontend/options/options.go
@@ -71,13 +71,14 @@ func (o *Options) Equal(o2 *Options) bool {
 // Clone returns a clone of the Options
 func (o *Options) Clone() *Options {
 	return &Options{
-		ListenAddress:           o.ListenAddress,
-		ListenPort:              o.ListenPort,
-		TLSListenAddress:        o.TLSListenAddress,
-		TLSListenPort:           o.TLSListenPort,
-		ConnectionsLimit:        o.ConnectionsLimit,
-		ServeTLS:                o.ServeTLS,
-		MaxRequestBodySizeBytes: o.MaxRequestBodySizeBytes,
+		ListenAddress:               o.ListenAddress,
+		ListenPort:                  o.ListenPort,
+		TLSListenAddress:            o.TLSListenAddress,
+		TLSListenPort:               o.TLSListenPort,
+		ConnectionsLimit:            o.ConnectionsLimit,
+		ServeTLS:                    o.ServeTLS,
+		MaxRequestBodySizeBytes:     o.MaxRequestBodySizeBytes,
+		TruncateRequestBodyTooLarge: o.TruncateRequestBodyTooLarge,
 	}
 }
 

--- a/pkg/frontend/options/options.go
+++ b/pkg/frontend/options/options.go
@@ -20,6 +20,8 @@ import (
 	"crypto/tls"
 	"errors"
 	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 )
 
 // FrontendConfig is a collection of configurations for the main http frontend for the application
@@ -59,7 +61,7 @@ func New() *Options {
 		TLSListenPort:           DefaultTLSProxyListenPort,
 		TLSListenAddress:        DefaultTLSProxyListenAddress,
 		ReadHeaderTimeout:       DefaultReadHeaderTimeout,
-		MaxRequestBodySizeBytes: DefaultMaxRequestBodySizeBytesRef(),
+		MaxRequestBodySizeBytes: pointers.New(DefaultMaxRequestBodySizeBytes),
 	}
 }
 
@@ -91,7 +93,7 @@ func (o *Options) Validate(f TLSConfigFunc) error {
 		return err
 	}
 	if o.MaxRequestBodySizeBytes == nil {
-		o.MaxRequestBodySizeBytes = DefaultMaxRequestBodySizeBytesRef()
+		o.MaxRequestBodySizeBytes = pointers.New(DefaultMaxRequestBodySizeBytes)
 	}
 	return nil
 }

--- a/pkg/frontend/options/options_test.go
+++ b/pkg/frontend/options/options_test.go
@@ -27,6 +27,8 @@ func TestFrontendOptions(t *testing.T) {
 	// expect f1 and f2 to be equal
 	f1 := New()
 	f2 := New()
+	f1.MaxRequestBodySizeBytes = nil
+	f2.MaxRequestBodySizeBytes = nil
 	require.True(t, f1.Equal(f2))
 
 	// expect f1 and f2 to be equal, after modifying f1

--- a/pkg/proxy/engines/key_test.go
+++ b/pkg/proxy/engines/key_test.go
@@ -172,8 +172,8 @@ func TestDeriveCacheKey(t *testing.T) {
 	tr.Header.Set(headers.NameContentLength, strconv.Itoa(len(testMultipartBody)))
 	pr = newProxyRequest(tr, nil)
 	ck = pr.DeriveCacheKey("extra")
-	if ck != "1caeb9fb60f5613ed89d68d5ab8bed99" {
-		t.Errorf("expected %s got %s", "1caeb9fb60f5613ed89d68d5ab8bed99", ck)
+	if ck != "279463f7c59dd2736dc28dc7531208b2" {
+		t.Errorf("expected %s got %s", "279463f7c59dd2736dc28dc7531208b2", ck)
 	}
 
 	_, _, tr, _, _ = tu.NewTestInstance("", nil, 0, "", nil,

--- a/pkg/proxy/handlers/clickhouse/clickhouse.go
+++ b/pkg/proxy/handlers/clickhouse/clickhouse.go
@@ -25,6 +25,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
 )
@@ -64,6 +65,7 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache, cl.DefaultPathConfigs(o), nil)
+	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache,
+		cl.DefaultPathConfigs(o), nil, fo.DefaultMaxRequestBodySizeBytes)
 	return r, nil
 }

--- a/pkg/proxy/handlers/clickhouse/clickhouse.go
+++ b/pkg/proxy/handlers/clickhouse/clickhouse.go
@@ -25,6 +25,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	"github.com/trickstercache/trickster/v2/pkg/config"
 	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
@@ -65,7 +66,8 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache,
-		cl.DefaultPathConfigs(o), nil, fo.DefaultMaxRequestBodySizeBytes)
+	barecfg := &config.Config{Frontend: &fo.Options{MaxRequestBodySizeBytes: fo.DefaultMaxRequestBodySizeBytesRef()}}
+	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache,
+		cl.DefaultPathConfigs(o), nil)
 	return r, nil
 }

--- a/pkg/proxy/handlers/clickhouse/clickhouse.go
+++ b/pkg/proxy/handlers/clickhouse/clickhouse.go
@@ -26,7 +26,7 @@ import (
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
 	"github.com/trickstercache/trickster/v2/pkg/config"
-	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
+	fopt "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
 )
@@ -66,7 +66,7 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	barecfg := &config.Config{Frontend: &fo.Options{MaxRequestBodySizeBytes: fo.DefaultMaxRequestBodySizeBytesRef()}}
+	barecfg := &config.Config{Frontend: &fopt.Options{MaxRequestBodySizeBytes: fopt.DefaultMaxRequestBodySizeBytesRef()}}
 	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache,
 		cl.DefaultPathConfigs(o), nil)
 	return r, nil

--- a/pkg/proxy/handlers/clickhouse/clickhouse.go
+++ b/pkg/proxy/handlers/clickhouse/clickhouse.go
@@ -66,7 +66,7 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	barecfg := &config.Config{Frontend: &fopt.Options{MaxRequestBodySizeBytes: fopt.DefaultMaxRequestBodySizeBytesRef()}}
+	barecfg := &config.Config{Frontend: fopt.New()}
 	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache,
 		cl.DefaultPathConfigs(o), nil)
 	return r, nil

--- a/pkg/proxy/handlers/influxdb/influxdb.go
+++ b/pkg/proxy/handlers/influxdb/influxdb.go
@@ -66,7 +66,7 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	barecfg := &config.Config{Frontend: &fopt.Options{MaxRequestBodySizeBytes: fopt.DefaultMaxRequestBodySizeBytesRef()}}
+	barecfg := &config.Config{Frontend: fopt.New()}
 	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache, cl.DefaultPathConfigs(o), nil)
 	return r, nil
 }

--- a/pkg/proxy/handlers/influxdb/influxdb.go
+++ b/pkg/proxy/handlers/influxdb/influxdb.go
@@ -25,6 +25,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	"github.com/trickstercache/trickster/v2/pkg/config"
 	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
@@ -65,6 +66,7 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache, cl.DefaultPathConfigs(o), nil, fo.DefaultMaxRequestBodySizeBytes)
+	barecfg := &config.Config{Frontend: &fo.Options{MaxRequestBodySizeBytes: fo.DefaultMaxRequestBodySizeBytesRef()}}
+	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache, cl.DefaultPathConfigs(o), nil)
 	return r, nil
 }

--- a/pkg/proxy/handlers/influxdb/influxdb.go
+++ b/pkg/proxy/handlers/influxdb/influxdb.go
@@ -26,7 +26,7 @@ import (
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
 	"github.com/trickstercache/trickster/v2/pkg/config"
-	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
+	fopt "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
 )
@@ -66,7 +66,7 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	barecfg := &config.Config{Frontend: &fo.Options{MaxRequestBodySizeBytes: fo.DefaultMaxRequestBodySizeBytesRef()}}
+	barecfg := &config.Config{Frontend: &fopt.Options{MaxRequestBodySizeBytes: fopt.DefaultMaxRequestBodySizeBytesRef()}}
 	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache, cl.DefaultPathConfigs(o), nil)
 	return r, nil
 }

--- a/pkg/proxy/handlers/influxdb/influxdb.go
+++ b/pkg/proxy/handlers/influxdb/influxdb.go
@@ -25,6 +25,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
 )
@@ -64,6 +65,6 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache, cl.DefaultPathConfigs(o), nil)
+	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache, cl.DefaultPathConfigs(o), nil, fo.DefaultMaxRequestBodySizeBytes)
 	return r, nil
 }

--- a/pkg/proxy/handlers/prometheus/prometheus.go
+++ b/pkg/proxy/handlers/prometheus/prometheus.go
@@ -25,6 +25,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
 )
@@ -64,6 +65,7 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache, cl.DefaultPathConfigs(o), nil)
+	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache,
+		cl.DefaultPathConfigs(o), nil, fo.DefaultMaxRequestBodySizeBytes)
 	return o.Router, nil
 }

--- a/pkg/proxy/handlers/prometheus/prometheus.go
+++ b/pkg/proxy/handlers/prometheus/prometheus.go
@@ -26,7 +26,7 @@ import (
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
 	"github.com/trickstercache/trickster/v2/pkg/config"
-	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
+	fopt "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
 )
@@ -66,7 +66,7 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	barecfg := &config.Config{Frontend: &fo.Options{MaxRequestBodySizeBytes: fo.DefaultMaxRequestBodySizeBytesRef()}}
+	barecfg := &config.Config{Frontend: &fopt.Options{MaxRequestBodySizeBytes: fopt.DefaultMaxRequestBodySizeBytesRef()}}
 	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache,
 		cl.DefaultPathConfigs(o), nil)
 	return o.Router, nil

--- a/pkg/proxy/handlers/prometheus/prometheus.go
+++ b/pkg/proxy/handlers/prometheus/prometheus.go
@@ -66,7 +66,7 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	barecfg := &config.Config{Frontend: &fopt.Options{MaxRequestBodySizeBytes: fopt.DefaultMaxRequestBodySizeBytesRef()}}
+	barecfg := &config.Config{Frontend: fopt.New()}
 	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache,
 		cl.DefaultPathConfigs(o), nil)
 	return o.Router, nil

--- a/pkg/proxy/handlers/prometheus/prometheus.go
+++ b/pkg/proxy/handlers/prometheus/prometheus.go
@@ -25,6 +25,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	"github.com/trickstercache/trickster/v2/pkg/config"
 	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
@@ -65,7 +66,8 @@ func NewAcceleratorWithOptions(baseURL string, o *bo.Options, c *co.Options) (ht
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache,
-		cl.DefaultPathConfigs(o), nil, fo.DefaultMaxRequestBodySizeBytes)
+	barecfg := &config.Config{Frontend: &fo.Options{MaxRequestBodySizeBytes: fo.DefaultMaxRequestBodySizeBytesRef()}}
+	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache,
+		cl.DefaultPathConfigs(o), nil)
 	return o.Router, nil
 }

--- a/pkg/proxy/handlers/rpc/rpc.go
+++ b/pkg/proxy/handlers/rpc/rpc.go
@@ -25,6 +25,7 @@ import (
 	rpc "github.com/trickstercache/trickster/v2/pkg/backends/reverseproxycache"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
 )
@@ -64,6 +65,7 @@ func NewWithOptions(baseURL string, o *bo.Options, c *co.Options) (http.Handler,
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache, cl.DefaultPathConfigs(o), nil)
+	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache,
+		cl.DefaultPathConfigs(o), nil, fo.DefaultMaxRequestBodySizeBytes)
 	return r, nil
 }

--- a/pkg/proxy/handlers/rpc/rpc.go
+++ b/pkg/proxy/handlers/rpc/rpc.go
@@ -25,6 +25,7 @@ import (
 	rpc "github.com/trickstercache/trickster/v2/pkg/backends/reverseproxycache"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	"github.com/trickstercache/trickster/v2/pkg/config"
 	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
@@ -65,7 +66,8 @@ func NewWithOptions(baseURL string, o *bo.Options, c *co.Options) (http.Handler,
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	routing.RegisterPathRoutes(r, cl.Handlers(), cl, o, cache,
-		cl.DefaultPathConfigs(o), nil, fo.DefaultMaxRequestBodySizeBytes)
+	barecfg := &config.Config{Frontend: &fo.Options{MaxRequestBodySizeBytes: fo.DefaultMaxRequestBodySizeBytesRef()}}
+	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache,
+		cl.DefaultPathConfigs(o), nil)
 	return r, nil
 }

--- a/pkg/proxy/handlers/rpc/rpc.go
+++ b/pkg/proxy/handlers/rpc/rpc.go
@@ -66,7 +66,7 @@ func NewWithOptions(baseURL string, o *bo.Options, c *co.Options) (http.Handler,
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	barecfg := &config.Config{Frontend: &fopt.Options{MaxRequestBodySizeBytes: fopt.DefaultMaxRequestBodySizeBytesRef()}}
+	barecfg := &config.Config{Frontend: fopt.New()}
 	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache,
 		cl.DefaultPathConfigs(o), nil)
 	return r, nil

--- a/pkg/proxy/handlers/rpc/rpc.go
+++ b/pkg/proxy/handlers/rpc/rpc.go
@@ -26,7 +26,7 @@ import (
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
 	"github.com/trickstercache/trickster/v2/pkg/config"
-	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
+	fopt "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
 )
@@ -66,7 +66,7 @@ func NewWithOptions(baseURL string, o *bo.Options, c *co.Options) (http.Handler,
 		return nil, err
 	}
 	o.HTTPClient = cl.HTTPClient()
-	barecfg := &config.Config{Frontend: &fo.Options{MaxRequestBodySizeBytes: fo.DefaultMaxRequestBodySizeBytesRef()}}
+	barecfg := &config.Config{Frontend: &fopt.Options{MaxRequestBodySizeBytes: fopt.DefaultMaxRequestBodySizeBytesRef()}}
 	routing.RegisterPathRoutes(r, barecfg, cl.Handlers(), cl, o, cache,
 		cl.DefaultPathConfigs(o), nil)
 	return r, nil

--- a/pkg/proxy/handlers/trickster/failures/failures.go
+++ b/pkg/proxy/handlers/trickster/failures/failures.go
@@ -57,6 +57,16 @@ func HandleNotFound(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte("Resource Not Found"))
 }
 
+// HandlePayloadTooLarge responds to an HTTP Request with a 413 Payload Too Large
+func HandlePayloadTooLarge(w http.ResponseWriter, _ *http.Request) {
+	if w == nil {
+		return
+	}
+	w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
+	w.WriteHeader(http.StatusRequestEntityTooLarge)
+	w.Write([]byte("Request Body is too large"))
+}
+
 // HandleMiscFailure responds to an HTTP Request the provided status code
 func HandleMiscFailure(code int, w http.ResponseWriter) {
 	if w == nil {

--- a/pkg/proxy/handlers/trickster/failures/failures.go
+++ b/pkg/proxy/handlers/trickster/failures/failures.go
@@ -17,10 +17,16 @@
 package failures
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 )
+
+const PayloadTooLargeText = "Request Payload is too large"
+
+var ErrPayloadTooLarge = errors.New(strings.ToLower(PayloadTooLargeText))
 
 // HandleBadRequestResponse responds to an HTTP Request with 400 Bad Request
 func HandleBadRequestResponse(w http.ResponseWriter, _ *http.Request) {
@@ -64,7 +70,7 @@ func HandlePayloadTooLarge(w http.ResponseWriter, _ *http.Request) {
 	}
 	w.Header().Set(headers.NameContentType, headers.ValueTextPlain)
 	w.WriteHeader(http.StatusRequestEntityTooLarge)
-	w.Write([]byte("Request Body is too large"))
+	w.Write([]byte(PayloadTooLargeText))
 }
 
 // HandleMiscFailure responds to an HTTP Request the provided status code

--- a/pkg/proxy/request/body.go
+++ b/pkg/proxy/request/body.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/util/numbers"
 )
 
 func SetBody(r *http.Request, body []byte) {
@@ -55,7 +56,7 @@ func GetBody(r *http.Request, maxSize ...int64) ([]byte, error) {
 	}
 	var stopAt int64 = -1
 	if len(maxSize) > 0 && maxSize[0] >= 0 {
-		stopAt = maxSize[0] + 1
+		stopAt, _ = numbers.SafeAdd64(maxSize[0], 1)
 	}
 	rdr := io.Reader(r.Body)
 	if stopAt > 0 {

--- a/pkg/proxy/request/request.go
+++ b/pkg/proxy/request/request.go
@@ -17,3 +17,36 @@
 // Package request provides functionality for handling HTTP Requests
 // including the insertion of configuration options into the request
 package request
+
+import (
+	"context"
+	"net/http"
+
+	tctx "github.com/trickstercache/trickster/v2/pkg/proxy/context"
+)
+
+// This wrap the builtin clone to have a new deep clone of the request body
+// when present and the Trickstter context data
+func Clone(r *http.Request) (*http.Request, error) {
+	if r == nil {
+		return nil, nil
+	}
+	rsc := GetResources(r)
+	if rsc != nil {
+		rsc = rsc.Clone()
+	}
+	ctx := context.Background()
+	if rsc != nil {
+		ctx = tctx.WithResources(ctx, rsc.Clone())
+	}
+	out := r.Clone(context.Background()).WithContext(ctx)
+	if r.Method == http.MethodPost || r.Method == http.MethodPut ||
+		r.Method == http.MethodPatch {
+		br, err := GetBodyReader(r)
+		if err != nil {
+			return nil, err
+		}
+		out.Body = br
+	}
+	return out, nil
+}

--- a/pkg/proxy/request/request.go
+++ b/pkg/proxy/request/request.go
@@ -39,7 +39,7 @@ func Clone(r *http.Request) (*http.Request, error) {
 	if rsc != nil {
 		ctx = tctx.WithResources(ctx, rsc.Clone())
 	}
-	out := r.Clone(context.Background()).WithContext(ctx)
+	out := r.Clone(ctx)
 	if r.Method == http.MethodPost || r.Method == http.MethodPut ||
 		r.Method == http.MethodPatch {
 		br, err := GetBodyReader(r)

--- a/pkg/proxy/request/request.go
+++ b/pkg/proxy/request/request.go
@@ -25,8 +25,8 @@ import (
 	tctx "github.com/trickstercache/trickster/v2/pkg/proxy/context"
 )
 
-// This wrap the builtin clone to have a new deep clone of the request body
-// when present and the Trickstter context data
+// Clone wraps the builtin Clone to use a deep clone of both the request body
+// reader (when present) and the Trickster context data
 func Clone(r *http.Request) (*http.Request, error) {
 	if r == nil {
 		return nil, nil

--- a/pkg/proxy/request/resources.go
+++ b/pkg/proxy/request/resources.go
@@ -18,6 +18,7 @@ package request
 
 import (
 	"net/http"
+	"slices"
 	"sync"
 	"time"
 
@@ -71,7 +72,7 @@ func (r *Resources) Clone() *Resources {
 		TimeRangeQuery:    r.TimeRangeQuery,
 		Tracer:            r.Tracer,
 		IsMergeMember:     r.IsMergeMember,
-		RequestBody:       r.RequestBody, // shallow copy of slice pointer
+		RequestBody:       slices.Clone(r.RequestBody),
 		ResponseMergeFunc: r.ResponseMergeFunc,
 		TSUnmarshaler:     r.TSUnmarshaler,
 		TSMarshaler:       r.TSMarshaler,
@@ -79,6 +80,7 @@ func (r *Resources) Clone() *Resources {
 		TS:                r.TS,
 		TSReqestOptions:   r.TSReqestOptions,
 		AuthResult:        r.AuthResult, // shallow copy of the auth result
+		AlreadyEncoded:    r.AlreadyEncoded,
 	}
 }
 
@@ -131,4 +133,8 @@ func (r *Resources) Merge(r2 *Resources) {
 	r.TimeRangeQuery = r2.TimeRangeQuery
 	r.Tracer = r2.Tracer
 	r.AuthResult = r2.AuthResult
+
+	r.RequestBody = slices.Clone(r2.RequestBody)
+	r.IsMergeMember = r.IsMergeMember || r2.IsMergeMember
+	r.AlreadyEncoded = r.AlreadyEncoded || r2.AlreadyEncoded
 }

--- a/pkg/proxy/response/merge/merge.go
+++ b/pkg/proxy/response/merge/merge.go
@@ -74,3 +74,16 @@ func (rg *ResponseGate) Write(b []byte) (int, error) {
 	}
 	return len(b), nil
 }
+
+func (rgs ResponseGates) Compress() ResponseGates {
+	out := make(ResponseGates, len(rgs))
+	var k int
+	for _, rg := range rgs {
+		if rg == nil {
+			continue
+		}
+		out[k] = rg
+		k++
+	}
+	return out[:k]
+}

--- a/pkg/proxy/response/merge/merge.go
+++ b/pkg/proxy/response/merge/merge.go
@@ -75,6 +75,7 @@ func (rg *ResponseGate) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
+// Compress removes nil ResponseGates from the slice
 func (rgs ResponseGates) Compress() ResponseGates {
 	out := make(ResponseGates, len(rgs))
 	var k int

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -32,7 +32,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	encoding "github.com/trickstercache/trickster/v2/pkg/encoding/handler"
-	fo "github.com/trickstercache/trickster/v2/pkg/frontend/options"
+	fopt "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
@@ -218,7 +218,7 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 		}
 	}
 
-	maxBodySizeBytes := fo.DefaultMaxRequestBodySizeBytes
+	maxBodySizeBytes := fopt.DefaultMaxRequestBodySizeBytes
 	var truncateOnly bool
 	if conf.Frontend != nil && conf.Frontend.MaxRequestBodySizeBytes != nil {
 		maxBodySizeBytes = *conf.Frontend.MaxRequestBodySizeBytes
@@ -388,8 +388,8 @@ func RegisterDefaultBackendRoutes(r router.Router, conf *config.Config, bknds ba
 
 }
 
-func getSizeLimits(opt *fo.Options) (int64, bool) {
-	maxBodySizeBytes := fo.DefaultMaxRequestBodySizeBytes
+func getSizeLimits(opt *fopt.Options) (int64, bool) {
+	maxBodySizeBytes := fopt.DefaultMaxRequestBodySizeBytes
 	var truncateOnly bool
 	if opt != nil && opt.MaxRequestBodySizeBytes != nil {
 		maxBodySizeBytes = *opt.MaxRequestBodySizeBytes

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -218,15 +218,9 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 		}
 	}
 
-	maxBodySizeBytes := fopt.DefaultMaxRequestBodySizeBytes
-	var truncateOnly bool
-	if conf.Frontend != nil && conf.Frontend.MaxRequestBodySizeBytes != nil {
-		maxBodySizeBytes = *conf.Frontend.MaxRequestBodySizeBytes
-		truncateOnly = conf.Frontend.TruncateRequestBodyTooLarge
-	}
-
 	applyMiddleware := func(po1 *po.Options) http.Handler {
 		// default base route is the path handler
+		maxBodySizeBytes, truncateOnly := getSizeLimits(conf.Frontend)
 		h := bodyfilter.Handler(maxBodySizeBytes, truncateOnly, po1.Handler)
 		// attach distributed tracer
 		if tr != nil {

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -46,7 +46,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/util/middleware"
-	"github.com/trickstercache/trickster/v2/pkg/util/middleware/bodymgr"
+	"github.com/trickstercache/trickster/v2/pkg/util/middleware/bodyfilter"
 )
 
 // RegisterPprofRoutes will register the Pprof Debugging endpoints to the provided router
@@ -181,12 +181,8 @@ func registerBackendRoutes(r router.Router, metricsRouter router.Router,
 
 		h := client.Handlers()
 
-		maxRequestBodySizeBytes := fo.DefaultMaxRequestBodySizeBytes
-		if conf.Frontend.MaxRequestBodySizeBytes != nil {
-			maxRequestBodySizeBytes = *conf.Frontend.MaxRequestBodySizeBytes
-		}
-		RegisterPathRoutes(r, h, client, o, c, defaultPaths,
-			tracers, maxRequestBodySizeBytes)
+		RegisterPathRoutes(r, conf, h, client, o, c, defaultPaths,
+			tracers)
 
 		// now we'll go ahead and register the health handler
 		if h, ok := client.Handlers()["health"]; ok && o.Name != "" && metricsRouter != nil && (o.HealthCheck == nil ||
@@ -207,9 +203,9 @@ func registerBackendRoutes(r router.Router, metricsRouter router.Router,
 // RegisterPathRoutes will take the provided default paths map,
 // merge it with any path data in the provided backend options, and then register
 // the path routes to the appropriate handler from the provided handlers map
-func RegisterPathRoutes(r router.Router, handlers handlers.Lookup,
+func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.Lookup,
 	client backends.Backend, o *bo.Options, c cache.Cache,
-	paths po.Lookup, tracers tracing.Tracers, maxBodySizeBytes int64) {
+	paths po.Lookup, tracers tracing.Tracers) {
 	if o == nil {
 		return
 	}
@@ -222,9 +218,16 @@ func RegisterPathRoutes(r router.Router, handlers handlers.Lookup,
 		}
 	}
 
+	maxBodySizeBytes := fo.DefaultMaxRequestBodySizeBytes
+	var truncateOnly bool
+	if conf.Frontend != nil && conf.Frontend.MaxRequestBodySizeBytes != nil {
+		maxBodySizeBytes = *conf.Frontend.MaxRequestBodySizeBytes
+		truncateOnly = conf.Frontend.TruncateRequestBodyTooLarge
+	}
+
 	applyMiddleware := func(po1 *po.Options) http.Handler {
 		// default base route is the path handler
-		h := bodymgr.Handle(maxBodySizeBytes, po1.Handler)
+		h := bodyfilter.Handler(maxBodySizeBytes, truncateOnly, po1.Handler)
 		// attach distributed tracer
 		if tr != nil {
 			h = middleware.Trace(tr, h)
@@ -319,13 +322,14 @@ func RegisterPathRoutes(r router.Router, handlers handlers.Lookup,
 }
 
 // RegisterDefaultBackendRoutes will iterate the Backends and register the default routes
-func RegisterDefaultBackendRoutes(r router.Router, bknds backends.Backends,
-	tracers tracing.Tracers, maxBodySizeBytes int64) {
+func RegisterDefaultBackendRoutes(r router.Router, conf *config.Config, bknds backends.Backends,
+	tracers tracing.Tracers) {
 
 	applyMiddleware := func(o *bo.Options, po *po.Options, tr *tracing.Tracer,
 		c cache.Cache, client backends.Backend) http.Handler {
 		// default base route is the path handler
-		h := bodymgr.Handle(maxBodySizeBytes, po.Handler)
+		maxBodySizeBytes, truncateOnly := getSizeLimits(conf.Frontend)
+		h := bodyfilter.Handler(maxBodySizeBytes, truncateOnly, po.Handler)
 		// attach distributed tracer
 		if tr != nil {
 			h = middleware.Trace(tr, h)
@@ -382,4 +386,14 @@ func RegisterDefaultBackendRoutes(r router.Router, bknds backends.Backends,
 		}
 	}
 
+}
+
+func getSizeLimits(opt *fo.Options) (int64, bool) {
+	maxBodySizeBytes := fo.DefaultMaxRequestBodySizeBytes
+	var truncateOnly bool
+	if opt != nil && opt.MaxRequestBodySizeBytes != nil {
+		maxBodySizeBytes = *opt.MaxRequestBodySizeBytes
+		truncateOnly = opt.TruncateRequestBodyTooLarge
+	}
+	return maxBodySizeBytes, truncateOnly
 }

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -404,7 +404,7 @@ func TestRegisterMultipleBackendsPlusDefault(t *testing.T) {
 func TestRegisterPathRoutes(t *testing.T) {
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
 	p := po.Lookup{"test": {}}
-	RegisterPathRoutes(nil, nil, nil, nil, nil, p, nil)
+	RegisterPathRoutes(nil, nil, nil, nil, nil, p, nil, 5000)
 
 	conf, err := config.Load([]string{"-log-level", "debug", "-origin-url",
 		"http://1", "-provider", providers.ReverseProxyCacheShort})
@@ -420,7 +420,7 @@ func TestRegisterPathRoutes(t *testing.T) {
 	testHandler := http.HandlerFunc(testutil.BasicHTTPHandler)
 	handlers := handlers.Lookup{"testHandler": testHandler}
 
-	RegisterPathRoutes(nil, handlers, rpc, oo, nil, dpc, nil)
+	RegisterPathRoutes(nil, handlers, rpc, oo, nil, dpc, nil, 5000)
 
 	router := lm.NewRouter()
 	dpc = rpc.DefaultPathConfigs(oo)
@@ -428,7 +428,7 @@ func TestRegisterPathRoutes(t *testing.T) {
 	dpc["/-GET-HEAD"].Handler = testHandler
 	dpc["/-GET-HEAD"].HandlerName = "testHandler"
 	dpc["/-GET-HEAD"].ReqRewriter = testutil.NewTestRewriteInstructions()
-	RegisterPathRoutes(router, handlers, rpc, oo, nil, dpc, nil)
+	RegisterPathRoutes(router, handlers, rpc, oo, nil, dpc, nil, 5000)
 
 }
 
@@ -492,11 +492,11 @@ func TestRegisterDefaultBackendRoutes(t *testing.T) {
 	ri := testutil.NewTestRewriteInstructions()
 	oo.ReqRewriter = ri
 	po1.ReqRewriter = ri
-	RegisterDefaultBackendRoutes(r, b, tr)
+	RegisterDefaultBackendRoutes(r, b, tr, 5000)
 
 	r = lm.NewRouter()
 	po1.MatchType = matching.PathMatchTypeExact
-	RegisterDefaultBackendRoutes(r, b, tr)
+	RegisterDefaultBackendRoutes(r, b, tr, 5000)
 
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
 	l.Close()

--- a/pkg/util/middleware/bodyfilter/bodyfilter.go
+++ b/pkg/util/middleware/bodyfilter/bodyfilter.go
@@ -23,7 +23,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 )
 
-// Handler returns a handler for the BodyFilter, which supports
+// Handler returns a handler for the BodyFilter, which supports limiting the
+// maximum size of a request body.
 func Handler(maxSize int64, truncateOnly bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch && r.Method != http.MethodPost &&
@@ -32,7 +33,6 @@ func Handler(maxSize int64, truncateOnly bool, next http.Handler) http.Handler {
 			return
 		}
 		b, err := request.GetBody(r, maxSize)
-
 		if err != nil && (!truncateOnly || err != failures.ErrPayloadTooLarge) {
 			failures.HandleBadRequestResponse(w, nil)
 			return

--- a/pkg/util/middleware/bodyfilter/bodyfilter.go
+++ b/pkg/util/middleware/bodyfilter/bodyfilter.go
@@ -23,7 +23,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 )
 
-// Handler returns a handler for the BodyManager, which supports
+// Handler returns a handler for the BodyFilter, which supports
 func Handler(maxSize int64, truncateOnly bool, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPatch && r.Method != http.MethodPost &&

--- a/pkg/util/middleware/bodymgr/bodymgr.go
+++ b/pkg/util/middleware/bodymgr/bodymgr.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bodymgr
+
+import (
+	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/failures"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+)
+
+func Handle(maxSize int64, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPatch && r.Method != http.MethodPost &&
+			r.Method != http.MethodPut {
+			next.ServeHTTP(w, r)
+			return
+		}
+		b, err := request.GetBody(r, maxSize)
+		if err != nil {
+			failures.HandleBadRequestResponse(w, nil)
+			return
+		}
+		if int64(len(b)) > maxSize {
+			failures.HandlePayloadTooLarge(w, nil)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/pkg/util/pointers/pointers.go
+++ b/pkg/util/pointers/pointers.go
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pointers
+
+func New[T any](v T) *T {
+	return &v
+}
+
+func Clone[T any](p *T) *T {
+	if p == nil {
+		return nil
+	}
+	v := *p
+	return &v
+}

--- a/pkg/util/pointers/pointers_test.go
+++ b/pkg/util/pointers/pointers_test.go
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pointers
+
+import "testing"
+
+func TestNew(t *testing.T) {
+	const port = 8480
+	intPtr := New(port)
+	if intPtr == nil {
+		t.Fatal("expected non-nil")
+	}
+	if *intPtr != port {
+		t.Fatalf("expected %d got %d", port, *intPtr)
+	}
+	intPtr = Clone(intPtr)
+	if intPtr == nil {
+		t.Fatal("expected non-nil")
+	}
+	if *intPtr != port {
+		t.Fatalf("expected %d got %d", port, *intPtr)
+	}
+	intPtr = nil
+	intPtr = Clone(intPtr)
+	if intPtr != nil {
+		t.Fatal("expected nil")
+	}
+}


### PR DESCRIPTION
This patch fixes #808 and #806 by centralizing reading of the request body to a middleware handler that also implements the size limiter using an `io.LimitReader` as part of the centralized read. The default max request body size is 10MB but can be udpated in the config yaml. This patch also addresses POST-related defects in the ALB due to incompatibilities between the various non-centralized, slightly different DRY body reading implementations that are now refactored.