### PR TITLE
bugfix: retain errorType after replica group merge

### DIFF
--- a/pkg/backends/alb/mech/tsm/replica_groups.go
+++ b/pkg/backends/alb/mech/tsm/replica_groups.go
@@ -207,6 +207,12 @@ func coalesceReplicaGroup(contributions []*gatherContribution,
 				toleranceNanos, dataSets[i])
 		}
 	}
+	// Restore the configured-first replica's response envelope while retaining
+	// warnings aggregated from every replica.
+	base.Status = dataSets[0].Status
+	base.Error = dataSets[0].Error
+	base.ErrorType = dataSets[0].ErrorType
+	base.SourceResultType = dataSets[0].SourceResultType
 	return &gatherContribution{
 		data:           base,
 		mergeFunc:      first.mergeFunc,

--- a/pkg/backends/alb/mech/tsm/replica_groups_test.go
+++ b/pkg/backends/alb/mech/tsm/replica_groups_test.go
@@ -114,6 +114,79 @@ func TestReplicaGroupTolerantDedupKeepsConfiguredFirst(t *testing.T) {
 	}
 }
 
+func TestReplicaGroupKeepsConfiguredFirstEnvelope(t *testing.T) {
+	tests := []struct {
+		name           string
+		toleranceNanos int64
+		replicaEpoch   int64
+		wantWarnings   []string
+	}{
+		{
+			name:         "exact dedup",
+			replicaEpoch: 100,
+			wantWarnings: []string{
+				"primary warning",
+				"replica warning",
+			},
+		},
+		{
+			name:           "tolerant dedup",
+			toleranceNanos: 5,
+			replicaEpoch:   103,
+			wantWarnings:   []string{"primary warning"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			primary := replicaContribution(0, map[int64]string{100: "primary"})
+			primaryData := primary.data.(*dataset.DataSet)
+			primaryData.Status = "error"
+			primaryData.Error = "primary error"
+			primaryData.ErrorType = "primary_type"
+			primaryData.SourceResultType = "primary_result_type"
+			primaryData.Warnings = []string{"primary warning"}
+
+			replica := replicaContribution(1, map[int64]string{
+				test.replicaEpoch: "replica",
+			})
+			replicaData := replica.data.(*dataset.DataSet)
+			replicaData.Status = "error"
+			replicaData.Error = "replica error"
+			replicaData.ErrorType = "replica_type"
+			replicaData.SourceResultType = "replica_result_type"
+			replicaData.Warnings = []string{"replica warning"}
+
+			logical := coalesceReplicaGroup(
+				[]*gatherContribution{primary, replica}, test.toleranceNanos)
+			got := logical.data.(*dataset.DataSet)
+
+			if got.Status != primaryData.Status ||
+				got.Error != primaryData.Error ||
+				got.ErrorType != primaryData.ErrorType ||
+				got.SourceResultType != primaryData.SourceResultType {
+				t.Fatalf("envelope = (%q, %q, %q, %q), want configured-first (%q, %q, %q, %q)",
+					got.Status, got.Error, got.ErrorType, got.SourceResultType,
+					primaryData.Status, primaryData.Error, primaryData.ErrorType,
+					primaryData.SourceResultType)
+			}
+
+			warnings := make(map[string]bool, len(got.Warnings))
+			for _, warning := range got.Warnings {
+				warnings[warning] = true
+			}
+			if len(got.Warnings) != len(test.wantWarnings) {
+				t.Fatalf("warnings = %v, want %v", got.Warnings, test.wantWarnings)
+			}
+			for _, warning := range test.wantWarnings {
+				if !warnings[warning] {
+					t.Fatalf("warnings = %v, want %v", got.Warnings, test.wantWarnings)
+				}
+			}
+		})
+	}
+}
+
 func TestReplicaTopologyDefaultsToDistinctMembers(t *testing.T) {
 	targets := pool.Targets{
 		replicaTarget("a", "a"),

--- a/pkg/backends/prometheus/model/histogram_operations_test.go
+++ b/pkg/backends/prometheus/model/histogram_operations_test.go
@@ -17,6 +17,7 @@
 package model
 
 import (
+	"encoding/json"
 	"math"
 	"testing"
 
@@ -196,4 +197,172 @@ func TestPrometheusHistogramOperationsDropMixedSamples(t *testing.T) {
 
 	ds.FinalizeValueMerge(int(merge.StrategySum))
 	require.Equal(t, []string{mixedFloatHistogramWarning}, ds.Warnings)
+}
+
+func TestPrometheusHistogramOperationsRejectsInvalidInputs(t *testing.T) {
+	ops := prometheusHistogramOperations{}
+
+	_, handled := ops.MergeValues(`{"count":"1","sum":"1"}`, `{"count":"1","sum":"1"}`, merge.StrategyDedup)
+	require.False(t, handled)
+	_, handled = ops.MergeValues(1, `{"count":"1","sum":"1"}`, merge.StrategySum)
+	require.False(t, handled)
+	_, handled = ops.MergeValues(`{"count":"1","sum":"1"}`, `{`, merge.StrategySum)
+	require.False(t, handled)
+
+	_, handled = ops.DivideValue(`{"count":"1","sum":"1"}`, 0)
+	require.False(t, handled)
+	_, handled = ops.DivideValue(nil, 2)
+	require.False(t, handled)
+
+	ops.FinalizeMerge(&dataset.DataSet{}, merge.StrategyDedup)
+}
+
+func TestParseNormalizedHistogramEdgeCases(t *testing.T) {
+	_, err := parseNormalizedHistogram(123)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"x","sum":"1"}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"x"}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","buckets":[[0,"0","1"]]}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","buckets":[[9,"0","1","1"]]}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","buckets":[[0,"x","1","1"]]}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","buckets":[[0,"0","x","1"]]}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","buckets":[[0,"0","1","x"]]}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","buckets":[[0,"2","1","1"]]}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","zero_count":"x"}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","schema":0,` +
+		`"positive_spans":[{"offset":0,"length":1}],"positive_deltas":[1,2]}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","schema":0,` +
+		`"positive_spans":[{"offset":0,"length":1}],"positive_counts":["1","2"]}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","schema":99,` +
+		`"positive_spans":[{"offset":0,"length":1}],"positive_deltas":[1]}`)
+	require.Error(t, err)
+
+	hist, err := parseNormalizedHistogram(`{"count":"3","sum":"4","schema":0,"zero_threshold":0.5,` +
+		`"zero_count":"","positive_spans":[{"offset":0,"length":1}],"positive_counts":["2"],` +
+		`"negative_spans":[{"offset":0,"length":1}],"negative_deltas":[1]}`)
+	require.NoError(t, err)
+	require.Equal(t, 3.0, hist.count)
+	require.GreaterOrEqual(t, len(hist.buckets), 2)
+
+	// Clamp span bucket edges that fall inside the zero threshold.
+	hist, err = parseNormalizedHistogram(`{"count":"2","sum":"3","schema":0,"zero_threshold":2,` +
+		`"positive_spans":[{"offset":0,"length":1}],"positive_deltas":[1],` +
+		`"negative_spans":[{"offset":0,"length":1}],"negative_deltas":[1]}`)
+	require.NoError(t, err)
+	for _, bucket := range hist.buckets {
+		if bucket.lower > 0 {
+			require.GreaterOrEqual(t, bucket.lower, 2.0)
+		}
+		if bucket.upper < 0 {
+			require.LessOrEqual(t, bucket.upper, -2.0)
+		}
+	}
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","schema":0,` +
+		`"positive_spans":[{"offset":0,"length":1}],"positive_counts":["x"]}`)
+	require.Error(t, err)
+
+	_, err = parseNormalizedHistogram(`{"count":"1","sum":"1","schema":-53,"custom_values":[1],` +
+		`"positive_spans":[{"offset":5,"length":1}],"positive_deltas":[1]}`)
+	require.Error(t, err)
+
+	// Inclusive boundary modes and zero-count bucket omission.
+	value, err := marshalNormalizedHistogram(normalizedHistogram{
+		count: 1,
+		sum:   1,
+		buckets: []normalizedHistogramBucket{
+			{lower: 0, upper: 1, count: 0, upperInclusive: true},
+			{lower: 1, upper: 2, count: 1, lowerInclusive: true},
+			{lower: 2, upper: 3, count: 1, lowerInclusive: true, upperInclusive: true},
+			{lower: 3, upper: 4, count: 1},
+		},
+	})
+	require.NoError(t, err)
+	require.Contains(t, value, `[1,`)
+	require.Contains(t, value, `[3,`)
+	require.Contains(t, value, `[2,`)
+	require.NotContains(t, value, `"0","1","0"`)
+}
+
+func TestHistogramNumberHelpers(t *testing.T) {
+	v, err := parseHistogramNumber("", true)
+	require.NoError(t, err)
+	require.Equal(t, 0.0, v)
+
+	_, err = parseHistogramNumber("", false)
+	require.Error(t, err)
+
+	for _, in := range []any{"1.5", float64(2), float32(3), 4, int32(5), int64(6), json.Number("7")} {
+		got, err := histogramNumber(in)
+		require.NoError(t, err, "%T", in)
+		require.NotZero(t, got, "%T", in)
+	}
+	_, err = histogramNumber(true)
+	require.Error(t, err)
+
+	require.Equal(t, "0.000001", formatHistogramNumber(1e-6))
+	require.Contains(t, formatHistogramNumber(1e-7), "e")
+	require.Contains(t, formatHistogramNumber(1e21), "e")
+}
+
+func TestHistogramBucketBoundCustomSchema(t *testing.T) {
+	negInf, err := histogramBucketBound(-1, -53, []float64{1, 2, 4})
+	require.NoError(t, err)
+	require.True(t, math.IsInf(negInf, -1))
+
+	got, err := histogramBucketBound(1, -53, []float64{1, 2, 4})
+	require.NoError(t, err)
+	require.Equal(t, 2.0, got)
+
+	posInf, err := histogramBucketBound(3, -53, []float64{1, 2, 4})
+	require.NoError(t, err)
+	require.True(t, math.IsInf(posInf, 1))
+
+	_, err = histogramBucketBound(-2, -53, []float64{1, 2, 4})
+	require.Error(t, err)
+	_, err = histogramBucketBound(4, -53, []float64{1, 2, 4})
+	require.Error(t, err)
+
+	bucket, err := spanHistogramBucket(0, 2, true, -53, []float64{1, 2, 4})
+	require.NoError(t, err)
+	require.True(t, bucket.lowerInclusive)
+	require.True(t, bucket.upperInclusive)
+
+	bucket, err = spanHistogramBucket(1, 3, false, 0, nil)
+	require.NoError(t, err)
+	require.True(t, bucket.lowerInclusive)
+	require.False(t, bucket.upperInclusive)
+	require.Less(t, bucket.lower, 0.0)
+}
+
+func TestCoarsenHistogramBucketsSmall(t *testing.T) {
+	require.Empty(t, coarsenHistogramBuckets(nil, nil))
+	one := []normalizedHistogramBucket{{lower: 0, upper: 1, count: 1}}
+	require.Equal(t, one, coarsenHistogramBuckets(one, nil))
 }

--- a/pkg/backends/prometheus/model/merge_test.go
+++ b/pkg/backends/prometheus/model/merge_test.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeMergeFuncFromBytes(t *testing.T) {
+	mergeFunc := MakeMergeFuncFromBytes("labels", func() *WFLabelData {
+		return &WFLabelData{Envelope: &Envelope{}}
+	})
+
+	t.Run("success", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		body1, err := json.Marshal(&WFLabelData{
+			Envelope: &Envelope{Status: "success"},
+			Data:     []string{"a", "b"},
+		})
+		require.NoError(t, err)
+		body2, err := json.Marshal(&WFLabelData{
+			Envelope: &Envelope{Status: "success", Warnings: []string{"w1"}},
+			Data:     []string{"c"},
+		})
+		require.NoError(t, err)
+
+		require.NoError(t, mergeFunc(accum, body1, 0))
+		require.NoError(t, mergeFunc(accum, body2, 1))
+
+		got, ok := accum.GetGeneric().(*WFLabelData)
+		require.True(t, ok)
+		require.Equal(t, []string{"a", "b", "c"}, got.Data)
+		require.Equal(t, "success", got.Status)
+		require.Contains(t, got.Warnings, "w1")
+	})
+
+	t.Run("invalid_json", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		err := mergeFunc(accum, []byte(`{"status":`), 0)
+		require.Error(t, err)
+		require.Nil(t, accum.GetGeneric())
+	})
+}
+
+func TestMakeMergeFuncUnexpectedType(t *testing.T) {
+	mergeFunc := MakeMergeFunc("labels", func() *WFLabelData {
+		return &WFLabelData{Envelope: &Envelope{}}
+	})
+	err := mergeFunc(merge.NewAccumulator(), 123, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unexpected data type")
+}

--- a/pkg/backends/prometheus/model/vector_edge_test.go
+++ b/pkg/backends/prometheus/model/vector_edge_test.go
@@ -1,0 +1,288 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package model
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
+)
+
+type stubTimeseries struct {
+	timeseries.Timeseries
+}
+
+func (s stubTimeseries) Clone() timeseries.Timeseries { return s }
+func (s stubTimeseries) Merge(bool, ...timeseries.Timeseries) {}
+func (s stubTimeseries) Sort()                             {}
+func (s stubTimeseries) SetExtents(timeseries.ExtentList)  {}
+func (s stubTimeseries) Extents() timeseries.ExtentList    { return nil }
+func (s stubTimeseries) VolatileExtents() timeseries.ExtentList {
+	return nil
+}
+func (s stubTimeseries) SetVolatileExtents(timeseries.ExtentList) {}
+func (s stubTimeseries) TimestampCount() int64                    { return 0 }
+func (s stubTimeseries) Step() time.Duration                      { return 0 }
+func (s stubTimeseries) CroppedClone(timeseries.Extent) timeseries.Timeseries {
+	return s
+}
+func (s stubTimeseries) CropToRange(timeseries.Extent)                {}
+func (s stubTimeseries) CropToSize(int, time.Time, timeseries.Extent) {}
+func (s stubTimeseries) SeriesCount() int                             { return 0 }
+func (s stubTimeseries) ValueCount() int64                            { return 0 }
+func (s stubTimeseries) Size() int64                                  { return 0 }
+func (s stubTimeseries) SetTimeRangeQuery(*timeseries.TimeRangeQuery) {}
+
+func testUnmarshaler(data []byte, trq *timeseries.TimeRangeQuery) (timeseries.Timeseries, error) {
+	if trq == nil {
+		trq = &timeseries.TimeRangeQuery{}
+	}
+	return UnmarshalTimeseries(data, trq)
+}
+
+func scalarBody(ts int64, value string) string {
+	return `{"status":"success","data":{"resultType":"scalar","result":[` +
+		jsonNumber(ts) + `,"` + value + `"]}}`
+}
+
+func jsonNumber(n int64) string {
+	b, _ := json.Marshal(n)
+	return string(b)
+}
+
+func decodeTS(t *testing.T, body string) *dataset.DataSet {
+	t.Helper()
+	ts, err := testUnmarshaler([]byte(body), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ds, ok := ts.(*dataset.DataSet)
+	if !ok {
+		t.Fatalf("expected *dataset.DataSet, got %T", ts)
+	}
+	return ds
+}
+
+func TestMergeAndWriteVectorMergeFuncScalarPaths(t *testing.T) {
+	mergeFunc := MergeAndWriteVectorMergeFunc(testUnmarshaler)
+
+	t.Run("unknown_data_type", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		if err := mergeFunc(accum, 42, 0); err != timeseries.ErrUnknownFormat {
+			t.Fatalf("got %v want ErrUnknownFormat", err)
+		}
+	})
+
+	t.Run("passthrough_timeseries", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		ds := decodeTS(t, scalarBody(100, "7"))
+		if err := mergeFunc(accum, ds, 0); err != nil {
+			t.Fatal(err)
+		}
+		got, ok := accum.GetTSData().(*dataset.DataSet)
+		if !ok || !hasNonNaNScalar(got) {
+			t.Fatalf("unexpected accumulator data: %#v", accum.GetTSData())
+		}
+	})
+
+	t.Run("non_dataset_timeseries_falls_back", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		if err := mergeFunc(accum, stubTimeseries{}, 0); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := accum.GetTSData().(stubTimeseries); !ok {
+			t.Fatalf("expected stub timeseries in accumulator, got %T", accum.GetTSData())
+		}
+	})
+
+	t.Run("error_ignored_when_scalar_present", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		if err := mergeFunc(accum, []byte(scalarBody(100, "7")), 0); err != nil {
+			t.Fatal(err)
+		}
+		if err := mergeFunc(accum, []byte(`{"status":"error","errorType":"bad_data","error":"boom"}`), 1); err != nil {
+			t.Fatal(err)
+		}
+		got := accum.GetTSData().(*dataset.DataSet)
+		if got.SourceResultType != string(Scalar) || !hasNonNaNScalar(got) {
+			t.Fatalf("scalar should remain after error envelope: %#v", got)
+		}
+	})
+
+	t.Run("scalar_replaces_error", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		if err := mergeFunc(accum, []byte(`{"status":"error","errorType":"bad_data","error":"boom"}`), 0); err != nil {
+			t.Fatal(err)
+		}
+		if err := mergeFunc(accum, []byte(scalarBody(101, "42")), 1); err != nil {
+			t.Fatal(err)
+		}
+		got := accum.GetTSData().(*dataset.DataSet)
+		if got.SourceResultType != string(Scalar) || !hasNonNaNScalar(got) {
+			t.Fatalf("scalar should replace error envelope: %#v", got)
+		}
+	})
+
+	t.Run("scalar_keeps_existing_vector", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		if err := mergeFunc(accum, []byte(testVector), 0); err != nil {
+			t.Fatal(err)
+		}
+		if err := mergeFunc(accum, []byte(scalarBody(101, "42")), 1); err != nil {
+			t.Fatal(err)
+		}
+		got := accum.GetTSData().(*dataset.DataSet)
+		if got.SourceResultType != string(Vector) {
+			t.Fatalf("vector should win over later scalar: %#v", got.SourceResultType)
+		}
+	})
+
+	t.Run("scalar_prefers_first_non_nan", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		if err := mergeFunc(accum, []byte(scalarBody(100, "NaN")), 0); err != nil {
+			t.Fatal(err)
+		}
+		if err := mergeFunc(accum, []byte(scalarBody(101, "42")), 1); err != nil {
+			t.Fatal(err)
+		}
+		if err := mergeFunc(accum, []byte(scalarBody(102, "99")), 2); err != nil {
+			t.Fatal(err)
+		}
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		MergeAndWriteVectorRespondFunc(MarshalTimeseriesWriter)(w, r, accum, 0)
+		want := `{"status":"success","data":{"resultType":"scalar","result":[101,"42"]}}`
+		if got := w.Body.String(); got != want {
+			t.Fatalf("body: got %s want %s", got, want)
+		}
+	})
+
+	t.Run("keeps_current_non_dataset", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		accum.SetTSData(stubTimeseries{})
+		if err := mergeFunc(accum, []byte(scalarBody(101, "42")), 0); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := accum.GetTSData().(stubTimeseries); !ok {
+			t.Fatalf("expected non-dataset current to remain, got %T", accum.GetTSData())
+		}
+	})
+}
+
+func TestMergeAndWriteVectorBatchMergeFuncEdgeCases(t *testing.T) {
+	batch := MergeAndWriteVectorBatchMergeFunc()
+
+	t.Run("empty", func(t *testing.T) {
+		handled, err := batch(merge.NewAccumulator(), nil)
+		if err != nil || handled {
+			t.Fatalf("handled=%v err=%v", handled, err)
+		}
+	})
+
+	t.Run("non_dataset_falls_back", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		handled, err := batch(accum, []merge.BatchItem{{Data: stubTimeseries{}}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !handled {
+			t.Fatal("expected standard batch merge to handle stub timeseries")
+		}
+	})
+
+	t.Run("vector_falls_back", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		handled, err := batch(accum, []merge.BatchItem{
+			{Data: decodeTS(t, testVector)},
+		})
+		if err != nil || !handled {
+			t.Fatalf("handled=%v err=%v", handled, err)
+		}
+	})
+
+	t.Run("errors_only_falls_back", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		handled, err := batch(accum, []merge.BatchItem{
+			{Data: decodeTS(t, `{"status":"error","errorType":"bad_data","error":"boom"}`)},
+		})
+		if err != nil || !handled {
+			t.Fatalf("handled=%v err=%v", handled, err)
+		}
+	})
+
+	t.Run("existing_vector_falls_back", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		accum.SetTSData(decodeTS(t, testVector))
+		handled, err := batch(accum, []merge.BatchItem{
+			{Data: decodeTS(t, scalarBody(101, "42"))},
+		})
+		if err != nil || !handled {
+			t.Fatalf("handled=%v err=%v", handled, err)
+		}
+		if accum.GetTSData().(*dataset.DataSet).SourceResultType != string(Vector) {
+			t.Fatal("existing vector should remain when batch falls back")
+		}
+	})
+
+	t.Run("existing_error_replaced_by_scalars", func(t *testing.T) {
+		accum := merge.NewAccumulator()
+		accum.SetTSData(decodeTS(t, `{"status":"error","errorType":"bad_data","error":"boom"}`))
+		handled, err := batch(accum, []merge.BatchItem{
+			{Data: decodeTS(t, scalarBody(100, "NaN"))},
+			{Data: decodeTS(t, scalarBody(101, "42"))},
+		})
+		if err != nil || !handled {
+			t.Fatalf("handled=%v err=%v", handled, err)
+		}
+		got := accum.GetTSData().(*dataset.DataSet)
+		if got.SourceResultType != string(Scalar) || !hasNonNaNScalar(got) {
+			t.Fatalf("expected first non-NaN scalar, got %#v", got)
+		}
+	})
+}
+
+func TestHasNonNaNScalarEdgeCases(t *testing.T) {
+	if hasNonNaNScalar(&dataset.DataSet{
+		Results: dataset.Results{nil, {
+			SeriesList: dataset.SeriesList{nil, {
+				Points: dataset.Points{
+					{Values: nil},
+					{Values: []any{1.5}},
+					{Values: []any{"not-a-float"}},
+					{Values: []any{"NaN"}},
+				},
+			}},
+		}},
+	}) {
+		t.Fatal("expected no non-NaN scalar")
+	}
+	if !hasNonNaNScalar(&dataset.DataSet{
+		Results: dataset.Results{{
+			SeriesList: dataset.SeriesList{{
+				Points: dataset.Points{{Values: []any{"3.14"}}},
+			}},
+		}},
+	}) {
+		t.Fatal("expected non-NaN scalar")
+	}
+}


### PR DESCRIPTION
## Description
- Adds test coverage for several Prometheus model/serilalize funcs.
- fixes replica group correctness issue where the errorType might get reset, by restoring from the original dataSet determination.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
