### PR TITLE
refactor: [caches/memory] drop "referenced object" support 

### DIFF
--- a/docs/chunked_caching.md
+++ b/docs/chunked_caching.md
@@ -16,7 +16,6 @@ Chunked caching can be enabled and disabled using `use_cache_chunking`:
 
 ```yaml
 fs1:
-    cache_type: filesystem
     provider: filesystem
     use_cache_chunking: true
     timeseries_chunk_factor: 420
@@ -58,7 +57,6 @@ frontend:
 
 caches:
   mem1:
-    cache_type: memory
     provider: memory
     index:
       max_size_objects: 512

--- a/docs/developer/environment/docker-compose-data/dashboards/trickster-prometheus.json
+++ b/docs/developer/environment/docker-compose-data/dashboards/trickster-prometheus.json
@@ -3,7 +3,10 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -14,10 +17,9 @@
   },
   "description": "Trickster Developer Dashboard for Prometheus",
   "editable": true,
-  "gnetId": 3681,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 2,
-  "iteration": 1588708030077,
+  "id": 5,
   "links": [
     {
       "icon": "question",
@@ -50,8 +52,10 @@
   ],
   "panels": [
     {
-      "content": "<img src=\"https://github.com/trickstercache/trickster/raw/main/docs/images/logos/trickster-logo.svg?sanitize=true\" height=\"90\" />\n",
-      "datasource": "${DS_PROMETHEUS}",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 3,
         "w": 1,
@@ -59,112 +63,183 @@
         "y": 0
       },
       "id": 80,
-      "mode": "html",
-      "timeFrom": null,
-      "timeShift": null,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "<img src=\"https://github.com/trickstercache/trickster/raw/main/docs/images/logos/trickster-logo.svg?sanitize=true\" height=\"90\" />\n",
+        "mode": "html"
+      },
+      "pluginVersion": "11.6.0",
       "title": "",
       "transparent": true,
       "type": "text"
     },
     {
-      "cacheTimeout": null,
-      "colorBackground": false,
-      "colorPostfix": false,
-      "colorValue": true,
-      "colors": [
-        "#d44a3a",
-        "rgba(237, 129, 40, 0.89)",
-        "#299c46"
-      ],
-      "datasource": "$datasource",
-      "format": "none",
-      "gauge": {
-        "maxValue": 100,
-        "minValue": 0,
-        "show": false,
-        "thresholdLabels": false,
-        "thresholdMarkers": true
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            },
+            {
+              "options": {
+                "0": {
+                  "text": "✗"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "1": {
+                  "text": "✓"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a"
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0.1
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
       },
       "gridPos": {
         "h": 3,
-        "w": 1,
+        "w": 2,
         "x": 1,
         "y": 0
       },
       "id": 82,
-      "interval": null,
-      "links": [],
-      "mappingType": 1,
-      "mappingTypes": [
-        {
-          "name": "value to text",
-          "value": 1
-        },
-        {
-          "name": "range to text",
-          "value": 2
-        }
-      ],
       "maxDataPoints": 100,
-      "nullPointMode": "connected",
-      "nullText": null,
-      "pluginVersion": "6.4.2",
-      "postfix": "",
-      "postfixFontSize": "50%",
-      "prefix": "",
-      "prefixFontSize": "50%",
-      "rangeMaps": [
-        {
-          "from": "null",
-          "text": "N/A",
-          "to": "null"
-        }
-      ],
-      "sparkline": {
-        "fillColor": "rgba(31, 118, 189, 0.18)",
-        "full": false,
-        "lineColor": "#73BF69",
-        "show": false,
-        "ymax": null,
-        "ymin": null
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
       },
-      "tableColumn": "",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "up{job=\"trickster\"}",
           "instant": true,
           "refId": "A"
         }
       ],
-      "thresholds": "0.1,1",
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Up?",
       "transparent": true,
-      "type": "singlestat",
-      "valueFontSize": "120%",
-      "valueMaps": [
-        {
-          "op": "=",
-          "text": "N/A",
-          "value": "null"
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
         },
-        {
-          "op": "=",
-          "text": "✗",
-          "value": "0"
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 3,
+        "x": 3,
+        "y": 0
+      },
+      "id": 92,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
         },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
         {
-          "op": "=",
-          "text": "✓",
-          "value": "1"
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "go_sched_gomaxprocs_threads{job=\"trickster\"}",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
         }
       ],
-      "valueName": "current"
+      "title": "GOMAXPROCS",
+      "type": "stat"
     },
     {
       "collapsed": false,
-      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
@@ -177,140 +252,218 @@
       "type": "row"
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
-      "fillGradient": 0,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
         "y": 4
       },
-      "hiddenSeries": false,
       "id": 57,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "go_goroutines{job=\"trickster\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Goroutine Total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {
-        "trickster": "yellow"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trickster"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trickster"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
         "y": 4
       },
-      "hiddenSeries": false,
       "id": 84,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "go_memstats_alloc_bytes{job=\"trickster\"}",
           "format": "time_series",
           "intervalFactor": 1,
@@ -318,154 +471,385 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "go_memstats_heap_alloc_bytes{job=\"trickster\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "heap",
           "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Memory Usage",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "decbytes",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
         },
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "go_memstats_sys_bytes{job=\"trickster\"}",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "sys",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "process_resident_memory_bytes{job=\"trickster\"}",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "process",
+          "range": true,
+          "refId": "D"
         }
       ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "Memory Usage",
+      "type": "timeseries"
     },
     {
-      "aliasColors": {
-        "trickster": "super-light-red"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trickster"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "trickster"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 16,
         "y": 4
       },
-      "hiddenSeries": false,
       "id": 63,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
-          "expr": "go_memstats_gc_cpu_fraction{job=\"trickster\"}",
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "rate(process_cpu_seconds_total{job=\"trickster\"}[1m])",
           "format": "time_series",
           "intervalFactor": 1,
+          "legendFormat": "cpu",
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Trickster GC CPU Fraction",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
+      "title": "Trickster CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
       },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
         },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 12
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(go_gc_duration_seconds_sum{job=\"trickster\"}[5m])) / sum(rate(go_gc_duration_seconds_count{job=\"trickster\"}[5m]))",
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
         }
       ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "Go GC Duration (Average)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 12
+      },
+      "id": 93,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(process_network_transmit_bytes_total{job=\"trickster\"}[5m]))",
+          "instant": false,
+          "legendFormat": "TX",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(process_network_receive_bytes_total{job=\"trickster\"}[5m]))",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "RX",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Processed Bytes Last 5m",
+      "type": "timeseries"
     },
     {
       "collapsed": false,
-      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 20
       },
       "id": 68,
       "panels": [],
@@ -473,56 +857,123 @@
       "type": "row"
     },
     {
-      "aliasColors": {
-        "proxy-error": "dark-red",
-        "proxy-only": "rgba(204, 204, 204, 0.8)"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "proxy-error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "proxy-only"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "rgba(204, 204, 204, 0.8)",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 13
+        "y": 21
       },
-      "hiddenSeries": false,
       "id": 61,
-      "interval": "",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "proxy-error"
+        "dataLinks": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
         }
-      ],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(delta(trickster_proxy_requests_total{job=\"trickster\"}[1m])) by (cache_status)",
           "format": "time_series",
           "intervalFactor": 1,
@@ -530,99 +981,115 @@
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Time Series Cache Efficiency - All Caches",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {
-        "default": "light-blue"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
       "description": "",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "default"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-blue",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 13
+        "y": 21
       },
-      "hiddenSeries": false,
       "id": 25,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "sort": "max",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(trickster_cache_usage_bytes{job=\"trickster\"}) by (cache_name)",
           "format": "time_series",
           "interval": "",
@@ -633,100 +1100,114 @@
           "step": 300
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Cache Utilization (# Bytes)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "decimals": 2,
-          "format": "decbytes",
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {
-        "default": "super-light-red"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
       "description": "",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
-      "grid": {},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "default"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 13
+        "y": 21
       },
-      "hiddenSeries": false,
       "id": 64,
-      "legend": {
-        "alignAsTable": false,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "sort": "max",
-        "sortDesc": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 2,
-      "links": [],
-      "nullPointMode": "connected",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(trickster_cache_usage_objects{job=\"trickster\"}) by (cache_name)",
           "format": "time_series",
           "interval": "",
@@ -737,337 +1218,354 @@
           "step": 300
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Cache Utilization (# Objects)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "cumulative"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "none",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {
-        "default": "super-light-yellow"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "default"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 21
+        "y": 29
       },
-      "hiddenSeries": false,
       "id": 15,
-      "legend": {
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(delta(trickster_cache_events_total{event=\"eviction\",job=\"trickster\"}[1m])) by (cache_name)",
           "legendFormat": "{{cache_name}}",
           "refId": "B"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Cache Object Evictions",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "none",
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {
-        "default": "super-light-yellow"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "default"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 21
+        "y": 29
       },
-      "hiddenSeries": false,
       "id": 77,
-      "legend": {
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(delta(trickster_cache_operation_bytes_total{job=\"trickster\"}[1m])) by (cache_name, operation)",
           "legendFormat": "{{cache_name}} - {{operation}}",
           "refId": "B"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Cache Operations (Bytes)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "none",
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {
-        "default": "super-light-yellow"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
       "description": "",
-      "editable": true,
-      "error": false,
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "default"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 21
+        "y": 29
       },
-      "hiddenSeries": false,
       "id": 78,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": true,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(delta(trickster_cache_operation_objects_total{job=\"trickster\"}[1m])) by (cache_name, operation)",
           "legendFormat": "{{cache_name}} - {{operation}}",
           "refId": "B"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Cache Operations (Objects)",
-      "tooltip": {
-        "msResolution": false,
-        "shared": true,
-        "sort": 2,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "none",
-          "label": "",
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
       "collapsed": false,
-      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 37
       },
       "id": 70,
       "panels": [],
@@ -1075,50 +1573,108 @@
       "type": "row"
     },
     {
-      "aliasColors": {
-        "sim1 - 5xx": "dark-red"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "sim1 - 5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 30
+        "y": 38
       },
-      "hiddenSeries": false,
       "id": 71,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(idelta(trickster_frontend_requests_total{job=\"trickster\",job=\"trickster\"}[1m])) by (backend_name, http_status)",
           "format": "time_series",
           "intervalFactor": 1,
@@ -1126,101 +1682,143 @@
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "Trickster Frontend Responses by Origin & Type",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {
-        "prom1": "light-purple",
-        "total": "dark-green"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "prom1"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "total"
+            },
+            "properties": [
+              {
+                "id": "custom.fillOpacity",
+                "value": 0
+              },
+              {
+                "id": "custom.lineWidth",
+                "value": 2
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 30
+        "y": 38
       },
-      "hiddenSeries": false,
       "id": 72,
-      "interval": "",
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
-      },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [
-        {
-          "alias": "total",
-          "fill": 0,
-          "linewidth": 2
+        "dataLinks": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
         },
-        {}
-      ],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(idelta(trickster_frontend_written_bytes_total{job=\"trickster\",job=\"trickster\"}[1m])) by (backend_name)",
           "format": "time_series",
           "intervalFactor": 1,
@@ -1228,6 +1826,9 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(idelta(trickster_frontend_written_bytes_total{job=\"trickster\",job=\"trickster\"}[1m]))",
           "format": "time_series",
           "intervalFactor": 1,
@@ -1235,95 +1836,157 @@
           "refId": "B"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "# Bytes Written to Frontend by Origin",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "type": "timeseries"
     },
     {
-      "aliasColors": {
-        "accepted": "purple",
-        "failed": "dark-red",
-        "requested": "semi-dark-yellow",
-        "sum(idelta(trickster_proxy_accepted_connections_total{job=\"trickster\"}[1m])) ": "light-purple"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "accepted"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "requested"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-yellow",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "sum(idelta(trickster_proxy_accepted_connections_total{job=\"trickster\"}[1m])) "
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 30
+        "y": 38
       },
-      "hiddenSeries": false,
       "id": 73,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(idelta(trickster_proxy_requested_connections_total{job=\"trickster\"}[1m])) ",
           "format": "time_series",
           "intervalFactor": 1,
@@ -1331,6 +1994,9 @@
           "refId": "B"
         },
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(idelta(trickster_proxy_accepted_connections_total{job=\"trickster\"}[1m])) ",
           "format": "time_series",
           "intervalFactor": 1,
@@ -1338,6 +2004,9 @@
           "refId": "A"
         },
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(idelta(trickster_proxy_closed_connections_total{job=\"trickster\"}[1m])) ",
           "format": "time_series",
           "intervalFactor": 1,
@@ -1345,6 +2014,9 @@
           "refId": "C"
         },
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(idelta(trickster_proxy_failed_connections_total{job=\"trickster\"}[1m])) ",
           "format": "time_series",
           "intervalFactor": 1,
@@ -1352,55 +2024,95 @@
           "refId": "D"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "# Inbound Connections Handled",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
       },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            }
+          }
+        },
+        "overrides": []
       },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 46
+      },
+      "id": 91,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-blue",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Blues",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
           "show": true
         },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "auto",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(increase(trickster_frontend_requests_duration_seconds_bucket{job=\"trickster\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "refId": "A"
         }
       ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "Frontend Request Duration Heatmap",
+      "type": "heatmap"
     },
     {
       "collapsed": false,
-      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 54
       },
       "id": 88,
       "panels": [],
@@ -1408,50 +2120,108 @@
       "type": "row"
     },
     {
-      "aliasColors": {
-        "sum(idelta(trickster_proxy_accepted_connections_total{job=\"trickster\"}[1m])) ": "light-purple"
+      "datasource": {
+        "uid": "$datasource"
       },
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "$datasource",
-      "fill": 1,
-      "fillGradient": 0,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "sum(idelta(trickster_proxy_accepted_connections_total{job=\"trickster\"}[1m])) "
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 39
+        "y": 55
       },
-      "hiddenSeries": false,
       "id": 76,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
       "options": {
-        "dataLinks": []
+        "dataLinks": [],
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
       },
-      "paceLength": 10,
-      "percentage": false,
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
+      "pluginVersion": "11.6.0",
       "targets": [
         {
+          "datasource": {
+            "uid": "$datasource"
+          },
           "expr": "sum(idelta(trickster_proxy_requests_total{job=\"trickster\"}[1m])) by (backend_name)",
           "format": "time_series",
           "intervalFactor": 1,
@@ -1459,71 +2229,107 @@
           "refId": "A"
         }
       ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
       "title": "# Backend Requests Total",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
       },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "scaleDistribution": {
+              "log": 2,
+              "type": "log"
+            }
+          }
+        },
+        "overrides": []
       },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": "0",
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 55
+      },
+      "id": 90,
+      "options": {
+        "calculate": false,
+        "cellGap": 1,
+        "color": {
+          "exponent": 0.5,
+          "fill": "dark-orange",
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Oranges",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
           "show": true
         },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "showColorScale": false,
+          "yHistogram": false
+        },
+        "yAxis": {
+          "axisLabel": "",
+          "axisPlacement": "auto",
+          "reverse": false,
+          "unit": "s"
+        }
+      },
+      "pluginVersion": "11.6.0",
+      "targets": [
         {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": false
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(increase(trickster_proxy_request_duration_seconds_bucket{job=\"trickster\"}[$__rate_interval])) by (le)",
+          "format": "heatmap",
+          "intervalFactor": 1,
+          "legendFormat": "{{le}}",
+          "refId": "A"
         }
       ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
+      "title": "Request Duration Heatmap",
+      "type": "heatmap"
     }
   ],
+  "preload": false,
   "refresh": "5s",
-  "schemaVersion": 22,
-  "style": "dark",
+  "schemaVersion": 41,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": true,
-          "tags": [],
-          "text": "prom-trickster-memory-stdout",
-          "value": "prom-trickster-memory-stdout"
+          "text": "1: Prom | Direct | GET",
+          "value": "ds_prom_direct"
         },
-        "hide": 0,
         "includeAll": false,
         "label": "Prometheus datasource",
-        "multi": false,
         "name": "datasource",
         "options": [],
         "query": "prometheus",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
         "type": "datasource"
       }
     ]
@@ -1532,36 +2338,9 @@
     "from": "now-30m",
     "to": "now"
   },
-  "timepicker": {
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
-  },
+  "timepicker": {},
   "timezone": "browser",
   "title": "Prometheus",
   "uid": "uAJ8w1wZz",
-  "variables": {
-    "list": []
-  },
-  "version": 4
+  "version": 12
 }

--- a/docs/developer/environment/docker-compose-data/grafana-config/provisioning/datasources/datasource.yaml
+++ b/docs/developer/environment/docker-compose-data/grafana-config/provisioning/datasources/datasource.yaml
@@ -73,6 +73,16 @@ datasources:
   editable: true
   jsonData:
     httpMethod: POST
+- name: "8: Trickster | Redis | GET"
+  type: prometheus
+  access: proxy
+  orgId: 1
+  uid: ds_prom_trickster_redis_get
+  url: http://host.docker.internal:8480/prom3
+  version: 1
+  editable: true
+  jsonData:
+    httpMethod: GET
 
 # Mockster (Prom API Simulator)
 - name: sim-direct

--- a/docs/developer/environment/trickster-config/trickster.yaml
+++ b/docs/developer/environment/trickster-config/trickster.yaml
@@ -8,20 +8,17 @@ negative_caches:
     '502': 3s
 caches:
   mem1:
-    cache_type: memory
     provider: memory
-    index:
-      max_size_objects: 512
-      max_size_backoff_objects: 128
   mem2:
-    cache_type: memory
     provider: memory
-    index:
-      max_size_objects: 1024
-      max_size_backoff_objects: 128
   fs1:
-    cache_type: filesystem
     provider: filesystem
+  redis:
+    provider: redis
+    redis:
+      client_type: standard
+      endpoint: localhost:6379
+      protocol: tcp
 request_rewriters:
   remove-accept-encoding:
     instructions:
@@ -114,6 +111,10 @@ backends:
     provider: prometheus
     origin_url: 'http://127.0.0.1:9090'
     cache_name: fs1
+  prom3:
+    provider: prometheus
+    origin_url: 'http://127.0.0.1:9090'
+    cache_name: redis
   flux1:
     provider: influxdb
     origin_url: 'http://127.0.0.1:8186/'

--- a/pkg/backends/alb/pool/health_test.go
+++ b/pkg/backends/alb/pool/health_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestCheckHealth(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	tgt := &Target{
 		hcStatus: &healthcheck.Status{},

--- a/pkg/backends/clickhouse/parsing_test.go
+++ b/pkg/backends/clickhouse/parsing_test.go
@@ -17,7 +17,6 @@
 package clickhouse
 
 import (
-	"context"
 	"errors"
 	"strconv"
 	"testing"
@@ -160,7 +159,7 @@ func TestParseErrors(t *testing.T) {
 
 func TestAtWith(t *testing.T) {
 	tk := token.Tokens{&token.Token{Typ: token.Space, Val: " "}}
-	rs := parsing.NewRunState(context.Background(), tk)
+	rs := parsing.NewRunState(t.Context(), tk)
 	rs.Next()
 	f := atWith(nil, nil, rs)
 	if f != nil {
@@ -168,7 +167,7 @@ func TestAtWith(t *testing.T) {
 	}
 
 	tk = token.Tokens{&token.Token{Typ: sql.TokenWith, Val: "with"}}
-	rs = parsing.NewRunState(context.Background(), tk)
+	rs = parsing.NewRunState(t.Context(), tk)
 	rs.Next()
 	atWith(nil, nil, rs)
 	if rs.Error() != parsing.ErrUnsupportedParser {
@@ -180,7 +179,7 @@ func TestAtWith(t *testing.T) {
 		&token.Token{Typ: sql.TokenSelect, Val: "select"},
 	}
 
-	rs = parsing.NewRunState(context.Background(), tk)
+	rs = parsing.NewRunState(t.Context(), tk)
 	rs.Next()
 	f = atWith(parser, parser, rs)
 	if f == nil {
@@ -191,7 +190,7 @@ func TestAtWith(t *testing.T) {
 		&token.Token{Typ: sql.TokenWith, Val: "with"},
 		&token.Token{Typ: token.EOF},
 	}
-	rs = parsing.NewRunState(context.Background(), tk)
+	rs = parsing.NewRunState(t.Context(), tk)
 	rs.Next()
 	f = atWith(parser, parser, rs)
 	if f != nil {
@@ -203,7 +202,7 @@ func TestAtWith(t *testing.T) {
 		&token.Token{Typ: token.Identifier, Val: "x"},
 		&token.Token{Typ: sql.TokenSelect, Val: "select"},
 	}
-	rs = parsing.NewRunState(context.Background(), tk)
+	rs = parsing.NewRunState(t.Context(), tk)
 	rs.Next()
 	f = atWith(parser, parser, rs)
 	if f != nil {
@@ -215,7 +214,7 @@ func TestAtWith(t *testing.T) {
 }
 
 func TestAtPreWhere(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := atPreWhere(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -230,7 +229,7 @@ func TestAtFormat(t *testing.T) {
 		&token.Token{Typ: sql.TokenComment},
 		&token.Token{Typ: token.EOF},
 	}
-	rs := parsing.NewRunState(context.Background(), tk)
+	rs := parsing.NewRunState(t.Context(), tk)
 	f := atFormat(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -240,7 +239,7 @@ func TestAtFormat(t *testing.T) {
 		&token.Token{Typ: token.Identifier, Val: "UnsupportedFormat"},
 		&token.Token{Typ: token.EOF},
 	}
-	rs = parsing.NewRunState(context.Background(), tk)
+	rs = parsing.NewRunState(t.Context(), tk)
 	f = atFormat(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")

--- a/pkg/backends/healthcheck/healthcheck_test.go
+++ b/pkg/backends/healthcheck/healthcheck_test.go
@@ -17,7 +17,6 @@
 package healthcheck
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -68,7 +67,7 @@ func TestRegister(t *testing.T) {
 		t.Error(err)
 	}
 	target := hc.targets["test"]
-	target.Start(context.Background())
+	target.Start(t.Context())
 	target.Stop()
 	_, err = hc.Register("test", "test", o, http.DefaultClient)
 	if err != nil {

--- a/pkg/backends/healthcheck/target_test.go
+++ b/pkg/backends/healthcheck/target_test.go
@@ -17,7 +17,6 @@
 package healthcheck
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -35,12 +34,12 @@ import (
 )
 
 func TestNewTarget(t *testing.T) {
-	_, err := newTarget(context.Background(), "", "", nil, nil)
+	_, err := newTarget(t.Context(), "", "", nil, nil)
 	if err != ho.ErrNoOptionsProvided {
 		t.Errorf("expected %v got %v", ho.ErrNoOptionsProvided, err)
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	o := ho.New()
 	o.FailureThreshold = -1
 	o.RecoveryThreshold = -1
@@ -234,12 +233,12 @@ func TestProbe(t *testing.T) {
 			httpClient:  ts.Client(),
 			ec:          []int{200},
 		}
-		target.probe(context.Background())
+		target.probe(t.Context())
 		if v := target.successConsecutiveCnt.Load(); v != 1 {
 			t.Error("expected 1 got ", v)
 		}
 		target.ec[0] = 404
-		target.probe(context.Background())
+		target.probe(t.Context())
 		if v := target.successConsecutiveCnt.Load(); v != 0 {
 			t.Error("expected 0 got ", v)
 		}
@@ -254,7 +253,7 @@ func TestProbe(t *testing.T) {
 
 		u, err := url.Parse(ts.URL)
 		require.NoError(t, err)
-		target, err := newTarget(context.Background(), "testprobe", "testprobe", &ho.Options{
+		target, err := newTarget(t.Context(), "testprobe", "testprobe", &ho.Options{
 			Verb:          "GET",
 			Scheme:        u.Scheme,
 			Host:          u.Host,

--- a/pkg/backends/rule/rule_test.go
+++ b/pkg/backends/rule/rule_test.go
@@ -17,7 +17,6 @@
 package rule
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -225,7 +224,7 @@ func TestEvaluateOpArg(t *testing.T) {
 
 	hr, _ := http.NewRequest(http.MethodGet, "http://www.google.com/", nil)
 	hr.Header = http.Header{testRuleHeader: []string{"trickster"}}
-	ctx := tc.WithHops(context.Background(), 0, 20)
+	ctx := tc.WithHops(t.Context(), 0, 20)
 	hr = hr.WithContext(ctx)
 
 	_, _, err = r.EvaluateOpArg(hr)
@@ -277,7 +276,7 @@ func TestEvaluateCaseArg(t *testing.T) {
 
 	hr, _ := http.NewRequest(http.MethodGet, "http://www.google.com/", nil)
 	hr.Header = http.Header{testRuleHeader: []string{providers.Proxy}}
-	ctx := tc.WithHops(context.Background(), 0, 20)
+	ctx := tc.WithHops(t.Context(), 0, 20)
 	hr = hr.WithContext(ctx)
 
 	_, _, err = r.EvaluateCaseArg(hr)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -46,11 +46,8 @@ type Cache interface {
 type Lookup map[string]Cache
 
 // MemoryCache is the interface for an in-memory cache
-// This offers an additional method for storing references to bypass serialization
 type MemoryCache interface {
 	Client
-	StoreReference(cacheKey string, data ReferenceObject, ttl time.Duration) error
-	RetrieveReference(cacheKey string) (any, status.LookupStatus, error)
 }
 
 // ReferenceObject defines an interface for a cache object possessing the ability to report

--- a/pkg/cache/index/client.go
+++ b/pkg/cache/index/client.go
@@ -40,9 +40,7 @@ var (
 	_ cache.MemoryCache = &IndexedClient{}
 )
 
-var (
-	ErrIndexInvalidCacheKey = errors.New("cannot store index")
-)
+var ErrIndexInvalidCacheKey = errors.New("cannot store index")
 
 // IndexedClientOptions modify an IndexedClient's behavior.
 type IndexedClientOptions struct {

--- a/pkg/cache/index/client.go
+++ b/pkg/cache/index/client.go
@@ -42,7 +42,6 @@ var (
 
 var (
 	ErrIndexInvalidCacheKey = errors.New("cannot store index")
-	ErrInvalidCacheBackend  = errors.New("invalid cache backend for reference access")
 )
 
 // IndexedClientOptions modify an IndexedClient's behavior.
@@ -186,26 +185,6 @@ func (idx *IndexedClient) updateIndex(cacheKey string, size int64, la, lw, e tim
 	idx.Objects.Store(cacheKey, obj)
 }
 
-func (idx *IndexedClient) StoreReference(cacheKey string, data cache.ReferenceObject, ttl time.Duration) error {
-	if cacheKey == IndexKey {
-		return ErrIndexInvalidCacheKey
-	}
-	mc, ok := idx.Client.(cache.MemoryCache)
-	if !ok {
-		return ErrInvalidCacheBackend
-	}
-	if err := mc.StoreReference(cacheKey, data, ttl); err != nil {
-		return err
-	}
-	now := time.Now()
-	var expiry time.Time
-	if ttl > 0 {
-		expiry = now.Add(ttl)
-	}
-	idx.updateIndex(cacheKey, int64(data.Size()), now, now, expiry)
-	return nil
-}
-
 func (idx *IndexedClient) Store(cacheKey string, byteData []byte, ttl time.Duration) error {
 	if cacheKey == IndexKey {
 		return ErrIndexInvalidCacheKey
@@ -240,18 +219,6 @@ func (idx *IndexedClient) updateAccessTime(cacheKey string) {
 	obj := o.(*Object)
 	now := time.Now()
 	obj.LastAccess.Store(now)
-}
-
-func (idx *IndexedClient) RetrieveReference(cacheKey string) (any, status.LookupStatus, error) {
-	if cacheKey == IndexKey {
-		return nil, status.LookupStatusError, ErrIndexInvalidCacheKey
-	}
-	mc, ok := idx.Client.(cache.MemoryCache)
-	if !ok {
-		return nil, status.LookupStatusError, ErrInvalidCacheBackend
-	}
-	idx.updateAccessTime(cacheKey)
-	return mc.RetrieveReference(cacheKey)
 }
 
 // Retrieve implements the cache.Client interface, looking up the object and updating the index last access time

--- a/pkg/cache/manager/manager.go
+++ b/pkg/cache/manager/manager.go
@@ -60,14 +60,6 @@ type Manager struct {
 	opts        CacheOptions
 }
 
-func (cm *Manager) StoreReference(cacheKey string, data cache.ReferenceObject, ttl time.Duration) error {
-	nl, _ := cm.locker.Acquire(filepath.Join(cm.config.Name, cm.config.Provider, cacheKey))
-	defer nl.Release()
-	metrics.ObserveCacheOperation(cm.config.Name, cm.config.Provider, "setDirect", "none", float64(data.Size()))
-	logger.Debug("cache store", logging.Pairs{"key": cacheKey, "provider": cm.config.Provider})
-	return cm.Client.(cache.MemoryCache).StoreReference(cacheKey, data, ttl)
-}
-
 func (cm *Manager) Store(cacheKey string, byteData []byte, ttl time.Duration) error {
 	nl, _ := cm.locker.Acquire(filepath.Join(cm.config.Name, cm.config.Provider, cacheKey))
 	defer nl.Release()
@@ -88,16 +80,6 @@ func (cm *Manager) observeRetrieval(cacheKey string, size int, s status.LookupSt
 		logger.Debug("cache retrieve", logging.Pairs{"key": cacheKey, "provider": cm.config.Provider})
 		metrics.ObserveCacheOperation(cm.config.Name, cm.config.Provider, "get", "hit", float64(size))
 	}
-}
-
-func (cm *Manager) RetrieveReference(cacheKey string) (any, status.LookupStatus, error) {
-	nl, _ := cm.locker.RAcquire(filepath.Join(cm.config.Name, cm.config.Provider, cacheKey))
-	defer nl.RRelease()
-	v, s, err := cm.Client.(cache.MemoryCache).RetrieveReference(cacheKey)
-	if ro, ok := v.(cache.ReferenceObject); ok {
-		cm.observeRetrieval(cacheKey, ro.Size(), s, err)
-	}
-	return v, s, err
 }
 
 type retrieveResult struct {

--- a/pkg/cache/manager/manager_test.go
+++ b/pkg/cache/manager/manager_test.go
@@ -20,7 +20,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/cache/memory"
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/cache/status"
@@ -80,22 +79,5 @@ func TestManager(t *testing.T) {
 		require.Equal(t, []byte("baz"), b)
 	})
 
-	t.Run("reference", func(t *testing.T) {
-		mc := c.(cache.MemoryCache)
-		key := "foo"
-		val := object{"bar"}
-		require.NoError(t, mc.StoreReference(key, &val, 0))
-		v, s, err := mc.RetrieveReference(key)
-		require.NoError(t, err)
-		require.Equal(t, status.LookupStatusHit, s)
-		require.Equal(t, val, *v.(*object))
-	})
 }
 
-type object struct {
-	field string
-}
-
-func (o *object) Size() int {
-	return len(o.field)
-}

--- a/pkg/cache/manager/manager_test.go
+++ b/pkg/cache/manager/manager_test.go
@@ -78,6 +78,4 @@ func TestManager(t *testing.T) {
 		require.Equal(t, status.LookupStatusHit, s)
 		require.Equal(t, []byte("baz"), b)
 	})
-
 }
-

--- a/pkg/cache/memory/memory.go
+++ b/pkg/cache/memory/memory.go
@@ -69,8 +69,6 @@ func New(name string, cfg *options.Options) *Cache {
 			switch v := value.(type) {
 			case []byte:
 				return int64(len(v))
-			case cache.ReferenceObject:
-				return int64(v.Size())
 			default:
 				return 1 // fallback for unknown types
 			}
@@ -110,48 +108,23 @@ func (c *Cache) Connect() error {
 	return nil
 }
 
-// StoreReference stores an object directly to the memory cache without requiring serialization
-func (c *Cache) StoreReference(cacheKey string, data cache.ReferenceObject, ttl time.Duration) error {
-	return c.store(cacheKey, nil, data, ttl)
-}
-
 // Store places an object in the cache using the specified key and ttl
 func (c *Cache) Store(cacheKey string, data []byte, ttl time.Duration) error {
-	return c.store(cacheKey, data, nil, ttl)
+	return c.store(cacheKey, data, ttl)
 }
 
-func (c *Cache) store(cacheKey string, byteData []byte, refData cache.ReferenceObject,
-	ttl time.Duration,
-) error {
-	var value any
+func (c *Cache) store(cacheKey string, byteData []byte, ttl time.Duration) error {
 	if byteData != nil {
-		value = byteData
-	} else if refData != nil {
-		value = refData
-	}
-
-	if value != nil {
 		if ttl > 0 {
-			c.client.SetWithTTL(cacheKey, value, 0, ttl) // 0 = use Cost function
+			c.client.SetWithTTL(cacheKey, byteData, 0, ttl) // 0 = use Cost function
 		} else {
-			c.client.Set(cacheKey, value, 0) // 0 = use Cost function
+			c.client.Set(cacheKey, byteData, 0) // 0 = use Cost function
 		}
 		// Wait for buffered write to complete to ensure synchronous semantics
 		c.client.Wait()
 	}
 
 	return nil
-}
-
-// RetrieveReference looks for an object in cache and returns it (or an error if not found)
-func (c *Cache) RetrieveReference(cacheKey string) (any,
-	status.LookupStatus, error,
-) {
-	o, s, err := c.retrieve(cacheKey)
-	if err != nil {
-		return nil, s, err
-	}
-	return o, s, nil
 }
 
 // Retrieve looks for an object in cache and returns it (or an error if not found)

--- a/pkg/cache/memory/memory_test.go
+++ b/pkg/cache/memory/memory_test.go
@@ -34,12 +34,6 @@ const (
 	cacheKey = "cacheKey"
 )
 
-type testReferenceObject struct{}
-
-func (r *testReferenceObject) Size() int {
-	return 1
-}
-
 func storeBenchmark(b *testing.B) *Cache {
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
 	cacheConfig := co.Options{Provider: provider, Index: &io.Options{ReapInterval: 0}}
@@ -70,45 +64,6 @@ func TestCache_Connect(t *testing.T) {
 
 	// it should connect
 	err := mc.Connect()
-	if err != nil {
-		t.Error(err)
-	}
-}
-
-func TestCache_StoreReferenceDirect(t *testing.T) {
-	logger.SetLogger(logging.ConsoleLogger(level.Error))
-	cacheConfig := newCacheConfig()
-	mc := New(t.Name(), &cacheConfig)
-
-	err := mc.Connect()
-	if err != nil {
-		t.Error(err)
-	}
-	// it should store a value
-	mc.StoreReference("test", &testReferenceObject{}, 1*time.Second)
-
-	r, _, _ := mc.RetrieveReference("test")
-	if r == nil {
-		t.Errorf("expected %s got nil", r)
-	}
-
-	_, _, err = mc.RetrieveReference("test2")
-	if err == nil {
-		t.Errorf("expected non-nil error")
-	}
-}
-
-func TestCache_StoreReference(t *testing.T) {
-	logger.SetLogger(logging.ConsoleLogger(level.Error))
-	cacheConfig := newCacheConfig()
-	mc := New(t.Name(), &cacheConfig)
-
-	err := mc.Connect()
-	if err != nil {
-		t.Error(err)
-	}
-	// it should store a value
-	err = mc.StoreReference(cacheKey, nil, time.Duration(60)*time.Second)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/cache/redis/redis_test.go
+++ b/pkg/cache/redis/redis_test.go
@@ -91,10 +91,7 @@ func TestClientSelectionSentinel(t *testing.T) {
 	if !ok {
 		t.Errorf("expected cache named %s", cacheName)
 	}
-	cache := New(context.Background(), cacheName, cfg)
-	if err != nil {
-		t.Error(err)
-	}
+	cache := New(t.Context(), cacheName, cfg)
 	err = cache.Connect()
 	if err == nil {
 		t.Errorf("expected error for %s", expected1)
@@ -170,10 +167,7 @@ func TestClientSelectionCluster(t *testing.T) {
 	if !ok {
 		t.Errorf("expected cache named %s", cacheName)
 	}
-	cache := New(context.Background(), cacheName, cfg)
-	if err != nil {
-		t.Error(err)
-	}
+	cache := New(t.Context(), cacheName, cfg)
 	err = cache.Connect()
 	if err == nil {
 		t.Errorf("expected error for %s", expected1)
@@ -197,7 +191,7 @@ func TestClientSelectionStandard(t *testing.T) {
 	if !ok {
 		t.Errorf("expected cache named %s", cacheName)
 	}
-	cache := New(context.Background(), cacheName, cfg)
+	cache := New(t.Context(), cacheName, cfg)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/encoding/profile/context_test.go
+++ b/pkg/encoding/profile/context_test.go
@@ -17,26 +17,24 @@
 package profile
 
 import (
-	"context"
 	"testing"
 )
 
 func TestContext(t *testing.T) {
-	ctx := context.Background()
 	ep := &Profile{Supported: 8}
-	ctx2 := ToContext(ctx, ep)
+	ctx2 := ToContext(t.Context(), ep)
 
 	ep2 := FromContext(ctx2)
 	if ep2.Supported != 8 {
 		t.Errorf("expected %d got %d", 8, ep2.Supported)
 	}
 
-	ep2 = FromContext(context.Background())
+	ep2 = FromContext(t.Context())
 	if ep2 != nil {
 		t.Error("expected nil")
 	}
 
-	ep2 = FromContext(context.Background())
+	ep2 = FromContext(t.Context())
 	if ep2 != nil {
 		t.Error("expected nil")
 	}

--- a/pkg/observability/tracing/span/span_test.go
+++ b/pkg/observability/tracing/span/span_test.go
@@ -17,7 +17,6 @@
 package span
 
 import (
-	stdcontext "context"
 	"net/http"
 	"testing"
 
@@ -30,7 +29,7 @@ import (
 
 func TestNewChildSpan(t *testing.T) {
 	// test with nil context and tracer:
-	_, span := NewChildSpan(stdcontext.Background(), nil, "test")
+	_, span := NewChildSpan(t.Context(), nil, "test")
 
 	if span != nil {
 		t.Error("expected nil span")
@@ -44,7 +43,7 @@ func TestNewChildSpan(t *testing.T) {
 	tr.Options.Provider = "stdout"
 	options.ProcessTracingOptions(options.Lookup{"default": tr.Options})
 
-	ctx, span := NewChildSpan(stdcontext.Background(), tr, "test")
+	ctx, span := NewChildSpan(t.Context(), tr, "test")
 	if ctx == nil {
 		t.Error("expected non-nil context")
 	}

--- a/pkg/parsing/run_state_test.go
+++ b/pkg/parsing/run_state_test.go
@@ -17,7 +17,6 @@
 package parsing
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -25,7 +24,7 @@ import (
 )
 
 func TestNewRunState(t *testing.T) {
-	rs := NewRunState(context.Background(), nil)
+	rs := NewRunState(t.Context(), nil)
 	if rs == nil {
 		t.Error("expected non-nil run state")
 	}
@@ -37,8 +36,8 @@ func testStateFn(p1, p2 Parser, rs *RunState) StateFn {
 
 func TestRunState(t *testing.T) {
 	v := "trickster"
-	ctx := context.Background()
-	rs := NewRunState(context.Background(), nil).WithContext(ctx)
+	ctx := t.Context()
+	rs := NewRunState(t.Context(), nil).WithContext(ctx)
 	rs.SetResultsCollection("test", v)
 	v2, _ := rs.GetResultsCollection("test")
 	if v3, ok := v2.(string); !ok || v3 != v {
@@ -83,7 +82,7 @@ func TestRunState(t *testing.T) {
 
 	tk := &token.Token{Typ: token.EOF}
 	tokens := token.Tokens{tk}
-	rs = NewRunState(context.Background(), tokens).WithContext(ctx)
+	rs = NewRunState(t.Context(), tokens).WithContext(ctx)
 	rs.Peek()
 	tk2 := rs.Next()
 	if tk2 != tk {

--- a/pkg/parsing/sql/select_test.go
+++ b/pkg/parsing/sql/select_test.go
@@ -17,7 +17,6 @@
 package sql
 
 import (
-	"context"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/parsing"
@@ -26,7 +25,7 @@ import (
 )
 
 func TestSelectTokens(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	ts := SelectTokens(rs)
 	if ts != nil {
 		t.Error("expected nil tokens list")
@@ -83,7 +82,7 @@ func TestHasLimitClause(t *testing.T) {
 func TestGetFieldList(t *testing.T) {
 	p := New(nil).(*Parser)
 	tokens := token.Tokens{&token.Token{Typ: token.Space, Pos: 0, Val: " "}}
-	rs := parsing.NewRunState(context.Background(), tokens)
+	rs := parsing.NewRunState(t.Context(), tokens)
 	p.GetFieldList(rs, token.Bool, parsing.ErrUnexpectedToken, nil, nil, nil, false)
 	if rs.Error() != parsing.ErrUnexpectedToken {
 		t.Error("expected ErrUnexpectedToken")
@@ -91,7 +90,7 @@ func TestGetFieldList(t *testing.T) {
 }
 
 func TestAtSelect(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := AtSelect(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -102,7 +101,7 @@ func TestAtSelect(t *testing.T) {
 
 	p := New(nil)
 	tokens := token.Tokens{&token.Token{Typ: token.Space, Pos: 0, Val: " "}}
-	rs = parsing.NewRunState(context.Background(), tokens)
+	rs = parsing.NewRunState(t.Context(), tokens)
 	rs.Next()
 	f = AtSelect(p, p, rs)
 	if f != nil {
@@ -118,7 +117,7 @@ func TestAtSelect(t *testing.T) {
 		&token.Token{Typ: token.EOF, Pos: 8, Val: ""},
 	}
 
-	rs = parsing.NewRunState(context.Background(), tokens)
+	rs = parsing.NewRunState(t.Context(), tokens)
 	rs.Next()
 	f = AtSelect(p, p, rs)
 	if f != nil {
@@ -130,7 +129,7 @@ func TestAtSelect(t *testing.T) {
 }
 
 func TestAtFrom(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := AtFrom(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -141,7 +140,7 @@ func TestAtFrom(t *testing.T) {
 }
 
 func TestAtWhere(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := AtWhere(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -152,7 +151,7 @@ func TestAtWhere(t *testing.T) {
 }
 
 func TestAtGroupBy(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := AtGroupBy(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -165,7 +164,7 @@ func TestAtGroupBy(t *testing.T) {
 	tokens := token.Tokens{
 		&token.Token{Typ: token.Space, Pos: 0, Val: " "},
 	}
-	rs = parsing.NewRunState(context.Background(), tokens)
+	rs = parsing.NewRunState(t.Context(), tokens)
 	rs.Next()
 	f = AtGroupBy(p, p, rs)
 	if f != nil {
@@ -177,7 +176,7 @@ func TestAtGroupBy(t *testing.T) {
 }
 
 func TestAtHaving(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := AtHaving(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -188,7 +187,7 @@ func TestAtHaving(t *testing.T) {
 }
 
 func TestAtOrderBy(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := AtOrderBy(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -199,7 +198,7 @@ func TestAtOrderBy(t *testing.T) {
 }
 
 func TestAtLimit(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := AtLimit(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -210,7 +209,7 @@ func TestAtLimit(t *testing.T) {
 }
 
 func TestAtIntoOutfile(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := AtIntoOutfile(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")
@@ -221,7 +220,7 @@ func TestAtIntoOutfile(t *testing.T) {
 }
 
 func TestAtUnion(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	f := AtUnion(nil, nil, rs)
 	if f != nil {
 		t.Error("expected nil StateFn")

--- a/pkg/parsing/sql/sql_test.go
+++ b/pkg/parsing/sql/sql_test.go
@@ -17,7 +17,6 @@
 package sql
 
 import (
-	"context"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/parsing"
@@ -58,7 +57,7 @@ func TestParser(t *testing.T) {
 	if sp == nil {
 		t.Error("expected non-nil parser")
 	}
-	_, err := sp.Run(context.Background(), p, tq01)
+	_, err := sp.Run(t.Context(), p, tq01)
 	if err != parsing.ErrNoLexer {
 		t.Error("expected error for no lexer")
 	}
@@ -70,19 +69,19 @@ func TestParser(t *testing.T) {
 	if sp == nil {
 		t.Error("expected non-nil parser")
 	}
-	_, err = sp.Run(context.Background(), sp, tq01+"\n LIMIT 10")
+	_, err = sp.Run(t.Context(), sp, tq01+"\n LIMIT 10")
 	if err != nil {
 		t.Error(err)
 	}
 
-	_, err = sp.Run(context.Background(), sp, tq01+"\n UNION something else")
+	_, err = sp.Run(t.Context(), sp, tq01+"\n UNION something else")
 	if err != parsing.ErrUnsupportedKeyword {
 		t.Error("expected error for UnsupportedKeyword got", err)
 	}
 }
 
 func TestUnsupportedVerb(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	UnsupportedVerb(nil, nil, rs)
 	if rs.Error() != ErrUnsupportedVerb {
 		t.Error("expected err for UnsupportedVerb")
@@ -90,7 +89,7 @@ func TestUnsupportedVerb(t *testing.T) {
 }
 
 func TestUnsupportedClause(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	UnsupportedClause(nil, nil, rs)
 	if rs.Error() != ErrUnsupportedClause {
 		t.Error("expected err for UnsupportedClause")
@@ -98,7 +97,7 @@ func TestUnsupportedClause(t *testing.T) {
 }
 
 func TestFindVerbUnsupportedParser(t *testing.T) {
-	rs := parsing.NewRunState(context.Background(), nil)
+	rs := parsing.NewRunState(t.Context(), nil)
 	FindVerb(nil, nil, rs)
 	if rs.Error() != parsing.ErrUnsupportedParser {
 		t.Error("expected err for UnsupportedParser")

--- a/pkg/proxy/context/healthcheck_test.go
+++ b/pkg/proxy/context/healthcheck_test.go
@@ -17,17 +17,16 @@
 package context
 
 import (
-	"context"
 	"testing"
 )
 
 func TestHealthcheck(t *testing.T) {
-	b := HealthCheckFlag(context.Background())
+	b := HealthCheckFlag(t.Context())
 	if b {
 		t.Error("expected false")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	b = HealthCheckFlag(ctx)
 	if b {

--- a/pkg/proxy/context/hops_test.go
+++ b/pkg/proxy/context/hops_test.go
@@ -17,14 +17,13 @@
 package context
 
 import (
-	"context"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends/rule/options"
 )
 
 func TestHops(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	_, j := Hops(ctx)
 	if j != options.DefaultMaxRuleExecutions {
 		t.Errorf("expected %d got %d", options.DefaultMaxRuleExecutions, j)
@@ -41,7 +40,7 @@ func TestHops(t *testing.T) {
 		t.Errorf("expected %d got %d", 1, j)
 	}
 
-	ctx = context.Background()
+	ctx = t.Context()
 	IncrementedRewriterHops(ctx, 5)
 	_ = RewriterHops(ctx)
 	ctx = StartRewriterHops(ctx)

--- a/pkg/proxy/context/resources_test.go
+++ b/pkg/proxy/context/resources_test.go
@@ -17,7 +17,6 @@
 package context
 
 import (
-	"context"
 	"testing"
 )
 
@@ -26,7 +25,7 @@ type testStruct struct {
 }
 
 func TestResources(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// cover nil short circuit case
 	ctx = WithResources(ctx, nil)

--- a/pkg/proxy/engines/cache.go
+++ b/pkg/proxy/engines/cache.go
@@ -40,10 +40,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-const (
-	providerMemory = "memory"
-)
-
 type queryResult struct {
 	queryKey     string
 	d            *HTTPDocument
@@ -53,48 +49,33 @@ type queryResult struct {
 
 func queryConcurrent(_ context.Context, c cache.Cache, key string) *queryResult {
 	qr := &queryResult{queryKey: key, d: &HTTPDocument{}}
-	if c.Configuration().Provider == providerMemory {
-		mc := c.(cache.MemoryCache)
-		var ifc any
-		ifc, qr.lookupStatus, qr.err = mc.RetrieveReference(key)
+	var b []byte
+	b, qr.lookupStatus, qr.err = c.Retrieve(key)
 
-		if qr.err != nil || (qr.lookupStatus != status.LookupStatusHit) {
-			return qr
-		}
+	if qr.err != nil || (qr.lookupStatus != status.LookupStatusHit) {
+		return qr
+	}
 
-		if ifc == nil {
-			return qr
+	var inflate bool
+	// check and remove compression bit
+	if len(b) > 0 {
+		if b[0] == 1 {
+			inflate = true
 		}
-		qr.d, _ = ifc.(*HTTPDocument)
-	} else {
-		var b []byte
-		b, qr.lookupStatus, qr.err = c.Retrieve(key)
+		b = b[1:]
+	}
 
-		if qr.err != nil || (qr.lookupStatus != status.LookupStatusHit) {
-			return qr
-		}
-
-		var inflate bool
-		// check and remove compression bit
-		if len(b) > 0 {
-			if b[0] == 1 {
-				inflate = true
-			}
-			b = b[1:]
-		}
-
-		if inflate {
-			// tl.Debug(rsc.Logger, "decompressing cached data", tl.Pairs{"cacheKey": key})
-			decoder := brotli.NewReader(bytes.NewReader(b))
-			b, qr.err = io.ReadAll(decoder)
-			if qr.err != nil {
-				return qr
-			}
-		}
-		_, qr.err = qr.d.UnmarshalMsg(b)
+	if inflate {
+		// tl.Debug(rsc.Logger, "decompressing cached data", tl.Pairs{"cacheKey": key})
+		decoder := brotli.NewReader(bytes.NewReader(b))
+		b, qr.err = io.ReadAll(decoder)
 		if qr.err != nil {
 			return qr
 		}
+	}
+	_, qr.err = qr.d.UnmarshalMsg(b)
+	if qr.err != nil {
+		return qr
 	}
 	return qr
 }
@@ -200,25 +181,6 @@ func writeConcurrent(_ context.Context, c cache.Cache, key string, d *HTTPDocume
 	var b []byte
 	var err error
 
-	// for memory cache, don't serialize the document, since we can retrieve it by reference.
-	if c.Configuration().Provider == providerMemory {
-		mc := c.(cache.MemoryCache)
-
-		if d != nil {
-			// during unmarshal, these would come back as false, so lets set them as such even for direct access
-			d.rangePartsLoaded = false
-			d.isFulfillment = false
-			d.isLoaded = false
-			d.RangeParts = nil
-
-			if d.CachingPolicy != nil {
-				d.CachingPolicy.ResetClientConditionals()
-			}
-		}
-		return mc.StoreReference(key, d, ttl)
-	}
-
-	// for non-memory, we have to serialize the document to a byte slice to store
 	b, err = d.MarshalMsg(nil)
 	if err != nil {
 		return err

--- a/pkg/proxy/engines/cache_chunk_test.go
+++ b/pkg/proxy/engines/cache_chunk_test.go
@@ -17,7 +17,6 @@
 package engines
 
 import (
-	"context"
 	"io"
 	"log"
 	"net/http"
@@ -55,7 +54,7 @@ func TestMultiPartByteRangeChunks(t *testing.T) {
 	resp2.StatusCode = 200
 	d := DocumentFromHTTPResponse(resp2, []byte("This is a t"), nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	ranges := make(byterange.Ranges, 1)
@@ -86,7 +85,7 @@ func TestCacheHitRangeRequestChunks(t *testing.T) {
 	resp2.Header.Add(headers.NameContentLength, strconv.Itoa(len(testRangeBody)))
 	resp2.StatusCode = 200
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody), nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -131,7 +130,7 @@ func TestCacheHitRangeRequest2Chunks(t *testing.T) {
 	resp2.Header.Add(headers.NameContentRange, have.ContentRangeHeader(cl))
 	resp2.StatusCode = 206
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -176,7 +175,7 @@ func TestCacheHitRangeRequest3Chunks(t *testing.T) {
 	resp2.Header.Add(headers.NameContentRange, have.ContentRangeHeader(cl))
 	resp2.StatusCode = 206
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -219,7 +218,7 @@ func TestPartialCacheMissRangeRequestChunks(t *testing.T) {
 	resp2.StatusCode = 206
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -264,7 +263,7 @@ func TestFullCacheMissRangeRequestChunks(t *testing.T) {
 	resp2.StatusCode = 206
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -316,7 +315,7 @@ func TestRangeRequestFromClientChunks(t *testing.T) {
 	}
 	cache.Configuration().UseCacheChunking = true
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	d := DocumentFromHTTPResponse(resp, bytes, nil)
@@ -369,7 +368,7 @@ func TestQueryCacheChunks(t *testing.T) {
 	d := DocumentFromHTTPResponse(resp, []byte(expected), nil)
 	d.ContentType = headers.ValueTextPlain
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)

--- a/pkg/proxy/engines/cache_read.go
+++ b/pkg/proxy/engines/cache_read.go
@@ -159,17 +159,15 @@ type TimeseriesChunkQueryProcessor struct {
 }
 
 func (tcp *TimeseriesChunkQueryProcessor) ProcessChunk(index int, subkey string, qr *queryResult, c cache.Cache) error {
-	if c.Configuration().Provider != providerMemory {
-		var err error
-		qr.d.timeseries, err = tcp.unmarshal(qr.d.Body, nil)
-		if err != nil {
-			logger.Error("chunk unmarshal failed",
-				logging.Pairs{
-					"error": err, "chunkIdx": index,
-					"key": subkey, "cacheQueryStatus": qr.lookupStatus,
-				})
-			return err
-		}
+	var err error
+	qr.d.timeseries, err = tcp.unmarshal(qr.d.Body, nil)
+	if err != nil {
+		logger.Error("chunk unmarshal failed",
+			logging.Pairs{
+				"error": err, "chunkIdx": index,
+				"key": subkey, "cacheQueryStatus": qr.lookupStatus,
+			})
+		return err
 	}
 	if qr.d.timeseries != nil {
 		tcp.ress[index] = qr.d.timeseries

--- a/pkg/proxy/engines/cache_test.go
+++ b/pkg/proxy/engines/cache_test.go
@@ -17,7 +17,6 @@
 package engines
 
 import (
-	"context"
 	"errors"
 	"io"
 	"log"
@@ -80,7 +79,7 @@ func TestMultiPartByteRange(t *testing.T) {
 	resp2.StatusCode = 200
 	d := DocumentFromHTTPResponse(resp2, []byte("This is a t"), nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	ranges := make(byterange.Ranges, 1)
@@ -110,7 +109,7 @@ func TestCacheHitRangeRequest(t *testing.T) {
 	resp2.Header.Add(headers.NameContentLength, strconv.Itoa(len(testRangeBody)))
 	resp2.StatusCode = 200
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody), nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -154,7 +153,7 @@ func TestCacheHitRangeRequest2(t *testing.T) {
 	resp2.Header.Add(headers.NameContentRange, have.ContentRangeHeader(cl))
 	resp2.StatusCode = 206
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -198,7 +197,7 @@ func TestCacheHitRangeRequest3(t *testing.T) {
 	resp2.Header.Add(headers.NameContentRange, have.ContentRangeHeader(cl))
 	resp2.StatusCode = 206
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -240,7 +239,7 @@ func TestPartialCacheMissRangeRequest(t *testing.T) {
 	resp2.StatusCode = 206
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -285,7 +284,7 @@ func TestFullCacheMissRangeRequest(t *testing.T) {
 	resp2.StatusCode = 206
 	d := DocumentFromHTTPResponse(resp2, []byte(testRangeBody[have.Start:have.End+1]), nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)
@@ -337,7 +336,7 @@ func TestRangeRequestFromClient(t *testing.T) {
 		t.Error("could not load cache")
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	d := DocumentFromHTTPResponse(resp, bytes, nil)
@@ -389,7 +388,7 @@ func TestQueryCache(t *testing.T) {
 	d := DocumentFromHTTPResponse(resp, []byte(expected), nil)
 	d.ContentType = headers.ValueTextPlain
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: conf.Backends["default"], Tracer: tu.NewTestTracer()})
 
 	err = WriteCache(ctx, cache, "testKey", d, time.Duration(60)*time.Second, sets.New([]string{headers.ValueTextPlain}), nil)

--- a/pkg/proxy/engines/cache_write.go
+++ b/pkg/proxy/engines/cache_write.go
@@ -101,8 +101,7 @@ func (tc *TimeseriesChunkWriter) IterateChunks(
 		subkey := getSubKey(tc.key, chunkExtent)
 		chunkData := d.GetTimeseriesChunk(chunkExtent)
 
-		// Handle serialization for non-memory providers
-		if tc.c.Configuration().Provider != providerMemory && tc.marshal != nil {
+		if tc.marshal != nil {
 			chunkData.Body, _ = tc.marshal(chunkData.timeseries, nil, 0)
 		}
 

--- a/pkg/proxy/engines/key_test.go
+++ b/pkg/proxy/engines/key_test.go
@@ -17,7 +17,6 @@
 package engines
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -136,7 +135,7 @@ func TestDeriveCacheKey(t *testing.T) {
 	}
 
 	tr := httptest.NewRequest("GET", "http://127.0.0.1/?query=12345&start=0&end=0&step=300&time=0", nil)
-	tr = tr.WithContext(ct.WithResources(context.Background(), newResources()))
+	tr = tr.WithContext(ct.WithResources(t.Context(), newResources()))
 
 	pr := newProxyRequest(tr, nil)
 	ck := pr.DeriveCacheKey("extra")
@@ -157,7 +156,7 @@ func TestDeriveCacheKey(t *testing.T) {
 	const expected = "cb84ad010abb4d0f864470540a46f137"
 
 	tr = httptest.NewRequest(http.MethodPost, "http://127.0.0.1/", strings.NewReader("field1=value1"))
-	tr = tr.WithContext(ct.WithResources(context.Background(), newResources()))
+	tr = tr.WithContext(ct.WithResources(t.Context(), newResources()))
 	tr.Header.Set(headers.NameContentType, headers.ValueXFormURLEncoded)
 	pr = newProxyRequest(tr, nil)
 	ck = pr.DeriveCacheKey("extra")
@@ -166,7 +165,7 @@ func TestDeriveCacheKey(t *testing.T) {
 	}
 
 	tr = httptest.NewRequest(http.MethodPut, "http://127.0.0.1/", strings.NewReader(testMultipartBody))
-	tr = tr.WithContext(ct.WithResources(context.Background(), newResources()))
+	tr = tr.WithContext(ct.WithResources(t.Context(), newResources()))
 	tr.Header.Set(headers.NameContentType, headers.ValueMultipartFormData+testMultipartBoundary)
 	tr.Header.Set(headers.NameContentLength, strconv.Itoa(len(testMultipartBody)))
 	pr = newProxyRequest(tr, nil)
@@ -179,7 +178,7 @@ func TestDeriveCacheKey(t *testing.T) {
 		providers.ReverseProxyCacheShort, "http://127.0.0.1/", "INFO")
 	tr.Method = http.MethodPost
 	tr.Body = io.NopCloser(strings.NewReader(testJSONDocument))
-	tr = tr.WithContext(ct.WithResources(context.Background(), newResources()))
+	tr = tr.WithContext(ct.WithResources(t.Context(), newResources()))
 	tr.Header.Set(headers.NameContentType, headers.ValueApplicationJSON)
 	tr.Header.Set(headers.NameContentLength, strconv.Itoa(len(testJSONDocument)))
 	pr = newProxyRequest(tr, nil)
@@ -198,7 +197,7 @@ func TestDeriveCacheKey(t *testing.T) {
 
 	tr = httptest.NewRequest(http.MethodPost, "http://127.0.0.1/", nil)
 	tr.Body = io.NopCloser(strings.NewReader(testJSONDocument))
-	tr = tr.WithContext(ct.WithResources(context.Background(), newResources()))
+	tr = tr.WithContext(ct.WithResources(t.Context(), newResources()))
 	tr.Header.Set(headers.NameContentType, headers.ValueApplicationJSON)
 	tr.Header.Set(headers.NameContentLength, strconv.Itoa(len(testJSONDocument)))
 	pr = newProxyRequest(tr, nil)
@@ -229,7 +228,7 @@ func TestDeriveCacheKeyAuthHeader(t *testing.T) {
 	}
 
 	tr := httptest.NewRequest("GET", "http://127.0.0.1/?query=12345&start=0&end=0&step=300&time=0", nil)
-	tr = tr.WithContext(ct.WithResources(context.Background(),
+	tr = tr.WithContext(ct.WithResources(t.Context(),
 		request.NewResources(client.Configuration(), client.Configuration().Paths[0],
 			nil, nil, nil, nil)))
 
@@ -259,7 +258,7 @@ func TestDeriveCacheKeyNoPathConfig(t *testing.T) {
 	}
 
 	tr := httptest.NewRequest("GET", "http://127.0.0.1/?query=12345&start=0&end=0&step=300&time=0", nil)
-	tr = tr.WithContext(ct.WithResources(context.Background(),
+	tr = tr.WithContext(ct.WithResources(t.Context(),
 		request.NewResources(client.Configuration(), nil, nil, nil, nil, nil)))
 
 	pr := newProxyRequest(tr, nil)

--- a/pkg/proxy/engines/objectproxycache_chunk_test.go
+++ b/pkg/proxy/engines/objectproxycache_chunk_test.go
@@ -17,7 +17,6 @@
 package engines
 
 import (
-	"context"
 	stderrors "errors"
 	"net/http"
 	"net/http/httptest"
@@ -255,7 +254,7 @@ func TestObjectProxyCachePartialHitNotFreshChunks(t *testing.T) {
 		t.Error(err)
 	}
 	defer ts.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: rsc.BackendOptions})
 
 	pr := newProxyRequest(r, w)
@@ -290,7 +289,7 @@ func TestObjectProxyCachePartialHitFullResponseChunks(t *testing.T) {
 		t.Error(err)
 	}
 	defer ts.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: rsc.BackendOptions})
 
 	pr := newProxyRequest(r, w)
@@ -711,7 +710,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/1"
 	r.Header.Set(headers.NameRange, "bytes=0-6,25-32")
-	req := r.Clone(context.Background())
+	req := r.Clone(t.Context())
 	expectedBodyA, err := getExpectedRangeBody(req, "563a7014513fc6f0cbb4e8632dd107fc")
 	if err != nil {
 		t.Error(err)
@@ -722,7 +721,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=0-10,20-28")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err := getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -733,7 +732,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=0-6")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -745,7 +744,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=5-7")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -756,7 +755,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=29-29")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -767,7 +766,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=9-22,28-60")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "1fd80b6b357b4608027dd500ad3f3c21")
 	if err != nil {
 		t.Error(err)
@@ -778,7 +777,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 	}
 
 	r.Header.Del(headers.NameRange)
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "1fd80b6b357b4608027dd500ad3f3c21")
 	if err != nil {
 		t.Error(err)
@@ -789,7 +788,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=0-10,20-28")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -800,7 +799,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=0-6")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -817,7 +816,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/2"
 	r.Header.Set(headers.NameRange, "bytes=0-6")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody1, err := getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -829,7 +828,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/3"
 	r.Header.Set(headers.NameRange, "bytes=0-6, 8-10")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody2, err := getExpectedRangeBody(req, "1b4e59d25d723e317359c5e542d80f5c")
 	if err != nil {
 		t.Error(err)
@@ -841,7 +840,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/4"
 	r.Header.Set(headers.NameRange, "bytes=0-6, 8-10")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody3, err := getExpectedRangeBody(req, "1b4e59d25d723e317359c5e542d80f5c")
 	if err != nil {
 		t.Error(err)
@@ -853,7 +852,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/5"
 	r.Header.Set(headers.NameRange, "bytes=6-20")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody4, err := getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -865,7 +864,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/6"
 	r.Header.Set(headers.NameRange, "bytes=6-20")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody5, err := getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -877,7 +876,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/7"
 	r.Header.Set(headers.NameRange, "bytes=6-20")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody6, err := getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -909,7 +908,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/4"
 	r.Header.Set(headers.NameRange, "bytes=5-9")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody3, err = getExpectedRangeBody(req, "1b4e59d25d723e317359c5e542d80f5c")
 	if err != nil {
 		t.Error(err)
@@ -921,7 +920,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/5"
 	r.Header.Set(headers.NameRange, "bytes=0-5")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody4, err = getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -933,7 +932,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/6"
 	r.Header.Set(headers.NameRange, "bytes=0-5,21-30")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody5, err = getExpectedRangeBody(req, "d51d39834c9650e17cc486c4a52cf572")
 	if err != nil {
 		t.Error(err)
@@ -945,7 +944,7 @@ func TestRangesExhaustiveChunks(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/7"
 	r.Header.Set(headers.NameRange, "bytes=22-30,32-40")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody6, err = getExpectedRangeBody(req, "bab29463882afe6d6033e88dc74d2bdd")
 	if err != nil {
 		t.Error(err)

--- a/pkg/proxy/engines/objectproxycache_test.go
+++ b/pkg/proxy/engines/objectproxycache_test.go
@@ -17,7 +17,6 @@
 package engines
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -375,7 +374,7 @@ func TestObjectProxyCachePartialHitNotFresh(t *testing.T) {
 		t.Error(err)
 	}
 	defer ts.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: rsc.BackendOptions})
 
 	pr := newProxyRequest(r, w)
@@ -409,7 +408,7 @@ func TestObjectProxyCachePartialHitFullResponse(t *testing.T) {
 		t.Error(err)
 	}
 	defer ts.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = tc.WithResources(ctx, &request.Resources{BackendOptions: rsc.BackendOptions})
 
 	pr := newProxyRequest(r, w)
@@ -832,7 +831,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/1"
 	r.Header.Set(headers.NameRange, "bytes=0-6,25-32")
-	req := r.Clone(context.Background())
+	req := r.Clone(t.Context())
 	expectedBodyA, err := getExpectedRangeBody(req, "563a7014513fc6f0cbb4e8632dd107fc")
 	if err != nil {
 		t.Error(err)
@@ -843,7 +842,7 @@ func TestRangesExhaustive(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=0-10,20-28")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err := getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -854,7 +853,7 @@ func TestRangesExhaustive(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=0-6")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -866,7 +865,7 @@ func TestRangesExhaustive(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=5-7")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -877,7 +876,7 @@ func TestRangesExhaustive(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=29-29")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -888,7 +887,7 @@ func TestRangesExhaustive(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=9-22,28-60")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "1fd80b6b357b4608027dd500ad3f3c21")
 	if err != nil {
 		t.Error(err)
@@ -899,7 +898,7 @@ func TestRangesExhaustive(t *testing.T) {
 	}
 
 	r.Header.Del(headers.NameRange)
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "1fd80b6b357b4608027dd500ad3f3c21")
 	if err != nil {
 		t.Error(err)
@@ -910,7 +909,7 @@ func TestRangesExhaustive(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=0-10,20-28")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -921,7 +920,7 @@ func TestRangesExhaustive(t *testing.T) {
 	}
 
 	r.Header.Set(headers.NameRange, "bytes=0-6")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody, err = getExpectedRangeBody(req, "33f2477458123b02034bfbe20c52d949")
 	if err != nil {
 		t.Error(err)
@@ -938,7 +937,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/2"
 	r.Header.Set(headers.NameRange, "bytes=0-6")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody1, err := getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -950,7 +949,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/3"
 	r.Header.Set(headers.NameRange, "bytes=0-6, 8-10")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody2, err := getExpectedRangeBody(req, "1b4e59d25d723e317359c5e542d80f5c")
 	if err != nil {
 		t.Error(err)
@@ -962,7 +961,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/4"
 	r.Header.Set(headers.NameRange, "bytes=0-6, 8-10")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody3, err := getExpectedRangeBody(req, "1b4e59d25d723e317359c5e542d80f5c")
 	if err != nil {
 		t.Error(err)
@@ -974,7 +973,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/5"
 	r.Header.Set(headers.NameRange, "bytes=6-20")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody4, err := getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -986,7 +985,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/6"
 	r.Header.Set(headers.NameRange, "bytes=6-20")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody5, err := getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -998,7 +997,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/7"
 	r.Header.Set(headers.NameRange, "bytes=6-20")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody6, err := getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -1030,7 +1029,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/4"
 	r.Header.Set(headers.NameRange, "bytes=5-9")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody3, err = getExpectedRangeBody(req, "1b4e59d25d723e317359c5e542d80f5c")
 	if err != nil {
 		t.Error(err)
@@ -1042,7 +1041,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/5"
 	r.Header.Set(headers.NameRange, "bytes=0-5")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody4, err = getExpectedRangeBody(req, "")
 	if err != nil {
 		t.Error(err)
@@ -1054,7 +1053,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/6"
 	r.Header.Set(headers.NameRange, "bytes=0-5,21-30")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody5, err = getExpectedRangeBody(req, "d51d39834c9650e17cc486c4a52cf572")
 	if err != nil {
 		t.Error(err)
@@ -1066,7 +1065,7 @@ func TestRangesExhaustive(t *testing.T) {
 
 	r.URL.Path = "/byterange/test/7"
 	r.Header.Set(headers.NameRange, "bytes=22-30,32-40")
-	req = r.Clone(context.Background())
+	req = r.Clone(t.Context())
 	expectedBody6, err = getExpectedRangeBody(req, "bab29463882afe6d6033e88dc74d2bdd")
 	if err != nil {
 		t.Error(err)

--- a/pkg/proxy/handlers/trickster/redirect/redirector_test.go
+++ b/pkg/proxy/handlers/trickster/redirect/redirector_test.go
@@ -17,13 +17,12 @@
 package redirect
 
 import (
-	"context"
 	"net/http/httptest"
 	"testing"
 )
 
 func TestRedirector(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = WithRedirects(ctx, 302, "http://trickstercache.org")
 	r := httptest.NewRequest("GET", "http://0/trickster/", nil)
 	w := httptest.NewRecorder()

--- a/pkg/proxy/request/resources_test.go
+++ b/pkg/proxy/request/resources_test.go
@@ -17,7 +17,6 @@
 package request
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -48,7 +47,7 @@ func TestGetAndSetResources(t *testing.T) {
 	r = NewResources(nil, nil, nil, nil, nil, nil)
 	r.AlternateCacheTTL = time.Duration(1) * time.Second
 	req, _ := http.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
-	ctx := context.Background()
+	ctx := t.Context()
 	// test nil short circuit bail out
 	req = SetResources(req.WithContext(ctx), nil)
 	req = SetResources(req.WithContext(ctx), r)
@@ -58,7 +57,7 @@ func TestGetAndSetResources(t *testing.T) {
 	}
 
 	req, _ = http.NewRequest(http.MethodGet, "http://127.0.0.1/", nil)
-	ctx = context.Background()
+	ctx = t.Context()
 	req = req.WithContext(ctx)
 
 	// set something other than a resource into the context to verify a get returns nil

--- a/pkg/proxy/request/rewriter/rewrite_instructions_test.go
+++ b/pkg/proxy/request/rewriter/rewrite_instructions_test.go
@@ -17,7 +17,6 @@
 package rewriter
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -512,7 +511,7 @@ func TestReqChainExecute(t *testing.T) {
 		&rwiChainExecutor{rewriterName: "rewriter1", rewriter: testRWI},
 	}
 	r, _ := http.NewRequest(http.MethodGet, "/", nil)
-	r = r.WithContext(tctx.StartRewriterHops(context.Background()))
+	r = r.WithContext(tctx.StartRewriterHops(t.Context()))
 	ri.Execute(r)
 	hops := tctx.RewriterHops(r.Context())
 	if hops != 1 {


### PR DESCRIPTION
## Changes:
- refactor: [caches/memory] drop "referenced object" support
  -  no noticeable performance differences; this optimization did not seem to be worth the complexity it caused within the overall codebase
  - calling code should be simpler now; should make it simpler to optimize the overall codebase (no more provider specific code paths)
- chore: [tests] use t.Context() over context.Background()
- - chore: [docs/dashboards] add redis datasource to grafana
- chore: [docs/dashboards] add more memory & request duration panels
  - added: "GOMAXPROCS" stat, 2 extra memory stats, cpu usage, go gc duration, processed bytes, frontend request duration histogram, + overall request duration histogram
  - (processed bytes not working via darwin at this time) 

---
new panels:
<img width="1125" height="663" alt="Screenshot 2026-02-23 at 6 52 00 PM" src="https://github.com/user-attachments/assets/703d1217-f76a-4b14-8320-a3f923fa5d7e" />
more new panels:

<img width="1124" height="524" alt="Screenshot 2026-02-23 at 6 52 11 PM" src="https://github.com/user-attachments/assets/e3daae83-69e7-4387-8b21-69e15b235667" />
