### PR TITLE
test: add simple integration test

### DIFF
--- a/.github/workflows/ci-build-tests.yml
+++ b/.github/workflows/ci-build-tests.yml
@@ -99,9 +99,19 @@ jobs:
           path-to-profile: .coverprofile
           flag-name: Go-${{ matrix.go }}
           parallel: true
+
+  integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make developer-start integration-test
   finish:
     needs:
       - build
+      - integration
     runs-on: ubuntu-latest
     steps:
       - uses: shogo82148/actions-goveralls@v1

--- a/Makefile
+++ b/Makefile
@@ -122,9 +122,10 @@ GO_TEST_FLAGS ?= -coverprofile=.coverprofile
 .PHONY: test
 test: check-license-headers check-codegen gotest check-fmtprints check-todos
 
+GO_TEST_PATH ?= $(shell $(GO) list ./... | grep -v v2/integration)
 .PHONY: gotest
 gotest:
-	go test -timeout=5m -v ${GO_TEST_FLAGS} ./...
+	$(GO) test -timeout=5m -v ${GO_TEST_FLAGS} $(GO_TEST_PATH)
 
 .PHONY: data-race-test
 data-race-test:
@@ -133,6 +134,10 @@ data-race-test:
 .PHONY: data-race-test-inspect
 data-race-test-inspect:
 	./hack/inspect-race-output.sh race-output.log
+
+.PHONY: integration-test
+integration-test:
+	$(MAKE) -C integration test
 
 .PHONY: bench
 bench:

--- a/cmd/trickster/main.go
+++ b/cmd/trickster/main.go
@@ -18,6 +18,9 @@
 package main
 
 import (
+	"context"
+	"os"
+
 	"github.com/trickstercache/trickster/v2/pkg/appinfo"
 	"github.com/trickstercache/trickster/v2/pkg/daemon"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
@@ -38,7 +41,7 @@ const (
 func main() {
 	appinfo.SetAppInfo(applicationName, applicationVersion,
 		applicationBuildTime, applicationGitCommitID)
-	err := daemon.Start()
+	err := daemon.Start(context.Background(), os.Args[1:]...)
 	if err != nil {
 		logger.Fatal(1, "trickster daemon failed to start",
 			logging.Pairs{"error": err})

--- a/integration/Makefile
+++ b/integration/Makefile
@@ -1,0 +1,14 @@
+GO             ?= go
+
+# Start/Stop the docker-compose environment for integration testing
+developer-start:
+	@$(MAKE) -C .. developer-start
+
+developer-stop:
+	@$(MAKE) -C .. developer-stop
+
+developer-delete:
+	@$(MAKE) -C .. developer-delete
+
+test:
+	$(GO) test -v --failfast

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1,0 +1,57 @@
+package integration
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/trickstercache/trickster/v2/pkg/daemon"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
+// the expected error for Trickster's 'Start' to return
+type expectedStartError struct {
+	ErrorContains *string
+	Error         *error
+}
+
+// start a trickster instance with the provided context (for cancellation), and any args to pass to the daemon.
+func startTrickster(t *testing.T, ctx context.Context, expected expectedStartError, args ...string) {
+	err := daemon.Start(ctx, args...)
+	if expected.Error != nil {
+		require.ErrorIs(t, err, *expected.Error)
+	} else if expected.ErrorContains != nil {
+		require.ErrorContains(t, err, *expected.ErrorContains)
+	} else {
+		require.NoError(t, err)
+	}
+}
+
+// query for prometheus metrics from a Trickster server at the given address.
+func checkTricksterMetrics(t *testing.T, address string) []string {
+	url := "http://" + filepath.Join(address, "metrics")
+	t.Log("Checking Trickster metrics at", url)
+	resp, err := http.Get(url)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "Expected 200 OK from Trickster metrics endpoint")
+	b, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	lines := strings.Split(string(b), "\n")
+	// Filter out comments and empty lines
+	return slices.DeleteFunc(lines, func(s string) bool {
+		if strings.HasPrefix(s, "#") || s == "" {
+			return true
+		}
+		return false
+	})
+}

--- a/integration/trickster_test.go
+++ b/integration/trickster_test.go
@@ -1,0 +1,37 @@
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
+)
+
+// Test Trickster capabilities common to all backends / caches / configurations.
+func TestTrickster(t *testing.T) {
+	t.Run("config not found", func(t *testing.T) {
+		// Simple test to ensure trickster returns an error if its config is not found.
+		ctx := context.Background()
+		expected := expectedStartError{
+			ErrorContains: pointers.New("open testdata/cfg-notfound.yaml: no such file or directory"),
+		}
+		startTrickster(t, ctx, expected, "-config", "testdata/cfg-notfound.yaml")
+	})
+	t.Run("start and stop", func(t *testing.T) {
+		// Simple test to ensure that Trickster can start and be stopped within a test.
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		started := make(chan struct{})
+		go func() { // wait for trickster to start
+			time.Sleep(5 * time.Second) // TODO: remove sleep & return explicit start signal
+			checkTricksterMetrics(t, "localhost:8480")
+			started <- struct{}{}
+		}()
+		go startTrickster(t, ctx, expectedStartError{}, "-config", "../docs/developer/environment/trickster-config/trickster.yaml")
+		<-started
+		t.Log("started...")
+		metrics := checkTricksterMetrics(t, "localhost:8480")
+		t.Log("Trickster metrics:", metrics)
+	})
+}

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -53,11 +53,11 @@ import (
 
 var mtx sync.Mutex
 
-func LoadAndValidate() (*config.Config, error) {
+func LoadAndValidate(args ...string) (*config.Config, error) {
 	mtx.Lock()
 	defer mtx.Unlock()
 	// Load Config
-	cfg, err := config.Load(os.Args[1:])
+	cfg, err := config.Load(args)
 	if err != nil {
 		logger.Error("Could not load configuration:", logging.Pairs{"error": err.Error()})
 		if cfg != nil && cfg.Flags != nil && cfg.Flags.ValidateConfig {


### PR DESCRIPTION
* Extends `pkg/daemon.Start` and `pkg/daemon/signaling` with `context.Context` for cancellation
* Adds an `integration` top-level package and simple test calling equivalent to trickster binary
* Adds a new PR workflow job that runs the integration test

---

To Do:
- [ ] add prometheus backend tests
