### PR TITLE
fix rules panic

### DIFF
--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -17,6 +17,7 @@
 package validate
 
 import (
+	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb"
 	"github.com/trickstercache/trickster/v2/pkg/backends/rule"
 	"github.com/trickstercache/trickster/v2/pkg/cache"
@@ -143,7 +144,7 @@ func Backends(c *config.Config) error {
 	return c.Backends.Validate()
 }
 
-func RoutesRulesAndPools(c *config.Config) error {
+func RoutesRulesAndPools(c *config.Config, clients backends.Backends) error {
 	var caches = make(cache.Lookup)
 	for k := range c.Caches {
 		caches[k] = nil
@@ -155,7 +156,7 @@ func RoutesRulesAndPools(c *config.Config) error {
 	if err != nil {
 		return err
 	}
-	clients, err := routing.RegisterProxyRoutes(c, r, mr, caches, tracers, true)
+	err = routing.RegisterProxyRoutes(c, clients, r, mr, caches, tracers, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/daemon/setup/listeners.go
+++ b/pkg/daemon/setup/listeners.go
@@ -26,14 +26,14 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
+	"github.com/trickstercache/trickster/v2/pkg/observability/pprof"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	ch "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/config"
 	ph "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/purge"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
-	ttls "github.com/trickstercache/trickster/v2/pkg/proxy/tls"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
-	"github.com/trickstercache/trickster/v2/pkg/routing"
+	ttls "github.com/trickstercache/trickster/v2/pkg/proxy/tls"
 )
 
 var lg = listener.NewGroup()
@@ -140,7 +140,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		metricsRouter.RegisterRoute(conf.MgmtConfig.ConfigHandlerPath, nil, nil,
 			false, http.HandlerFunc(ch.HandlerFunc(conf)))
 		if conf.MgmtConfig.PprofServer == "both" || conf.MgmtConfig.PprofServer == "metrics" {
-			routing.RegisterPprofRoutes("metrics", metricsRouter)
+			pprof.RegisterRoutes("metrics", metricsRouter)
 		}
 		go lg.StartListener("metricsListener",
 			conf.Metrics.ListenAddress, conf.Metrics.ListenPort,
@@ -166,7 +166,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		mr.RegisterRoute(conf.MgmtConfig.PurgeByPathHandlerPath, nil, nil,
 			true, http.HandlerFunc(ph.PathHandler(conf.MgmtConfig.PurgeByPathHandlerPath, &o)))
 		if conf.MgmtConfig.PprofServer == "both" || conf.MgmtConfig.PprofServer == "mgmt" {
-			routing.RegisterPprofRoutes("mgmt", mr)
+			pprof.RegisterRoutes("mgmt", mr)
 		}
 		go lg.StartListener("mgmtListener",
 			conf.MgmtConfig.ListenAddress, conf.MgmtConfig.ListenPort,

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/appinfo"
 	"github.com/trickstercache/trickster/v2/pkg/appinfo/usage"
+	"github.com/trickstercache/trickster/v2/pkg/backends"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb"
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/cache/index"
@@ -85,7 +86,7 @@ func LoadAndValidate() (*config.Config, error) {
 }
 
 func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
-	hupFunc dr.Reloader, errorFunc func()) error {
+	clients backends.Backends, hupFunc dr.Reloader, errorFunc func()) error {
 	if si == nil || newConf == nil {
 		return nil
 	}
@@ -125,7 +126,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 
 	var caches = applyCachingConfig(si, newConf)
 	rh := reload.HandlerFunc(hupFunc)
-	backends, err := routing.RegisterProxyRoutes(newConf, r, mr, caches, tracers, false)
+	err = routing.RegisterProxyRoutes(newConf, clients, r, mr, caches, tracers, false)
 	if err != nil {
 		handleStartupIssue("route registration failed",
 			logging.Pairs{"detail": err.Error()}, errorFunc)
@@ -137,7 +138,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	}
 	r.RegisterRoute(newConf.MgmtConfig.PurgeByKeyHandlerPath, nil,
 		[]string{http.MethodDelete}, true,
-		http.HandlerFunc(ph.KeyHandler(newConf.MgmtConfig.PurgeByKeyHandlerPath, backends)))
+		http.HandlerFunc(ph.KeyHandler(newConf.MgmtConfig.PurgeByKeyHandlerPath, clients)))
 
 	if si.Backends != nil {
 		alb.StopPools(si.Backends)
@@ -145,20 +146,20 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	if si.HealthChecker != nil {
 		si.HealthChecker.Shutdown()
 	}
-	si.HealthChecker, err = backends.StartHealthChecks()
+	si.HealthChecker, err = clients.StartHealthChecks()
 	if err != nil {
 		return err
 	}
-	alb.StartALBPools(backends, si.HealthChecker.Statuses())
-	routing.RegisterDefaultBackendRoutes(r, newConf, backends, tracers)
+	alb.StartALBPools(clients, si.HealthChecker.Statuses())
+	routing.RegisterDefaultBackendRoutes(r, newConf, clients, tracers)
 	routing.RegisterHealthHandler(mr, newConf.MgmtConfig.HealthHandlerPath, si.HealthChecker)
-	applyListenerConfigs(newConf, si.Config, r, rh, mr, tracers, backends, errorFunc)
+	applyListenerConfigs(newConf, si.Config, r, rh, mr, tracers, clients, errorFunc)
 
 	metrics.LastReloadSuccessfulTimestamp.Set(float64(time.Now().Unix()))
 	metrics.LastReloadSuccessful.Set(1)
 	si.Config = newConf
 	si.Caches = caches
-	si.Backends = backends
+	si.Backends = clients
 	return nil
 }
 

--- a/pkg/observability/pprof/pprof.go
+++ b/pkg/observability/pprof/pprof.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pprof
+
+import (
+	"net/http"
+	"net/http/pprof"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
+)
+
+// RegisterRoutes will register the Pprof Debugging endpoints to the provided router
+func RegisterRoutes(routerName string, r router.Router) {
+	logger.Info("registering pprof /debug routes", logging.Pairs{"routerName": routerName})
+	r.RegisterRoute("/debug/pprof/", nil, nil,
+		false, http.HandlerFunc(pprof.Index))
+	r.RegisterRoute("/debug/pprof/cmdline", nil, nil,
+		false, http.HandlerFunc(pprof.Cmdline))
+	r.RegisterRoute("/debug/pprof/profile", nil, nil,
+		false, http.HandlerFunc(pprof.Profile))
+	r.RegisterRoute("/debug/pprof/symbol", nil, nil,
+		false, http.HandlerFunc(pprof.Symbol))
+	r.RegisterRoute("/debug/pprof/trace", nil, nil,
+		false, http.HandlerFunc(pprof.Trace))
+}

--- a/pkg/observability/pprof/pprof_test.go
+++ b/pkg/observability/pprof/pprof_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pprof
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
+)
+
+func TestRegisterRoutes(t *testing.T) {
+	logger.SetLogger(logging.ConsoleLogger(level.Info))
+	router := lm.NewRouter()
+	RegisterRoutes("test", router)
+	r, _ := http.NewRequest("GET", "http://0/debug/pprof", nil)
+	h := router.Handler(r)
+	if h == nil {
+		t.Error("expected non-nil handler")
+	}
+}

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -20,7 +20,6 @@ package routing
 import (
 	"fmt"
 	"net/http"
-	"net/http/pprof"
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
@@ -48,21 +47,6 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/util/middleware"
 	"github.com/trickstercache/trickster/v2/pkg/util/middleware/bodyfilter"
 )
-
-// RegisterPprofRoutes will register the Pprof Debugging endpoints to the provided router
-func RegisterPprofRoutes(routerName string, r router.Router) {
-	logger.Info("registering pprof /debug routes", logging.Pairs{"routerName": routerName})
-	r.RegisterRoute("/debug/pprof/", nil, nil,
-		false, http.HandlerFunc(pprof.Index))
-	r.RegisterRoute("/debug/pprof/cmdline", nil, nil,
-		false, http.HandlerFunc(pprof.Cmdline))
-	r.RegisterRoute("/debug/pprof/profile", nil, nil,
-		false, http.HandlerFunc(pprof.Profile))
-	r.RegisterRoute("/debug/pprof/symbol", nil, nil,
-		false, http.HandlerFunc(pprof.Symbol))
-	r.RegisterRoute("/debug/pprof/trace", nil, nil,
-		false, http.HandlerFunc(pprof.Trace))
-}
 
 var noCacheBackends = providers.NonCacheBackends()
 

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -64,19 +64,17 @@ func RegisterPprofRoutes(routerName string, r router.Router) {
 		false, http.HandlerFunc(pprof.Trace))
 }
 
+var noCacheBackends = providers.NonCacheBackends()
+
 // RegisterProxyRoutes iterates the Trickster Configuration and
 // registers the routes for the configured backends
-func RegisterProxyRoutes(conf *config.Config, r router.Router,
-	metricsRouter router.Router, caches cache.Lookup,
-	tracers tracing.Tracers, dryRun bool) (backends.Backends, error) {
+func RegisterProxyRoutes(conf *config.Config, clients backends.Backends,
+	r router.Router, metricsRouter router.Router, caches cache.Lookup,
+	tracers tracing.Tracers, dryRun bool) error {
 
 	// a fake "top-level" backend representing the main frontend, so rules can route
 	// to it via the clients map
-	tlo, _ := reverseproxycache.NewClient("frontend", &bo.Options{}, r, nil, nil, nil)
-
-	// proxyClients maintains a list of proxy clients configured for use by Trickster
-	var clients = backends.Backends{"frontend": tlo}
-	var err error
+	clients["frontend"], _ = reverseproxycache.NewClient("frontend", &bo.Options{}, r, nil, nil, nil)
 
 	defaultBackend := ""
 	var ndo *bo.Options // points to the backend options named "default"
@@ -85,16 +83,14 @@ func RegisterProxyRoutes(conf *config.Config, r router.Router,
 	// This iteration will ensure default backends are handled properly
 	for k, o := range conf.Backends {
 		if !providers.IsValidProvider(o.Provider) {
-			return nil,
-				fmt.Errorf(`unknown backend provider in backend options. backendName: %s, backendProvider: %s`,
-					k, o.Provider)
+			return fmt.Errorf(`unknown backend provider in backend options. backendName: %s, backendProvider: %s`,
+				k, o.Provider)
 		}
 		// Ensure only one default backend exists
 		if o.IsDefault {
 			if cdo != nil {
-				return nil,
-					fmt.Errorf("only one backend can be marked as default. Found both %s and %s",
-						defaultBackend, k)
+				return fmt.Errorf("only one backend can be marked as default. Found both %s and %s",
+					defaultBackend, k)
 			}
 			if !dryRun {
 				logger.Debug("default backend identified", logging.Pairs{"name": k})
@@ -109,10 +105,9 @@ func RegisterProxyRoutes(conf *config.Config, r router.Router,
 			ndo = o
 			continue
 		}
-		err = registerBackendRoutes(r, metricsRouter, conf,
-			k, o, clients, caches, tracers, dryRun)
-		if err != nil {
-			return nil, err
+		if err := registerBackendRoutes(r, metricsRouter, conf,
+			k, o, clients, caches, tracers, dryRun); err != nil {
+			return err
 		}
 	}
 	if ndo != nil {
@@ -121,24 +116,20 @@ func RegisterProxyRoutes(conf *config.Config, r router.Router,
 			cdo = ndo
 			defaultBackend = "default"
 		} else {
-			err = registerBackendRoutes(r, nil, conf, "default", ndo, clients,
-				caches, tracers, dryRun)
-			if err != nil {
-				return nil, err
+			if err := registerBackendRoutes(r, nil, conf, "default", ndo, clients,
+				caches, tracers, dryRun); err != nil {
+				return err
 			}
 		}
 	}
 	if cdo != nil {
-		err = registerBackendRoutes(r, metricsRouter, conf,
-			defaultBackend, cdo, clients, caches, tracers, dryRun)
-		if err != nil {
-			return nil, err
+		if err := registerBackendRoutes(r, metricsRouter, conf,
+			defaultBackend, cdo, clients, caches, tracers, dryRun); err != nil {
+			return err
 		}
 	}
-	return clients, nil
+	return nil
 }
-
-var noCacheBackends = providers.NonCacheBackends()
 
 // RegisterHealthHandler registers the main health handler
 func RegisterHealthHandler(router router.Router, path string,
@@ -149,34 +140,35 @@ func RegisterHealthHandler(router router.Router, path string,
 func registerBackendRoutes(r router.Router, metricsRouter router.Router,
 	conf *config.Config, k string, o *bo.Options, clients backends.Backends,
 	caches cache.Lookup, tracers tracing.Tracers, dryRun bool) error {
-
-	var client backends.Backend
 	var c cache.Cache
-	var ok bool
-	var err error
 
-	if _, ok = noCacheBackends[o.Provider]; !ok {
+	if _, ok := noCacheBackends[o.Provider]; !ok {
 		if c, ok = caches[o.CacheName]; !ok {
 			return fmt.Errorf("could not find cache named [%s]", o.CacheName)
 		}
 	}
 
-	if !dryRun {
+	if dryRun {
+		cf := registry.SupportedProviders()
+		if f, ok := cf[strings.ToLower(o.Provider)]; ok && f != nil {
+			client, err := f(k, o, lm.NewRouter(), c, clients, cf)
+			if err != nil {
+				return err
+			}
+			clients[k] = client
+			o.HTTPClient = client.HTTPClient()
+		}
+	} else {
+		client, ok := clients[k]
+		if !ok || client == nil {
+			return fmt.Errorf("could not find backend client named [%s]", k)
+		}
+		if c != nil {
+			client.SetCache(c)
+		}
 		logger.Info("registering route paths", logging.Pairs{"backendName": k,
 			"backendProvider": o.Provider, "upstreamHost": o.Host})
-	}
 
-	cf := registry.SupportedProviders()
-	if f, ok := cf[strings.ToLower(o.Provider)]; ok && f != nil {
-		client, err = f(k, o, lm.NewRouter(), c, clients, cf)
-	}
-	if err != nil {
-		return err
-	}
-
-	if client != nil && !dryRun {
-		o.HTTPClient = client.HTTPClient()
-		clients[k] = client
 		defaultPaths := client.DefaultPathConfigs(o)
 
 		h := client.Handlers()
@@ -316,8 +308,8 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 }
 
 // RegisterDefaultBackendRoutes will iterate the Backends and register the default routes
-func RegisterDefaultBackendRoutes(r router.Router, conf *config.Config, bknds backends.Backends,
-	tracers tracing.Tracers) {
+func RegisterDefaultBackendRoutes(r router.Router, conf *config.Config,
+	bknds backends.Backends, tracers tracing.Tracers) {
 
 	applyMiddleware := func(o *bo.Options, po *po.Options, tr *tracing.Tracer,
 		c cache.Cache, client backends.Backend) http.Handler {
@@ -364,7 +356,7 @@ func RegisterDefaultBackendRoutes(r router.Router, conf *config.Config, bknds ba
 			for _, p := range o.Paths {
 				if p.Handler != nil && len(p.Methods) > 0 {
 					logger.Debug(
-						"registering default backend handler paths",
+						"registering default backend handler path",
 						logging.Pairs{"backendName": o.Name, "path": p.Path,
 							"handlerName": p.HandlerName,
 							"matchType":   p.MatchType})

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -56,17 +56,6 @@ func newPromClient() backends.Backend {
 
 var promClient = newPromClient()
 
-func TestRegisterPprofRoutes(t *testing.T) {
-	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	router := lm.NewRouter()
-	RegisterPprofRoutes("test", router)
-	r, _ := http.NewRequest("GET", "http://0/debug/pprof", nil)
-	h := router.Handler(r)
-	if h == nil {
-		t.Error("expected non-nil handler")
-	}
-}
-
 func TestRegisterHealthHandler(t *testing.T) {
 	router := lm.NewRouter()
 	path := "/test"

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -19,15 +19,18 @@ package routing
 import (
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
+	"github.com/trickstercache/trickster/v2/pkg/backends/alb"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/clickhouse"
 	"github.com/trickstercache/trickster/v2/pkg/backends/healthcheck"
+	"github.com/trickstercache/trickster/v2/pkg/backends/influxdb"
 	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus"
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	"github.com/trickstercache/trickster/v2/pkg/backends/reverseproxy"
 	"github.com/trickstercache/trickster/v2/pkg/backends/reverseproxycache"
 	"github.com/trickstercache/trickster/v2/pkg/backends/rule"
 	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
@@ -44,8 +47,14 @@ import (
 	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	testutil "github.com/trickstercache/trickster/v2/pkg/testutil"
-	tlstest "github.com/trickstercache/trickster/v2/pkg/testutil/tls"
 )
+
+func newPromClient() backends.Backend {
+	promClient, _ := prometheus.NewClient("default", nil, lm.NewRouter(), nil, nil, nil)
+	return promClient
+}
+
+var promClient = newPromClient()
 
 func TestRegisterPprofRoutes(t *testing.T) {
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
@@ -67,7 +76,6 @@ func TestRegisterHealthHandler(t *testing.T) {
 
 func TestRegisterProxyRoutes(t *testing.T) {
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
-	var proxyClients backends.Backends
 
 	conf, err := config.Load([]string{"-log-level", "debug", "-origin-url", "http://1", "-provider", providers.Prometheus})
 	if err != nil {
@@ -75,7 +83,9 @@ func TestRegisterProxyRoutes(t *testing.T) {
 	}
 	caches := registry.LoadCachesFromConfig(conf)
 	defer registry.CloseCaches(caches)
-	proxyClients, err = RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches, nil, false)
+	proxyClients := backends.Backends{"default": promClient}
+
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches, nil, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -90,7 +100,8 @@ func TestRegisterProxyRoutes(t *testing.T) {
 	o.Hosts = []string{"test", "test2"}
 
 	registry.LoadCachesFromConfig(conf)
-	RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches, tr, false)
+	proxyClients = backends.Backends{"default": promClient}
+	RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches, tr, false)
 
 	if len(proxyClients) == 0 {
 		t.Errorf("expected %d got %d", 1, 0)
@@ -111,33 +122,38 @@ func TestRegisterProxyRoutes(t *testing.T) {
 	conf.Backends["2"] = o2
 
 	router := lm.NewRouter()
-	_, err = RegisterProxyRoutes(conf, router, lm.NewRouter(), caches, tr, false)
+	proxyClients = backends.Backends{"default": promClient}
+	err = RegisterProxyRoutes(conf, proxyClients, router, lm.NewRouter(), caches, tr, false)
 	if err == nil {
 		t.Error("Expected error for too many default backends.")
 	}
 
 	o1.IsDefault = false
 	o1.CacheName = "invalid"
-	_, err = RegisterProxyRoutes(conf, router, lm.NewRouter(), caches, tr, false)
+	proxyClients = backends.Backends{"default": promClient}
+	err = RegisterProxyRoutes(conf, proxyClients, router, lm.NewRouter(), caches, tr, false)
 	if err == nil {
 		t.Errorf("Expected error for invalid cache name")
 	}
 
 	o1.CacheName = o2.CacheName
-	_, err = RegisterProxyRoutes(conf, router, lm.NewRouter(), caches, tr, false)
+	proxyClients = backends.Backends{"default": promClient, "2": promClient}
+	err = RegisterProxyRoutes(conf, proxyClients, router, lm.NewRouter(), caches, tr, false)
 	if err != nil {
 		t.Error(err)
 	}
 
 	o2.IsDefault = false
 	o2.CacheName = "invalid"
-	_, err = RegisterProxyRoutes(conf, router, lm.NewRouter(), caches, tr, false)
+	proxyClients = make(backends.Backends)
+	err = RegisterProxyRoutes(conf, proxyClients, router, lm.NewRouter(), caches, tr, false)
 	if err == nil {
 		t.Errorf("Expected error for invalid cache name")
 	}
 
 	o2.CacheName = "default"
-	_, err = RegisterProxyRoutes(conf, router, lm.NewRouter(), caches, tr, false)
+	proxyClients = backends.Backends{"default": promClient, "2": promClient}
+	err = RegisterProxyRoutes(conf, proxyClients, router, lm.NewRouter(), caches, tr, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -150,9 +166,8 @@ func TestRegisterProxyRoutes(t *testing.T) {
 	conf.Backends["1"] = o1
 	delete(conf.Backends, "default")
 
-	o1.Paths["/-GET-HEAD"].Methods = nil
-
-	_, err = RegisterProxyRoutes(conf, router, lm.NewRouter(), caches, tr, false)
+	proxyClients = backends.Backends{"default": promClient, "1": promClient, "2": promClient}
+	err = RegisterProxyRoutes(conf, proxyClients, router, lm.NewRouter(), caches, tr, false)
 	if err != nil {
 		t.Error(err)
 	}
@@ -169,7 +184,9 @@ func TestRegisterProxyRoutesInflux(t *testing.T) {
 	caches := registry.LoadCachesFromConfig(conf)
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
 	defer registry.CloseCaches(caches)
-	proxyClients, err := RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+	influxClient, _ := influxdb.NewClient("default", nil, lm.NewRouter(), nil, nil, nil)
+	proxyClients := backends.Backends{"default": influxClient}
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err != nil {
 		t.Error(err)
@@ -192,7 +209,9 @@ func TestRegisterProxyRoutesReverseProxy(t *testing.T) {
 	caches := registry.LoadCachesFromConfig(conf)
 	defer registry.CloseCaches(caches)
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	proxyClients, err := RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+	rpClient, _ := reverseproxy.NewClient("default", nil, lm.NewRouter(), nil, nil, nil)
+	proxyClients := backends.Backends{"default": rpClient}
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err != nil {
 		t.Error(err)
@@ -213,7 +232,9 @@ func TestRegisterProxyRoutesClickHouse(t *testing.T) {
 	caches := registry.LoadCachesFromConfig(conf)
 	defer registry.CloseCaches(caches)
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	proxyClients, err := RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+	clickhouseClient, _ := clickhouse.NewClient("default", nil, lm.NewRouter(), nil, nil, nil)
+	proxyClients := backends.Backends{"default": clickhouseClient}
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err != nil {
 		t.Error(err)
@@ -236,7 +257,10 @@ func TestRegisterProxyRoutesALB(t *testing.T) {
 	caches := registry.LoadCachesFromConfig(conf)
 	defer registry.CloseCaches(caches)
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	proxyClients, err := RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+
+	albClient, _ := alb.NewClient("default", nil, lm.NewRouter(), nil, nil, nil)
+	proxyClients := backends.Backends{"default": albClient}
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err != nil {
 		t.Error(err)
@@ -262,7 +286,9 @@ func TestRegisterProxyRoutesWithReqRewriters(t *testing.T) {
 	caches := registry.LoadCachesFromConfig(conf)
 	defer registry.CloseCaches(caches)
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	proxyClients, err := RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+	ruleClient, _ := rule.NewClient("test", nil, lm.NewRouter(), nil, nil, nil)
+	proxyClients := backends.Backends{"test": ruleClient}
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err != nil {
 		t.Error(err)
@@ -285,62 +311,13 @@ func TestRegisterProxyRoutesMultipleDefaults(t *testing.T) {
 	}
 	caches := registry.LoadCachesFromConfig(conf)
 	defer registry.CloseCaches(caches)
-	_, err = RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+	proxyClients := make(backends.Backends)
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err == nil {
 		t.Errorf("expected error `%s` got nothing", expected1)
 	} else if err.Error() != expected1 && err.Error() != expected2 {
 		t.Errorf("expected error `%s` got `%s`", expected1, err.Error())
-	}
-}
-
-func TestRegisterProxyRoutesInvalidCert(t *testing.T) {
-	logger.SetLogger(logging.ConsoleLogger(level.Error))
-	expected := "tls: failed to find any PEM data in certificate input"
-
-	kb, _, _ := tlstest.GetTestKeyAndCert(false)
-
-	td := t.TempDir()
-
-	certfile := td + "/cert.pem"
-	keyfile := td + "/key.pem"
-	confFile := td + "/trickster_test_config.conf"
-
-	err := os.WriteFile(certfile, []byte{}, 0600)
-	if err != nil {
-		t.Error(err)
-	}
-	err = os.WriteFile(keyfile, kb, 0600)
-	if err != nil {
-		t.Error(err)
-	}
-
-	b, err := os.ReadFile("../../testdata/test.bad_tls_cert.routes.conf")
-	if err != nil {
-		t.Error(err)
-	}
-	b = []byte(strings.ReplaceAll(string(b), `../../testdata/test.06.`, td+"/"))
-
-	err = os.WriteFile(confFile, b, 0600)
-	if err != nil {
-		t.Error(err)
-	}
-
-	a := []string{"-config", confFile}
-	conf, err := config.Load(a)
-	if err != nil {
-		t.Fatalf("Could not load configuration: %s", err.Error())
-	}
-	caches := registry.LoadCachesFromConfig(conf)
-	defer registry.CloseCaches(caches)
-	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	_, err = RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
-		nil, false)
-	if err == nil {
-		t.Errorf("expected error: %s", expected)
-	}
-	if err != nil && err.Error() != expected {
-		t.Errorf("expected error: %s, got: %s", expected, err.Error())
 	}
 }
 
@@ -355,7 +332,8 @@ func TestRegisterProxyRoutesBadProvider(t *testing.T) {
 	caches := registry.LoadCachesFromConfig(conf)
 	defer registry.CloseCaches(caches)
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	_, err = RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+	proxyClients := make(backends.Backends)
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err == nil {
 		t.Errorf("expected error `%s` got nothing", expected)
@@ -374,7 +352,8 @@ func TestRegisterMultipleBackends(t *testing.T) {
 	caches := registry.LoadCachesFromConfig(conf)
 	defer registry.CloseCaches(caches)
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	_, err = RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+	proxyClients := backends.Backends{"test": promClient, "test2": promClient}
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err != nil {
 		t.Error(err)
@@ -391,7 +370,8 @@ func TestRegisterMultipleBackendsPlusDefault(t *testing.T) {
 	caches := registry.LoadCachesFromConfig(conf)
 	defer registry.CloseCaches(caches)
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	_, err = RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+	proxyClients := backends.Backends{"default": promClient}
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err != nil {
 		t.Error(err)
@@ -459,7 +439,8 @@ func TestValidateRuleClients(t *testing.T) {
 	o.Provider = providers.Rule
 
 	logger.SetLogger(logging.ConsoleLogger(level.Info))
-	_, err = RegisterProxyRoutes(conf, lm.NewRouter(), lm.NewRouter(), caches,
+	proxyClients := backends.Backends{"default": promClient}
+	err = RegisterProxyRoutes(conf, proxyClients, lm.NewRouter(), lm.NewRouter(), caches,
 		nil, false)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
This PR fixes a panic when using `rule` backends. Fixes #856. The root cause of the panics was due to a change between Beta1 and Beta2 in the ordering of how configurations are loaded and when the http clients for the configured backends are instantiated.

To fix this, the scoping of the instantiated backend clients lookup has been moved into the `daemon` package and is now passed around and shared between the 'dryRun' (validation) setup and the actual running config setup, instead of being instantiated twice (once in validation and once in actual).

Separately, the Pprof routes instantiation has been moved to its own package for separation of concerns.

Ultimately, more streamlining and refinement is needed for this part of the codebase, but since it's generally working we can probably defer to 2.1.