### PR TITLE
tests: increase daemon test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ tags
 
 # for local notes that should not be made part of the project
 notes.txt
+
+# Local AI Agent Files & Directories
+AGENTS.md
+.claude

--- a/Makefile
+++ b/Makefile
@@ -114,14 +114,21 @@ docker-release:
 style:
 	! gofmt -d $$(find . -path ./vendor -prune -o -name '*.go' -print) | grep '^'
 
+.PHONY: check-imports
 check-imports:
 	@go run hack/check-imports/main.go
 
-LINT_FLAGS ?= 
-.PHONY: lint
-lint: check-imports spelling vulncheck
+.PHONY: gofix-diff
+gofix-diff:
 	@go fix -diff ./...
+
+LINT_FLAGS ?= 
+.PHONY: golangci-lint
+golangci-lint:
 	@go tool golangci-lint run $(LINT_FLAGS) -c .golangci.yml
+
+.PHONY: lint
+lint: check-imports spelling vulncheck gofix-diff golangci-lint
 
 .PHONY: vulncheck
 vulncheck:

--- a/pkg/backends/alb/errors/errors_test.go
+++ b/pkg/backends/alb/errors/errors_test.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package errors
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestNewErrInvalidALBOptions(t *testing.T) {
+	t.Parallel()
+	err := NewErrInvalidALBOptions("backend1")
+	var e *InvalidALBOptionsError
+	if !errors.As(err, &e) {
+		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "backend1") {
+		t.Errorf("error %q missing backend name", err.Error())
+	}
+}
+
+func TestNewErrInvalidPoolMemberName(t *testing.T) {
+	t.Parallel()
+	err := NewErrInvalidPoolMemberName("alb1", "missing")
+	var e *InvalidALBOptionsError
+	if !errors.As(err, &e) {
+		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "alb1") || !strings.Contains(msg, "missing") {
+		t.Errorf("error %q missing names", msg)
+	}
+}
+
+func TestNewErrInvalidBackendName(t *testing.T) {
+	t.Parallel()
+	err := NewErrInvalidBackendName("alb1", "bad")
+	var e *InvalidALBOptionsError
+	if !errors.As(err, &e) {
+		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "alb1") || !strings.Contains(msg, "bad") {
+		t.Errorf("error %q missing names", msg)
+	}
+}
+
+func TestNewErrInvalidUserRouterCreds(t *testing.T) {
+	t.Parallel()
+	err := NewErrInvalidUserRouterCreds("alb1")
+	var e *InvalidALBOptionsError
+	if !errors.As(err, &e) {
+		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
+	}
+	if !strings.Contains(err.Error(), "alb1") {
+		t.Errorf("error %q missing alb name", err.Error())
+	}
+	if !strings.Contains(err.Error(), "authenticator_name") {
+		t.Errorf("error %q missing authenticator hint", err.Error())
+	}
+}
+
+func TestSentinelErrors(t *testing.T) {
+	t.Parallel()
+	for _, err := range []error{
+		ErrInvalidTimeSeriesMergeProvider,
+		ErrUnsupportedMechanism,
+		ErrInvalidOptionsMetadata,
+	} {
+		if err == nil || err.Error() == "" {
+			t.Errorf("expected non-empty sentinel error")
+		}
+	}
+}

--- a/pkg/backends/alb/options/options_test.go
+++ b/pkg/backends/alb/options/options_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	ur "github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/ur/options"
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb/names"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
 
@@ -141,4 +142,103 @@ func TestErrInvalidALBOptions(t *testing.T) {
 	if !ok {
 		t.Error("invalid type assertion")
 	}
+}
+
+func TestCloneWithUserRouter(t *testing.T) {
+	o := New()
+	o.Pool = []string{"a", "b"}
+	o.UserRouter = &ur.Options{DefaultBackend: "prom1"}
+	co := o.Clone()
+	require.NotNil(t, co.UserRouter)
+	require.Equal(t, "prom1", co.UserRouter.DefaultBackend)
+	co.UserRouter.DefaultBackend = "changed"
+	require.Equal(t, "prom1", o.UserRouter.DefaultBackend)
+}
+
+func TestInitializeDeprecatedFGRAndDefaultOutputFormat(t *testing.T) {
+	o := New()
+	o.MechanismName = names.MechanismFGR
+	o.FGRStatusCodes = []int{200, 204}
+	require.NoError(t, o.Initialize(""))
+	require.Equal(t, []int{200, 204}, o.FGROptions.StatusCodes)
+	require.True(t, o.FgrCodesLookup.Contains(200))
+	require.True(t, o.FgrCodesLookup.Contains(204))
+
+	o = New()
+	o.MechanismName = names.MechanismTSM
+	require.NoError(t, o.Initialize(""))
+	require.Equal(t, "prometheus", o.OutputFormat)
+}
+
+func TestValidate(t *testing.T) {
+	t.Run("user router required", func(t *testing.T) {
+		o := New()
+		o.MechanismName = names.MechanismUR
+		ok, err := o.Validate()
+		require.False(t, ok)
+		require.ErrorIs(t, err, ErrUserRouterRequired)
+	})
+
+	t.Run("user router ok", func(t *testing.T) {
+		o := New()
+		o.MechanismName = names.MechanismUR
+		o.UserRouter = &ur.Options{DefaultBackend: "prom1"}
+		ok, err := o.Validate()
+		require.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid tsm output format", func(t *testing.T) {
+		o := New()
+		o.MechanismName = names.MechanismTSM
+		o.OutputFormat = "not-a-provider"
+		ok, err := o.Validate()
+		require.False(t, ok)
+		require.ErrorIs(t, err, ErrInvalidOutputFormat)
+	})
+
+	t.Run("valid tsm output format", func(t *testing.T) {
+		o := New()
+		o.MechanismName = names.MechanismTSM
+		o.OutputFormat = "prometheus"
+		ok, err := o.Validate()
+		require.True(t, ok)
+		require.NoError(t, err)
+	})
+
+	t.Run("output format only for tsm", func(t *testing.T) {
+		o := New()
+		o.MechanismName = names.MechanismRR
+		o.OutputFormat = "prometheus"
+		ok, err := o.Validate()
+		require.False(t, ok)
+		require.ErrorIs(t, err, ErrOutputFormatOnlyForTSM)
+	})
+
+	t.Run("rr without output format", func(t *testing.T) {
+		o := New()
+		o.MechanismName = names.MechanismRR
+		ok, err := o.Validate()
+		require.True(t, ok)
+		require.NoError(t, err)
+	})
+}
+
+func TestValidatePool(t *testing.T) {
+	o := New()
+	o.Pool = []string{"prom1", "prom2"}
+	err := o.ValidatePool("alb1", sets.New([]string{"prom1", "prom2", "prom3"}))
+	require.NoError(t, err)
+
+	err = o.ValidatePool("alb1", sets.New([]string{"prom1"}))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "prom2")
+	require.Contains(t, err.Error(), "alb1")
+}
+
+func TestUnmarshalYAMLError(t *testing.T) {
+	o := New()
+	want := errors.New("boom")
+	err := o.UnmarshalYAML(func(any) error { return want })
+	require.ErrorIs(t, err, want)
 }

--- a/pkg/backends/clickhouse/authenticator/authenticator_test.go
+++ b/pkg/backends/clickhouse/authenticator/authenticator_test.go
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package authenticator
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	pkgerrors "github.com/trickstercache/trickster/v2/pkg/errors"
+	ae "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/errors"
+	authopt "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
+)
+
+func TestRegistryEntry(t *testing.T) {
+	t.Parallel()
+	e := RegistryEntry()
+	if e.Provider != ID {
+		t.Errorf("unexpected provider %q", e.Provider)
+	}
+	if e.Provider != providers.ClickHouse {
+		t.Errorf("expected clickhouse provider, got %q", e.Provider)
+	}
+	if e.New == nil {
+		t.Fatal("expected New constructor")
+	}
+}
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+	a, err := New(map[string]any{"options": authopt.New()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if a == nil {
+		t.Fatal("expected non-nil authenticator")
+	}
+
+	_, err = New(nil)
+	if !errors.Is(err, pkgerrors.ErrInvalidOptions) {
+		t.Fatalf("expected ErrInvalidOptions, got %v", err)
+	}
+}
+
+func TestSetAndExtractCredentialsQueryParams(t *testing.T) {
+	t.Parallel()
+	auth, err := New(map[string]any{"options": authopt.New()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/?user=old&password=oldpass", nil)
+	if err := auth.SetCredentials(req, "alice", "secret"); err != nil {
+		t.Fatalf("SetCredentials: %v", err)
+	}
+	q := req.URL.Query()
+	if q.Get("user") != "alice" || q.Get("password") != "secret" {
+		t.Errorf("query creds = user=%q password=%q", q.Get("user"), q.Get("password"))
+	}
+
+	u, p, err := auth.ExtractCredentials(req)
+	if err != nil {
+		t.Fatalf("ExtractCredentials: %v", err)
+	}
+	if u != "alice" || p != "secret" {
+		t.Errorf("extracted (%q, %q)", u, p)
+	}
+}
+
+func TestSetAndExtractCredentialsBasicAuth(t *testing.T) {
+	t.Parallel()
+	auth, err := New(map[string]any{"options": authopt.New()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/", nil)
+	if err := auth.SetCredentials(req, "bob", "token"); err != nil {
+		t.Fatalf("SetCredentials: %v", err)
+	}
+	u, p, ok := req.BasicAuth()
+	if !ok || u != "bob" || p != "token" {
+		t.Errorf("basic auth = (%q, %q, %v)", u, p, ok)
+	}
+
+	u, p, err = auth.ExtractCredentials(req)
+	if err != nil {
+		t.Fatalf("ExtractCredentials: %v", err)
+	}
+	if u != "bob" || p != "token" {
+		t.Errorf("extracted (%q, %q)", u, p)
+	}
+}
+
+func TestExtractCredentialsMissing(t *testing.T) {
+	t.Parallel()
+	auth, err := New(map[string]any{"options": authopt.New()})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "http://example/", nil)
+	_, _, err = auth.ExtractCredentials(req)
+	if !errors.Is(err, ae.ErrInvalidCredentials) {
+		t.Fatalf("expected ErrInvalidCredentials, got %v", err)
+	}
+
+	// Only one of the query params present falls back to BasicAuth and fails.
+	req = httptest.NewRequest(http.MethodGet, "http://example/?user=alice", nil)
+	_, _, err = auth.ExtractCredentials(req)
+	if !errors.Is(err, ae.ErrInvalidCredentials) {
+		t.Fatalf("expected ErrInvalidCredentials, got %v", err)
+	}
+}

--- a/pkg/backends/clickhouse/model/marshal_test.go
+++ b/pkg/backends/clickhouse/model/marshal_test.go
@@ -19,10 +19,14 @@ package model
 import (
 	"bytes"
 	"encoding/json"
+	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+	"github.com/trickstercache/trickster/v2/pkg/timeseries/dataset"
 )
 
 func FuzzWFDataItemMarshalJSON(f *testing.F) {
@@ -100,5 +104,290 @@ func TestMarshalTimeseries(t *testing.T) {
 	}
 	if string(b) != testDataTSVWithNamesAndTypes {
 		t.Errorf("unexpected output:\n%s", string(b))
+	}
+}
+
+func TestMarshalTimeseriesWriterFormats(t *testing.T) {
+	ds := testDataSet()
+	tests := []struct {
+		name   string
+		format byte
+		want   string
+	}{
+		{name: "json", format: 0, want: testDataJSONMinified},
+		{name: "csv", format: 1, want: testDataCSV},
+		{name: "csv with names", format: 2, want: "t,hostname,avg_query,avg_global_thread\n" + testDataCSV},
+		{name: "tsv", format: 3, want: strings.ReplaceAll(testDataCSV, ",", "\t")},
+		{name: "tsv with names", format: 4, want: "t\thostname\tavg_query\tavg_global_thread\n" +
+			strings.ReplaceAll(testDataCSV, ",", "\t")},
+		{name: "tsv with names and types", format: 5, want: testDataTSVWithNamesAndTypes},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := MarshalTimeseries(ds, &timeseries.RequestOptions{OutputFormat: tc.format}, 200)
+			if err != nil {
+				t.Fatalf("MarshalTimeseries: %v", err)
+			}
+			if strings.TrimSpace(string(b)) != strings.TrimSpace(tc.want) {
+				t.Errorf("got:\n%s\nwant:\n%s", string(b), tc.want)
+			}
+		})
+	}
+}
+
+func TestMarshalTimeseriesErrors(t *testing.T) {
+	_, err := MarshalTimeseries(nil, nil, 200)
+	if err != timeseries.ErrUnknownFormat {
+		t.Fatalf("nil ts: got %v", err)
+	}
+
+	err = MarshalTimeseriesWriter(nil, nil, 200, new(bytes.Buffer))
+	if err != timeseries.ErrUnknownFormat {
+		t.Fatalf("nil writer input: got %v", err)
+	}
+
+	// Unsupported output format.
+	err = MarshalTimeseriesWriter(testDataSet(),
+		&timeseries.RequestOptions{OutputFormat: 99}, 200, new(bytes.Buffer))
+	if err != timeseries.ErrUnknownFormat {
+		t.Fatalf("bad format: got %v", err)
+	}
+
+	// Non-dataset timeseries.
+	fake := &fakeTimeseries{}
+	err = MarshalTimeseriesWriter(fake, &timeseries.RequestOptions{}, 200, new(bytes.Buffer))
+	if err != timeseries.ErrUnknownFormat {
+		t.Fatalf("non-dataset: got %v", err)
+	}
+}
+
+type fakeTimeseries struct{}
+
+func (f *fakeTimeseries) SetExtents(timeseries.ExtentList)             {}
+func (f *fakeTimeseries) Extents() timeseries.ExtentList               { return nil }
+func (f *fakeTimeseries) VolatileExtents() timeseries.ExtentList       { return nil }
+func (f *fakeTimeseries) SetVolatileExtents(timeseries.ExtentList)     {}
+func (f *fakeTimeseries) SetTimeRangeQuery(*timeseries.TimeRangeQuery) {}
+func (f *fakeTimeseries) Step() time.Duration                          { return 0 }
+func (f *fakeTimeseries) Merge(bool, ...timeseries.Timeseries)         {}
+func (f *fakeTimeseries) Sort()                                        {}
+func (f *fakeTimeseries) CropToRange(timeseries.Extent)                {}
+func (f *fakeTimeseries) CropToSize(int, time.Time, timeseries.Extent) {}
+func (f *fakeTimeseries) CroppedClone(timeseries.Extent) timeseries.Timeseries {
+	return f
+}
+func (f *fakeTimeseries) SeriesCount() int             { return 0 }
+func (f *fakeTimeseries) ValueCount() int64            { return 0 }
+func (f *fakeTimeseries) Size() int64                  { return 0 }
+func (f *fakeTimeseries) Clone() timeseries.Timeseries { return f }
+func (f *fakeTimeseries) TimestampCount() int64        { return 0 }
+
+func TestMarshalXSVHeadersAndEdges(t *testing.T) {
+	ds := testDataSet()
+	rw := httptest.NewRecorder()
+	err := marshalTimeseriesXSV(rw, ds, nil, true, false, ',')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ct := rw.Header().Get(headers.NameContentType); !strings.Contains(ct, "comma-separated") {
+		t.Errorf("unexpected content-type %q", ct)
+	}
+	if got := rw.Header().Get(formatHeader); got != "CSVWithNames" {
+		t.Errorf("unexpected format header %q", got)
+	}
+	body := rw.Body.String()
+	if !strings.HasPrefix(body, "t,hostname,avg_query,avg_global_thread\n") {
+		t.Errorf("expected names row, got %s", body)
+	}
+
+	rw = httptest.NewRecorder()
+	err = marshalTimeseriesXSV(rw, ds, nil, true, true, '\t')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ct := rw.Header().Get(headers.NameContentType); !strings.Contains(ct, "tab-separated") {
+		t.Errorf("unexpected content-type %q", ct)
+	}
+	if got := rw.Header().Get(formatHeader); got != "TSVWithNamesAndTypes" {
+		t.Errorf("unexpected format header %q", got)
+	}
+
+	// No value/tag fields => ErrNoTimerangeQuery
+	empty := &dataset.DataSet{
+		Results: []*dataset.Result{{
+			SeriesList: []*dataset.Series{{
+				Header: dataset.SeriesHeader{
+					TimestampField: timeseries.FieldDefinition{
+						Name:     "t",
+						DataType: 0,
+					},
+				},
+			}},
+		}},
+	}
+	err = marshalTimeseriesXSV(new(bytes.Buffer), empty, nil, false, false, ',')
+	if err != timeseries.ErrNoTimerangeQuery {
+		t.Fatalf("expected ErrNoTimerangeQuery, got %v", err)
+	}
+
+	// Timestamp OutputPosition beyond field count.
+	badPos := testDataSet()
+	badPos.Results[0].SeriesList[0].Header.TimestampField.OutputPosition = 99
+	err = marshalTimeseriesXSV(new(bytes.Buffer), badPos, nil, false, false, ',')
+	if err != timeseries.ErrTableHeader {
+		t.Fatalf("expected ErrTableHeader, got %v", err)
+	}
+}
+
+func TestMarshalXSVUntrackedAndSkips(t *testing.T) {
+	ds := &dataset.DataSet{
+		Results: []*dataset.Result{{
+			SeriesList: []*dataset.Series{{
+				Header: dataset.SeriesHeader{
+					TimestampField: timeseries.FieldDefinition{
+						Name:           "t",
+						DataType:       timeseries.DateTimeUnixMilli,
+						SDataType:      "UInt64",
+						Role:           timeseries.RoleTimestamp,
+						OutputPosition: 0,
+					},
+					TagFieldsList: []timeseries.FieldDefinition{
+						{
+							// Same name as timestamp is skipped in header rows.
+							Name:           "t",
+							Role:           timeseries.RoleTag,
+							OutputPosition: 0,
+							SDataType:      "String",
+						},
+						{
+							Name:           "host",
+							Role:           timeseries.RoleTag,
+							OutputPosition: 99, // skipped: beyond fieldCount
+							SDataType:      "String",
+						},
+						{
+							Name:           "env",
+							Role:           timeseries.RoleTag,
+							OutputPosition: 1,
+							SDataType:      "String",
+						},
+					},
+					ValueFieldsList: []timeseries.FieldDefinition{
+						{
+							Name:           "v",
+							Role:           timeseries.RoleValue,
+							OutputPosition: 2,
+							SDataType:      "Float64",
+						},
+					},
+					UntrackedFieldsList: []timeseries.FieldDefinition{
+						{
+							Name:           "meta",
+							Role:           timeseries.RoleUntracked,
+							OutputPosition: 3,
+							DefaultValue:   "x",
+							SDataType:      "String",
+						},
+						{
+							Name:           "skip",
+							Role:           timeseries.RoleUntracked,
+							OutputPosition: -1, // skipped in data rows
+							DefaultValue:   "nope",
+							SDataType:      "String",
+						},
+					},
+					Tags: dataset.Tags{"env": "prod"},
+				},
+				Points: []dataset.Point{
+					{Epoch: 1577836800000000000, Values: []any{"1.5"}},
+				},
+			}},
+		}},
+	}
+
+	// Avoid name/type header rows: vals with OutputPosition < 0 are not
+	// bounds-checked there, but data-row emission skips invalid positions.
+	b := new(bytes.Buffer)
+	err := marshalTimeseriesXSV(b, ds, nil, false, false, ',')
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := strings.TrimSpace(b.String())
+	if !strings.Contains(line, "prod") {
+		t.Errorf("expected tag value in %s", line)
+	}
+	if !strings.Contains(line, "x") {
+		t.Errorf("expected untracked default in %s", line)
+	}
+	if !strings.Contains(line, "1.5") {
+		t.Errorf("expected value in %s", line)
+	}
+	if strings.Contains(line, "nope") {
+		t.Errorf("did not expect skipped untracked default in %s", line)
+	}
+}
+
+func TestMarshalXSVHeaderTagSkips(t *testing.T) {
+	ds := &dataset.DataSet{
+		Results: []*dataset.Result{{
+			SeriesList: []*dataset.Series{{
+				Header: dataset.SeriesHeader{
+					TimestampField: timeseries.FieldDefinition{
+						Name:           "t",
+						DataType:       timeseries.DateTimeUnixMilli,
+						SDataType:      "UInt64",
+						Role:           timeseries.RoleTimestamp,
+						OutputPosition: 0,
+					},
+					TagFieldsList: []timeseries.FieldDefinition{
+						{
+							Name:           "t", // same as timestamp: skipped in header row
+							Role:           timeseries.RoleTag,
+							OutputPosition: 0,
+							SDataType:      "String",
+						},
+						{
+							Name:           "host",
+							Role:           timeseries.RoleTag,
+							OutputPosition: 99, // > fieldCount: skipped in header row
+							SDataType:      "String",
+						},
+						{
+							Name:           "env",
+							Role:           timeseries.RoleTag,
+							OutputPosition: 1,
+							SDataType:      "String",
+						},
+					},
+					ValueFieldsList: []timeseries.FieldDefinition{
+						{
+							Name:           "v",
+							Role:           timeseries.RoleValue,
+							OutputPosition: 2,
+							SDataType:      "Float64",
+						},
+					},
+					Tags: dataset.Tags{"env": "prod"},
+				},
+				Points: []dataset.Point{
+					{Epoch: 1577836800000000000, Values: []any{"1.5"}},
+				},
+			}},
+		}},
+	}
+
+	b := new(bytes.Buffer)
+	if err := marshalTimeseriesXSV(b, ds, nil, true, false, ','); err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(b.String()), "\n")
+	if len(lines) < 2 {
+		t.Fatalf("expected names + data, got %v", lines)
+	}
+	if !strings.HasPrefix(lines[0], "t,") {
+		t.Errorf("unexpected names row %q", lines[0])
+	}
+	if strings.Contains(lines[0], "host") {
+		t.Errorf("host tag with invalid output position should be skipped: %q", lines[0])
 	}
 }

--- a/pkg/backends/clickhouse/url_test.go
+++ b/pkg/backends/clickhouse/url_test.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/timeseries"
 )
 
@@ -54,5 +56,108 @@ func TestSetExtent(t *testing.T) {
 	client.SetExtent(r, trq, nil)
 	if expected != r.URL.RawQuery {
 		t.Errorf("\nexpected [%s]\ngot      [%s]", expected, r.URL.RawQuery)
+	}
+
+	client.SetExtent(nil, trq, e)
+	client.SetExtent(r, nil, e)
+}
+
+func TestSetExtentWithBody(t *testing.T) {
+	start := time.Unix(1577836800, 0).UTC()
+	end := time.Unix(1577836860, 0).UTC()
+	e := &timeseries.Extent{Start: start, End: end}
+	trq := &timeseries.TimeRangeQuery{
+		Statement: `SELECT * WHERE <$RANGE$> FORMAT <$FORMAT$>`,
+		TimestampDefinition: timeseries.FieldDefinition{
+			Name:     "ts",
+			DataType: timeseries.DateTimeUnixSecs,
+		},
+	}
+	r, err := http.NewRequest(http.MethodPost, "http://example/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	(&Client{}).SetExtent(r, trq, e)
+	body, err := request.GetBody(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "ts BETWEEN 1577836800 AND 1577836860") {
+		t.Errorf("unexpected body: %s", got)
+	}
+	if !strings.Contains(got, "TSVWithNamesAndTypes") {
+		t.Errorf("expected format token replacement in %s", got)
+	}
+	if r.URL.RawQuery != "" {
+		t.Errorf("expected empty query for body request, got %q", r.URL.RawQuery)
+	}
+}
+
+func TestFormatTimestampValues(t *testing.T) {
+	start := time.Unix(1577836800, 500*int64(time.Millisecond)).UTC()
+	end := time.Unix(1577836860, 0).UTC()
+	e := &timeseries.Extent{Start: start, End: end}
+
+	tests := []struct {
+		name      string
+		dataType  timeseries.FieldDataType
+		wantStart string
+		wantEnd   string
+	}{
+		{
+			name:      "milli",
+			dataType:  timeseries.DateTimeUnixMilli,
+			wantStart: "1577836800500",
+			wantEnd:   "1577836860000",
+		},
+		{
+			name:      "nano",
+			dataType:  timeseries.DateTimeUnixNano,
+			wantStart: "1577836800500000000",
+			wantEnd:   "1577836860000000000",
+		},
+		{
+			name:      "sql",
+			dataType:  timeseries.DateTimeSQL,
+			wantStart: "'2020-01-01 00:00:00'",
+			wantEnd:   "'2020-01-01 00:01:00'",
+		},
+		{
+			name:      "default secs",
+			dataType:  timeseries.DateTimeUnixSecs,
+			wantStart: "1577836800",
+			wantEnd:   "1577836860",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStart, gotEnd := formatTimestampValues(tc.dataType, e)
+			if gotStart != tc.wantStart || gotEnd != tc.wantEnd {
+				t.Errorf("got (%q, %q) want (%q, %q)",
+					gotStart, gotEnd, tc.wantStart, tc.wantEnd)
+			}
+		})
+	}
+}
+
+func TestInterpolateTimeQuerySecondaryType(t *testing.T) {
+	start := time.Unix(1577836800, 0).UTC()
+	end := time.Unix(1577836860, 0).UTC()
+	e := &timeseries.Extent{Start: start, End: end}
+	out := interpolateTimeQuery(
+		`WHERE <$RANGE$> AND secondary BETWEEN <$TS1$> AND <$TS2$>`,
+		timeseries.FieldDefinition{
+			Name:          "ts",
+			DataType:      timeseries.DateTimeUnixMilli,
+			ProviderData1: byte(timeseries.DateTimeUnixSecs),
+		},
+		e,
+	)
+	if !strings.Contains(out, "ts BETWEEN 1577836800000 AND 1577836860000") {
+		t.Errorf("unexpected primary range: %s", out)
+	}
+	if !strings.Contains(out, "secondary BETWEEN 1577836800 AND 1577836860") {
+		t.Errorf("unexpected secondary range: %s", out)
 	}
 }

--- a/pkg/cache/filesystem/options/options_test.go
+++ b/pkg/cache/filesystem/options/options_test.go
@@ -16,11 +16,77 @@
 
 package options
 
-import "testing"
+import (
+	"errors"
+	"testing"
 
-func TestNew(t *testing.T) {
+	d "github.com/trickstercache/trickster/v2/pkg/cache/options/defaults"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestNewDefaults(t *testing.T) {
 	o := New()
 	if o == nil {
-		t.Error("expected non-nil options")
+		t.Fatal("expected non-nil options")
+	}
+	if o.CachePath != d.DefaultCachePath {
+		t.Errorf("expected CachePath %q, got %q", d.DefaultCachePath, o.CachePath)
+	}
+}
+
+func TestEqual(t *testing.T) {
+	o := New()
+
+	if o.Equal(nil) {
+		t.Error("expected false for nil comparison")
+	}
+	if !o.Equal(o) {
+		t.Error("expected options equal to self")
+	}
+	if !o.Equal(New()) {
+		t.Error("expected default options to be equal")
+	}
+	if !(*Options)(nil).Equal(nil) {
+		t.Error("expected nil receivers to be equal")
+	}
+	if (*Options)(nil).Equal(o) {
+		t.Error("expected nil receiver unequal to non-nil")
+	}
+
+	o2 := New()
+	o2.CachePath = "/other"
+	if o.Equal(o2) {
+		t.Error("expected CachePath difference to make options unequal")
+	}
+}
+
+func TestUnmarshalYAML(t *testing.T) {
+	const raw = `
+cache_path: /tmp/fs-cache
+`
+	o := &Options{}
+	if err := yaml.Unmarshal([]byte(raw), o); err != nil {
+		t.Fatalf("yaml.Unmarshal: %v", err)
+	}
+	if o.CachePath != "/tmp/fs-cache" {
+		t.Errorf("expected CachePath /tmp/fs-cache, got %q", o.CachePath)
+	}
+
+	o2 := &Options{}
+	if err := yaml.Unmarshal([]byte("{}"), o2); err != nil {
+		t.Fatalf("yaml.Unmarshal empty: %v", err)
+	}
+	if !o2.Equal(New()) {
+		t.Errorf("expected defaults, got %+v", o2)
+	}
+}
+
+func TestUnmarshalYAMLError(t *testing.T) {
+	o := &Options{}
+	want := errors.New("boom")
+	err := o.UnmarshalYAML(func(any) error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("expected %v, got %v", want, err)
 	}
 }

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -173,7 +173,6 @@ func Hup(si *instance.ServerInstance, source string, args ...string) (bool, erro
 	oldClients := si.Backends
 	oldCaches := si.Caches
 	oldHealthChecker := si.HealthChecker
-	oldListeners := si.Listeners
 
 	hupFunc := newHupFunc(si, args)
 
@@ -185,7 +184,6 @@ func Hup(si *instance.ServerInstance, source string, args ...string) (bool, erro
 		si.Backends = oldClients
 		si.Caches = oldCaches
 		si.HealthChecker = oldHealthChecker
-		si.Listeners = oldListeners
 		metrics.ReloadFailuresTotal.Inc()
 		metrics.LastReloadSuccessful.Set(0)
 		metrics.ReloadDurationSeconds.Observe(time.Since(startTime).Seconds())
@@ -201,19 +199,6 @@ func Hup(si *instance.ServerInstance, source string, args ...string) (bool, erro
 			logger.Warn("reload completed but some listeners not ready",
 				logging.Pairs{"error": err.Error(), "source": source})
 		}
-	}
-
-	if oldListeners != nil && oldListeners != si.Listeners {
-		drainTimeout := 30 * time.Second
-		if newConf.MgmtConfig != nil && newConf.MgmtConfig.ReloadDrainTimeout > 0 {
-			drainTimeout = time.Duration(newConf.MgmtConfig.ReloadDrainTimeout)
-		}
-		safego.Go(reloadGoroutinePanic("oldListeners.Shutdown", source), func() {
-			if err := oldListeners.Shutdown(drainTimeout); err != nil {
-				logger.Warn("error shutting down old listeners",
-					logging.Pairs{"error": err.Error(), "source": source})
-			}
-		})
 	}
 
 	if oldClients != nil {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2026 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/config"
+	"github.com/trickstercache/trickster/v2/pkg/daemon/instance"
+	"github.com/trickstercache/trickster/v2/pkg/daemon/setup"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+)
+
+func init() {
+	// keeps test output free of application log lines
+	logger.SetLogger(logging.NoopLogger())
+}
+
+// writeConfig writes body into dir/trickster.yaml and returns the path. Using
+// an explicit dir lets a test rewrite the same path to trigger a reload.
+func writeConfig(t *testing.T, dir, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, "trickster.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func availablePort(t *testing.T) int {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// runnableConfig returns a config body that serves on port and leaves the
+// mgmt and metrics listeners unbound.
+func runnableConfig(port int) string {
+	return fmt.Sprintf(`
+listeners:
+  default:
+    address: 127.0.0.1
+    port: %d
+  mgmt:
+    port: 0
+  metrics:
+    port: 0
+backends:
+  test:
+    provider: rp
+    origin_url: 'http://example.com'
+`, port)
+}
+
+// unapplyableConfig writes a malformed credentials file into dir and returns a
+// config body referencing it. Configuration validation only checks that the
+// users file is readable, so this config validates but fails when ApplyConfig
+// compiles the authenticator.
+func unapplyableConfig(t *testing.T, dir string) string {
+	t.Helper()
+	usersFile := filepath.Join(dir, "users.csv")
+	// a short row makes encoding/csv reject the file
+	if err := os.WriteFile(usersFile, []byte("user,hash\na,b,c\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return fmt.Sprintf(`
+listeners:
+  default:
+    port: 0
+  mgmt:
+    port: 0
+  metrics:
+    port: 0
+authenticators:
+  test_auth:
+    provider: basic
+    users_file: '%s'
+    users_file_format: csv
+backends:
+  test:
+    provider: rp
+    origin_url: 'http://example.com'
+`, usersFile)
+}
+
+func waitForPort(t *testing.T, port int) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp",
+			fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("nothing is listening on port %d", port)
+}
+
+func TestStartPrintVersion(t *testing.T) {
+	if err := Start(context.Background(), "-version"); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+func TestStartValidateConfig(t *testing.T) {
+	path := writeConfig(t, t.TempDir(), runnableConfig(0))
+	if err := Start(context.Background(), "-validate-config", "-config", path); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+func TestStartBootstrapError(t *testing.T) {
+	if err := Start(context.Background(), "-not-a-real-flag"); err == nil {
+		t.Error("expected an error for an unknown flag")
+	}
+}
+
+func TestStartApplyConfigError(t *testing.T) {
+	dir := t.TempDir()
+	path := writeConfig(t, dir, unapplyableConfig(t, dir))
+	if err := Start(context.Background(), "-config", path); err == nil {
+		t.Error("expected an error when the config cannot be applied")
+	}
+}
+
+func TestStartServesAndShutsDownOnContextCancel(t *testing.T) {
+	port := availablePort(t)
+	path := writeConfig(t, t.TempDir(), runnableConfig(port))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errs := make(chan error, 1)
+	go func() { errs <- Start(ctx, "-config", path) }()
+
+	waitForPort(t, port)
+	response, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/trickster/ping", port))
+	if err != nil {
+		t.Fatal(err)
+	}
+	response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Errorf("ping status = %d, want %d", response.StatusCode, http.StatusOK)
+	}
+
+	cancel()
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Errorf("err = %v, want nil", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+func TestHupNoExistingConfig(t *testing.T) {
+	si := &instance.ServerInstance{}
+	ok, err := Hup(si, "test")
+	if ok {
+		t.Error("expected no reload when the instance has no config")
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+func TestHupNotStale(t *testing.T) {
+	// a config with no backing file path is never considered stale
+	si := &instance.ServerInstance{Config: config.NewConfig()}
+	ok, err := Hup(si, "test")
+	if ok {
+		t.Error("expected no reload for a non-stale config")
+	}
+	if err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+// markStale gives conf a backing file path with a zero last-modified time, so
+// the next staleness check sees the file as changed.
+func markStale(conf *config.Config, path string) {
+	conf.Main.SetStalenessInfo(path, time.Time{}, time.Time{})
+}
+
+func TestHupBootstrapFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := writeConfig(t, dir, runnableConfig(0))
+	conf, err := setup.LoadAndValidate("-config", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	markStale(conf, path)
+
+	si := &instance.ServerInstance{Config: conf}
+	// the reload reads from a path that no longer parses
+	if err := os.WriteFile(path, []byte("\tnot: [valid yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ok, err := Hup(si, "test", "-config", path)
+	if ok {
+		t.Error("expected the reload to fail")
+	}
+	if err == nil {
+		t.Error("expected an error from the failed reload")
+	}
+}
+
+func TestHupApplyConfigFailureRollsBack(t *testing.T) {
+	dir := t.TempDir()
+	path := writeConfig(t, dir, runnableConfig(0))
+	conf, clients, err := setup.BootstrapConfig("-config", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	group := listener.NewGroup()
+	t.Cleanup(func() { _ = group.Shutdown(0) })
+	si := &instance.ServerInstance{Listeners: group}
+	if err := setup.ApplyConfig(si, conf, clients, nil, nil, group); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if si.HealthChecker != nil {
+			si.HealthChecker.Shutdown()
+		}
+	})
+	oldConfig := si.Config
+	oldBackends := si.Backends
+	oldCaches := si.Caches
+	oldHealthChecker := si.HealthChecker
+	markStale(si.Config, path)
+
+	// the replacement config validates but cannot be applied
+	writeConfig(t, dir, unapplyableConfig(t, dir))
+	ok, err := Hup(si, "test", "-config", path)
+	if ok {
+		t.Error("expected the reload to fail")
+	}
+	if err == nil {
+		t.Error("expected an error from the failed reload")
+	}
+	if si.Config != oldConfig {
+		t.Error("config was not rolled back")
+	}
+	if len(si.Backends) != len(oldBackends) {
+		t.Error("backends were not rolled back")
+	}
+	if len(si.Caches) != len(oldCaches) {
+		t.Error("caches were not rolled back")
+	}
+	if si.HealthChecker != oldHealthChecker {
+		t.Error("health checker was not rolled back")
+	}
+}
+
+func TestHupSuccess(t *testing.T) {
+	dir := t.TempDir()
+	firstPort := availablePort(t)
+	path := writeConfig(t, dir, runnableConfig(firstPort))
+
+	conf, clients, err := setup.BootstrapConfig("-config", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	group := listener.NewGroup()
+	t.Cleanup(func() { _ = group.Shutdown(0) })
+	si := &instance.ServerInstance{Listeners: group}
+	if err := setup.ApplyConfig(si, conf, clients, nil, nil, group); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if si.HealthChecker != nil {
+			si.HealthChecker.Shutdown()
+		}
+	})
+	waitForPort(t, firstPort)
+	markStale(si.Config, path)
+
+	secondPort := availablePort(t)
+	writeConfig(t, dir, runnableConfig(secondPort))
+	ok, err := Hup(si, "test", "-config", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected the reload to succeed")
+	}
+	if si.Config == conf {
+		t.Error("expected the instance to hold the reloaded config")
+	}
+	waitForPort(t, secondPort)
+}
+
+func TestReloadGoroutinePanicHandler(t *testing.T) {
+	// the handler only logs; it must tolerate any panic value
+	reloadGoroutinePanic("test-site", "test-source")("boom", []byte("stack"))
+}

--- a/pkg/daemon/setup/listeners_test.go
+++ b/pkg/daemon/setup/listeners_test.go
@@ -21,6 +21,9 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -30,6 +33,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
+	to "github.com/trickstercache/trickster/v2/pkg/proxy/tls/options"
+	tlstest "github.com/trickstercache/trickster/v2/pkg/testutil/tls"
 )
 
 func TestListenerEnabledOn(t *testing.T) {
@@ -193,4 +198,151 @@ func assertResponseBody(t *testing.T, port int, want string) {
 	if string(body) != want {
 		t.Errorf("response body = %q, want %q", body, want)
 	}
+}
+
+func TestApplyListenerConfigsNoListeners(t *testing.T) {
+	group := listener.NewGroup()
+	t.Cleanup(func() { _ = group.Shutdown(0) })
+	// nil and empty configs are no-ops
+	applyListenerConfigs(nil, nil, nil, nil, nil, nil, nil, nil, group)
+	conf := config.NewConfig()
+	conf.Listeners = nil
+	applyListenerConfigs(conf, nil, nil, nil, nil, nil, nil, nil, group)
+}
+
+// TestApplyListenerConfigsManagementRoutes covers the config-handler and pprof
+// route registration on both the mgmt and metrics routers.
+func TestApplyListenerConfigsManagementRoutes(t *testing.T) {
+	group := listener.NewGroup()
+	t.Cleanup(func() { _ = group.Shutdown(0) })
+
+	conf := config.NewConfig()
+	deactivateBuiltinListeners(conf)
+	conf.MgmtConfig.ConfigHandlerListener = mgmt.ListenerNameBoth
+	conf.MgmtConfig.PprofListener = mgmt.ListenerNameBoth
+
+	metricsRouter := lm.NewRouter()
+	applyListenerConfigs(conf, nil, nil, http.NotFoundHandler(), metricsRouter,
+		nil, nil, nil, group)
+
+	for _, path := range []string{"/metrics", conf.MgmtConfig.ConfigHandlerPath} {
+		r := httptest.NewRequest(http.MethodGet, path, nil)
+		w := httptest.NewRecorder()
+		metricsRouter.ServeHTTP(w, r)
+		if w.Code == http.StatusNotFound {
+			t.Errorf("expected %s to be registered on the metrics router", path)
+		}
+	}
+}
+
+func TestApplyListenerConfigsTLS(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "test.key.pem")
+	certPath := filepath.Join(dir, "test.cert.pem")
+	if err := tlstest.WriteTestKeyAndCert(false, keyPath, certPath); err != nil {
+		t.Fatal(err)
+	}
+
+	group := listener.NewGroup()
+	t.Cleanup(func() { _ = group.Shutdown(0) })
+
+	port := availablePort(t)
+	conf := tlsTestConfig(t, keyPath, certPath, port)
+	key := listenerKey(listenerconfig.DefaultFrontendName, true)
+
+	routers := map[string]router.Router{listenerconfig.DefaultFrontendName: markerRouter("tls")}
+	applyListenerConfigs(conf, nil, routers, http.NotFoundHandler(), lm.NewRouter(),
+		nil, nil, nil, group)
+	waitForListener(t, group, key)
+	l := group.Get(key)
+	if l == nil {
+		t.Fatal("expected a TLS listener")
+	}
+
+	// An unchanged TLS listener is not restarted; its certificates are
+	// refreshed in place instead.
+	second := conf.Clone()
+	second.Listeners[listenerconfig.DefaultFrontendName].ServeTLS = true
+	applyListenerConfigs(second, conf, routers, http.NotFoundHandler(), lm.NewRouter(),
+		nil, nil, nil, group)
+	if group.Get(key) != l {
+		t.Error("an unchanged TLS listener should not be restarted")
+	}
+}
+
+func TestApplyListenerConfigsTLSCertError(t *testing.T) {
+	group := listener.NewGroup()
+	t.Cleanup(func() { _ = group.Shutdown(0) })
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "bad.key.pem")
+	certPath := filepath.Join(dir, "bad.cert.pem")
+	if err := os.WriteFile(keyPath, []byte("not a key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certPath, []byte("not a cert\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	conf := tlsTestConfig(t, keyPath, certPath, availablePort(t))
+	key := listenerKey(listenerconfig.DefaultFrontendName, true)
+	routers := map[string]router.Router{listenerconfig.DefaultFrontendName: lm.NewRouter()}
+
+	// an unloadable key pair is logged and the listener is skipped
+	applyListenerConfigs(conf, nil, routers, http.NotFoundHandler(), lm.NewRouter(),
+		nil, nil, nil, group)
+	if group.Get(key) != nil {
+		t.Error("a listener with unloadable certificates should not start")
+	}
+
+	// the same failure on the update path is also non-fatal
+	updateListenerCertificates(conf, desiredListener{
+		key: key, listenerName: listenerconfig.DefaultFrontendName, tls: true,
+	}, group)
+}
+
+// TestUpdateListenerCertificatesNoCerts covers the early return taken when a
+// listener resolves to an empty TLS configuration.
+func TestUpdateListenerCertificatesNoCerts(t *testing.T) {
+	group := listener.NewGroup()
+	t.Cleanup(func() { _ = group.Shutdown(0) })
+	conf := config.NewConfig()
+	updateListenerCertificates(conf, desiredListener{
+		key:          listenerKey(listenerconfig.DefaultFrontendName, true),
+		listenerName: listenerconfig.DefaultFrontendName,
+		tls:          true,
+	}, group)
+}
+
+// deactivateBuiltinListeners prevents the well-known ports from being bound.
+func deactivateBuiltinListeners(conf *config.Config) {
+	for _, name := range []string{
+		listenerconfig.DefaultFrontendName,
+		mgmt.ListenerNameMgmt,
+		mgmt.ListenerNameMetrics,
+	} {
+		conf.Listeners[name].ListenPort = 0
+		conf.Listeners[name].TLSListenPort = 0
+		conf.Listeners[name].Active = false
+	}
+}
+
+// tlsTestConfig returns a config whose default listener serves TLS on port
+// using the supplied key pair.
+func tlsTestConfig(t *testing.T, keyPath, certPath string, port int) *config.Config {
+	t.Helper()
+	conf := config.NewConfig()
+	deactivateBuiltinListeners(conf)
+	conf.Backends["default"].ListenerName = listenerconfig.DefaultFrontendName
+	conf.Backends["default"].TLS = &to.Options{
+		ServeTLS:          true,
+		FullChainCertPath: certPath,
+		PrivateKeyPath:    keyPath,
+	}
+	o := conf.Listeners[listenerconfig.DefaultFrontendName]
+	o.Active = true
+	o.ServeTLS = true
+	o.TLSListenAddress = "127.0.0.1"
+	o.TLSListenPort = port
+	return conf
 }

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -369,7 +369,7 @@ func closeOldCache(name string, w cache.Cache, drainTimeout time.Duration) {
 
 func initLogger(c *config.Config) logging.Logger {
 	logger.SetLogger(logging.New(c))
-	logger.Info("application loaded from configuration",
+	logger.InfoSynchronous("application loaded from configuration",
 		logging.Pairs{
 			"name":      appinfo.Name,
 			"version":   appinfo.Version,

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -316,8 +316,14 @@ func applyCachingConfig(si *instance.ServerInstance,
 				v.ProviderID == providers.MemoryID {
 				// Note: this is only necessary for the memory cache as all other providers will be closed and reopened with the newest config
 				if v.Index != nil {
-					mc := w.(*manager.Manager).Client.(*index.IndexedClient)
-					mc.UpdateOptions(v.Index)
+					// only index-backed clients carry index options; the memory
+					// cache manages its own sizing, so a failed assertion here
+					// is expected and simply means there is nothing to update
+					if m, ok := w.(*manager.Manager); ok {
+						if mc, ok := m.Client.(*index.IndexedClient); ok {
+							mc.UpdateOptions(v.Index)
+						}
+					}
 				}
 				caches[k] = w
 				continue

--- a/pkg/daemon/setup/setup_test.go
+++ b/pkg/daemon/setup/setup_test.go
@@ -423,14 +423,17 @@ func TestApplyLoggingConfigNoOps(t *testing.T) {
 }
 
 func TestApplyLoggingConfigInitial(t *testing.T) {
-	t.Cleanup(func() { logger.SetLogger(logging.NoopLogger()) })
+	dir := t.TempDir()
+	t.Cleanup(func() {
+		logger.Logger().Close()
+		logger.SetLogger(logging.NoopLogger())
+	})
 	c := config.NewConfig()
-	c.Logging.LogFile = filepath.Join(t.TempDir(), "trickster.log")
+	c.Logging.LogFile = filepath.Join(dir, "trickster.log")
 	applyLoggingConfig(c, nil)
 	if logger.Logger() == nil {
 		t.Fatal("expected a logger")
 	}
-	logger.Logger().Close()
 }
 
 func TestApplyLoggingConfigUnchanged(t *testing.T) {
@@ -457,8 +460,11 @@ func TestApplyLoggingConfigLevelChangeOnly(t *testing.T) {
 }
 
 func TestApplyLoggingConfigFileChange(t *testing.T) {
-	t.Cleanup(func() { logger.SetLogger(logging.NoopLogger()) })
 	dir := t.TempDir()
+	t.Cleanup(func() {
+		logger.Logger().Close()
+		logger.SetLogger(logging.NoopLogger())
+	})
 	old := config.NewConfig()
 	old.Logging.LogFile = filepath.Join(dir, "old.log")
 	old.MgmtConfig.ReloadDrainTimeout = 0
@@ -475,8 +481,7 @@ func TestApplyLoggingConfigFileChange(t *testing.T) {
 	if nc.MgmtConfig == nil {
 		t.Error("expected a default mgmt config to be created")
 	}
-	logger.Logger().Close()
-	// let the delayed closer for the old logger run
+	// let the delayed closer for the old logger run before TempDir cleanup
 	time.Sleep(20 * time.Millisecond)
 }
 
@@ -618,12 +623,15 @@ func TestHandleStartupIssue(t *testing.T) {
 }
 
 func TestInitLogger(t *testing.T) {
-	t.Cleanup(func() { logger.SetLogger(logging.NoopLogger()) })
+	dir := t.TempDir()
+	t.Cleanup(func() {
+		logger.Logger().Close()
+		logger.SetLogger(logging.NoopLogger())
+	})
 	c := config.NewConfig()
-	c.Logging.LogFile = filepath.Join(t.TempDir(), "init.log")
+	c.Logging.LogFile = filepath.Join(dir, "init.log")
 	l := initLogger(c)
 	if l == nil {
 		t.Fatal("expected a logger")
 	}
-	l.Close()
 }

--- a/pkg/daemon/setup/setup_test.go
+++ b/pkg/daemon/setup/setup_test.go
@@ -1,0 +1,629 @@
+/*
+ * Copyright 2026 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/cache"
+	cacheoptions "github.com/trickstercache/trickster/v2/pkg/cache/options"
+	"github.com/trickstercache/trickster/v2/pkg/cache/providers"
+	"github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	"github.com/trickstercache/trickster/v2/pkg/config"
+	"github.com/trickstercache/trickster/v2/pkg/daemon/instance"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/providers/basic"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+)
+
+func init() {
+	// keeps test output free of application log lines
+	logger.SetLogger(logging.NoopLogger())
+}
+
+// writeConfig writes body to a temp trickster.yaml and returns its path.
+func writeConfig(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "trickster.yaml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// quietListeners zeroes every listener port so ApplyConfig builds the full
+// router tree without binding any well-known ports during tests. Listeners
+// stay Active so backends still resolve to a router.
+func quietListeners(conf *config.Config) {
+	for _, o := range conf.Listeners {
+		o.ListenPort = 0
+		o.TLSListenPort = 0
+		o.ServeTLS = false
+	}
+}
+
+const minimalConfig = `
+backends:
+  test:
+    provider: rp
+    origin_url: 'http://example.com'
+`
+
+func TestLoadAndValidateSuccess(t *testing.T) {
+	conf, err := LoadAndValidate("-config", writeConfig(t, minimalConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := conf.Backends["test"]; !ok {
+		t.Errorf("expected backend 'test' in %v", conf.Backends)
+	}
+}
+
+func TestLoadAndValidateNoBackends(t *testing.T) {
+	// no -origin-url and no config file leaves zero usable backends
+	if _, err := LoadAndValidate("-log-level", "info"); err == nil {
+		t.Error("expected an error when no backends are configured")
+	}
+}
+
+func TestLoadAndValidateBadFlags(t *testing.T) {
+	if _, err := LoadAndValidate("-not-a-real-flag"); err == nil {
+		t.Error("expected an error for an unknown flag")
+	}
+}
+
+func TestLoadAndValidateMissingConfigFile(t *testing.T) {
+	if _, err := LoadAndValidate("-config", filepath.Join(t.TempDir(), "nope.yaml")); err == nil {
+		t.Error("expected an error for a missing config file")
+	}
+}
+
+// a load failure while -validate was requested also prints usage
+func TestLoadAndValidateMissingConfigFileWithValidateFlag(t *testing.T) {
+	_, err := LoadAndValidate("-validate-config", "-config", filepath.Join(t.TempDir(), "nope.yaml"))
+	if err == nil {
+		t.Error("expected an error for a missing config file")
+	}
+}
+
+func TestLoadAndValidatePrintVersion(t *testing.T) {
+	conf, err := LoadAndValidate("-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conf == nil || conf.Flags == nil || !conf.Flags.PrintVersion {
+		t.Fatal("expected a config with the PrintVersion flag set")
+	}
+}
+
+func TestLoadAndValidateBadBackend(t *testing.T) {
+	_, err := LoadAndValidate("-config", writeConfig(t, `
+backends:
+  test:
+    provider: rp
+`))
+	if err == nil {
+		t.Error("expected an error for a backend with no origin_url")
+	}
+}
+
+func TestLoadAndValidateBadCache(t *testing.T) {
+	_, err := LoadAndValidate("-config", writeConfig(t, `
+caches:
+  test:
+    provider: bbolt
+    index:
+      max_size_objects: 10
+      max_size_backoff_objects: 100
+backends:
+  test:
+    provider: rpc
+    cache_name: test
+    origin_url: 'http://example.com'
+`))
+	if err == nil {
+		t.Error("expected an error for an invalid cache index configuration")
+	}
+}
+
+func TestLoadAndValidateInvalidConfig(t *testing.T) {
+	_, err := LoadAndValidate("-config", writeConfig(t, `
+logging:
+  log_level: not-a-level
+backends:
+  test:
+    provider: rp
+    origin_url: 'http://example.com'
+`))
+	if err == nil {
+		t.Error("expected an error for an invalid log level")
+	}
+}
+
+func TestLoadAndValidateLoaderWarnings(t *testing.T) {
+	// the legacy 'frontend' section produces a loader warning that is logged
+	conf, err := LoadAndValidate("-config", writeConfig(t, `
+frontend:
+  listen_port: 57821
+backends:
+  test:
+    provider: rp
+    origin_url: 'http://example.com'
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(conf.LoaderWarnings) == 0 {
+		t.Error("expected at least one loader warning")
+	}
+}
+
+func TestBootstrapConfig(t *testing.T) {
+	conf, clients, err := BootstrapConfig("-config", writeConfig(t, minimalConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conf == nil {
+		t.Fatal("expected a config")
+	}
+	if clients == nil {
+		t.Fatal("expected a backends lookup")
+	}
+}
+
+func TestBootstrapConfigLoadError(t *testing.T) {
+	if _, _, err := BootstrapConfig("-not-a-real-flag"); err == nil {
+		t.Error("expected an error for an unknown flag")
+	}
+}
+
+func TestBootstrapConfigPrintVersion(t *testing.T) {
+	conf, clients, err := BootstrapConfig("-version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conf == nil || !conf.Flags.PrintVersion {
+		t.Fatal("expected a config with PrintVersion set")
+	}
+	if clients != nil {
+		t.Errorf("expected no clients for -version, got %v", clients)
+	}
+}
+
+func TestBootstrapConfigValidateOnly(t *testing.T) {
+	conf, clients, err := BootstrapConfig("-validate-config", "-config", writeConfig(t, minimalConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if conf == nil || !conf.Flags.ValidateConfig {
+		t.Fatal("expected a config with ValidateConfig set")
+	}
+	if clients != nil {
+		t.Errorf("expected no clients for -validate, got %v", clients)
+	}
+}
+
+func TestBootstrapConfigRoutesRulesAndPoolsError(t *testing.T) {
+	// two backends marked default fail during route registration, which only
+	// happens after the config itself validates cleanly
+	_, _, err := BootstrapConfig("-config", writeConfig(t, `
+backends:
+  test1:
+    is_default: true
+    provider: rp
+    origin_url: 'http://example.com'
+  test2:
+    is_default: true
+    provider: rp
+    origin_url: 'http://example.com'
+`))
+	if err == nil {
+		t.Error("expected an error for multiple default backends")
+	}
+}
+
+func TestApplyConfigNilArgs(t *testing.T) {
+	if err := ApplyConfig(nil, config.NewConfig(), nil, nil, nil, nil); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+	if err := ApplyConfig(&instance.ServerInstance{}, nil, nil, nil, nil, nil); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+func TestApplyConfig(t *testing.T) {
+	conf, clients, err := BootstrapConfig("-config", writeConfig(t, minimalConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	quietListeners(conf)
+	conf.Main.ServerName = ""
+	// the purge-by-key path is normalized to a trailing slash
+	conf.MgmtConfig.PurgeByKeyHandlerPath = strings.TrimSuffix(conf.MgmtConfig.PurgeByKeyHandlerPath, "/")
+
+	group := listener.NewGroup()
+	t.Cleanup(func() { _ = group.Shutdown(0) })
+	si := &instance.ServerInstance{Listeners: group}
+
+	if err := ApplyConfig(si, conf, clients, nil, nil, group); err != nil {
+		t.Fatal(err)
+	}
+	if si.Config != conf {
+		t.Error("expected the instance config to be the new config")
+	}
+	if si.HealthChecker == nil {
+		t.Error("expected a health checker")
+	}
+	if conf.Main.ServerName == "" {
+		t.Error("expected an inferred server name")
+	}
+	if !strings.HasSuffix(conf.MgmtConfig.PurgeByKeyHandlerPath, "/") {
+		t.Errorf("purge-by-key path %q should end in a slash",
+			conf.MgmtConfig.PurgeByKeyHandlerPath)
+	}
+	t.Cleanup(func() {
+		if si.HealthChecker != nil {
+			si.HealthChecker.Shutdown()
+		}
+	})
+
+	// a second pass exercises the reload branches that tear down the prior
+	// health checker and ALB pools
+	conf2, clients2, err := BootstrapConfig("-config", writeConfig(t, minimalConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	quietListeners(conf2)
+	if err := ApplyConfig(si, conf2, clients2, nil, nil, group); err != nil {
+		t.Fatal(err)
+	}
+	if si.Config != conf2 {
+		t.Error("expected the instance config to be replaced on reload")
+	}
+}
+
+func TestApplyConfigNilMgmtConfig(t *testing.T) {
+	conf, clients, err := BootstrapConfig("-config", writeConfig(t, minimalConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	quietListeners(conf)
+	conf.MgmtConfig = nil
+
+	group := listener.NewGroup()
+	t.Cleanup(func() { _ = group.Shutdown(0) })
+	si := &instance.ServerInstance{Listeners: group}
+	if err := ApplyConfig(si, conf, clients, nil, nil, group); err != nil {
+		t.Fatal(err)
+	}
+	if conf.MgmtConfig == nil {
+		t.Error("expected a default mgmt config to be created")
+	}
+	t.Cleanup(func() {
+		if si.HealthChecker != nil {
+			si.HealthChecker.Shutdown()
+		}
+	})
+}
+
+func TestApplyConfigAuthenticatorError(t *testing.T) {
+	conf, clients, err := BootstrapConfig("-config", writeConfig(t, minimalConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	quietListeners(conf)
+	conf.Authenticators = options.Lookup{
+		"bad": &options.Options{Name: "bad", Provider: "not-a-provider"},
+	}
+	si := &instance.ServerInstance{}
+	if err := ApplyConfig(si, conf, clients, nil, nil, listener.NewGroup()); err == nil {
+		t.Error("expected an error for an unsupported authenticator")
+	}
+}
+
+func TestApplyConfigTracingError(t *testing.T) {
+	conf, clients, err := BootstrapConfig("-config", writeConfig(t, minimalConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	quietListeners(conf)
+	// a backend pointing at a tracing config that does not exist fails
+	// tracer registration
+	conf.Backends["test"].TracingConfigName = "nonexistent"
+
+	var errorFuncCalls int
+	si := &instance.ServerInstance{}
+	err = ApplyConfig(si, conf, clients, nil, func() { errorFuncCalls++ }, listener.NewGroup())
+	if err == nil {
+		t.Fatal("expected a tracer registration error")
+	}
+	if errorFuncCalls != 1 {
+		t.Errorf("errorFunc calls = %d, want 1", errorFuncCalls)
+	}
+}
+
+func TestApplyConfigRouteRegistrationError(t *testing.T) {
+	conf, clients, err := BootstrapConfig("-config", writeConfig(t, minimalConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	quietListeners(conf)
+	// an unknown provider is rejected by route registration
+	conf.Backends["test"].Provider = "not-a-provider"
+
+	var errorFuncCalls int
+	si := &instance.ServerInstance{}
+	err = ApplyConfig(si, conf, clients, nil, func() { errorFuncCalls++ }, listener.NewGroup())
+	if err == nil {
+		t.Fatal("expected a route registration error")
+	}
+	if errorFuncCalls != 1 {
+		t.Errorf("errorFunc calls = %d, want 1", errorFuncCalls)
+	}
+}
+
+func TestBuildAuthenticators(t *testing.T) {
+	if err := buildAuthenticators(nil); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+	if err := buildAuthenticators(&config.Config{}); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+
+	c := &config.Config{Authenticators: options.Lookup{
+		"good": &options.Options{
+			Name:     "good",
+			Provider: basic.ID,
+			Users:    map[string]string{"user1": "pass1"},
+		},
+	}}
+	if err := buildAuthenticators(c); err != nil {
+		t.Fatal(err)
+	}
+	if c.Authenticators["good"].Authenticator == nil {
+		t.Error("expected a compiled authenticator")
+	}
+
+	c = &config.Config{Authenticators: options.Lookup{
+		"bad": &options.Options{Name: "bad", Provider: "not-a-provider"},
+	}}
+	if err := buildAuthenticators(c); err == nil {
+		t.Error("expected an error for an unsupported authenticator")
+	}
+}
+
+func TestApplyLoggingConfigNoOps(t *testing.T) {
+	before := logger.Logger()
+	applyLoggingConfig(nil, nil)
+	applyLoggingConfig(&config.Config{}, nil)
+	if logger.Logger() != before {
+		t.Error("logger should not be replaced when there is no logging config")
+	}
+}
+
+func TestApplyLoggingConfigInitial(t *testing.T) {
+	t.Cleanup(func() { logger.SetLogger(logging.NoopLogger()) })
+	c := config.NewConfig()
+	c.Logging.LogFile = filepath.Join(t.TempDir(), "trickster.log")
+	applyLoggingConfig(c, nil)
+	if logger.Logger() == nil {
+		t.Fatal("expected a logger")
+	}
+	logger.Logger().Close()
+}
+
+func TestApplyLoggingConfigUnchanged(t *testing.T) {
+	t.Cleanup(func() { logger.SetLogger(logging.NoopLogger()) })
+	old := config.NewConfig()
+	nc := config.NewConfig()
+	before := logger.Logger()
+	applyLoggingConfig(nc, old)
+	if logger.Logger() != before {
+		t.Error("an unchanged logging config should retain the existing logger")
+	}
+}
+
+func TestApplyLoggingConfigLevelChangeOnly(t *testing.T) {
+	t.Cleanup(func() { logger.SetLogger(logging.NoopLogger()) })
+	old := config.NewConfig()
+	nc := config.NewConfig()
+	nc.Logging.LogLevel = "debug"
+	before := logger.Logger()
+	applyLoggingConfig(nc, old)
+	if logger.Logger() != before {
+		t.Error("a log level change should retain the existing logger")
+	}
+}
+
+func TestApplyLoggingConfigFileChange(t *testing.T) {
+	t.Cleanup(func() { logger.SetLogger(logging.NoopLogger()) })
+	dir := t.TempDir()
+	old := config.NewConfig()
+	old.Logging.LogFile = filepath.Join(dir, "old.log")
+	old.MgmtConfig.ReloadDrainTimeout = 0
+	logger.SetLogger(logging.New(old))
+
+	nc := config.NewConfig()
+	nc.Logging.LogFile = filepath.Join(dir, "new.log")
+	nc.MgmtConfig = nil
+	before := logger.Logger()
+	applyLoggingConfig(nc, old)
+	if logger.Logger() == before {
+		t.Error("a log file change should install a new logger")
+	}
+	if nc.MgmtConfig == nil {
+		t.Error("expected a default mgmt config to be created")
+	}
+	logger.Logger().Close()
+	// let the delayed closer for the old logger run
+	time.Sleep(20 * time.Millisecond)
+}
+
+func TestApplyCachingConfigNilArgs(t *testing.T) {
+	if got := applyCachingConfig(nil, config.NewConfig()); got != nil {
+		t.Errorf("got = %v, want nil", got)
+	}
+	if got := applyCachingConfig(&instance.ServerInstance{}, nil); got != nil {
+		t.Errorf("got = %v, want nil", got)
+	}
+}
+
+func TestApplyCachingConfigInitial(t *testing.T) {
+	nc := config.NewConfig()
+	caches := applyCachingConfig(&instance.ServerInstance{}, nc)
+	if len(caches) != len(nc.Caches) {
+		t.Fatalf("cache count = %d, want %d", len(caches), len(nc.Caches))
+	}
+	for _, c := range caches {
+		_ = c.Close()
+	}
+}
+
+func TestApplyCachingConfigReuseUnchanged(t *testing.T) {
+	oc := config.NewConfig()
+	existing := registry.NewCache("default", oc.Caches["default"])
+	si := &instance.ServerInstance{
+		Config: oc,
+		Caches: cache.Lookup{"default": existing},
+	}
+	nc := config.NewConfig()
+	caches := applyCachingConfig(si, nc)
+	if caches["default"] != existing {
+		t.Error("an unchanged cache should be reused")
+	}
+	_ = existing.Close()
+}
+
+func TestApplyCachingConfigMemoryIndexUpdate(t *testing.T) {
+	oc := config.NewConfig()
+	oc.Caches["default"].Provider = providers.Memory
+	oc.Caches["default"].ProviderID = providers.MemoryID
+	existing := registry.NewCache("default", oc.Caches["default"])
+	if err := existing.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	si := &instance.ServerInstance{
+		Config: oc,
+		Caches: cache.Lookup{"default": existing},
+	}
+
+	nc := config.NewConfig()
+	nc.Caches["default"].Provider = providers.Memory
+	nc.Caches["default"].ProviderID = providers.MemoryID
+	// an index-only delta keeps the same underlying cache
+	nc.Caches["default"].Index.MaxSizeObjects = 12345
+
+	caches := applyCachingConfig(si, nc)
+	if caches["default"] != existing {
+		t.Error("a memory cache with only index changes should be preserved")
+	}
+	_ = existing.Close()
+}
+
+func TestApplyCachingConfigClosesReplacedAndRemoved(t *testing.T) {
+	oc := config.NewConfig()
+	oc.Caches["default"].Provider = providers.Memory
+	oc.Caches["default"].ProviderID = providers.MemoryID
+	oc.Caches["gone"] = cacheoptions.New()
+	oc.Caches["gone"].Name = "gone"
+
+	replaced := registry.NewCache("default", oc.Caches["default"])
+	if err := replaced.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	removed := registry.NewCache("gone", oc.Caches["gone"])
+	if err := removed.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	si := &instance.ServerInstance{
+		Config: oc,
+		Caches: cache.Lookup{"default": replaced, "gone": removed},
+	}
+
+	nc := config.NewConfig()
+	// a provider change means the old cache cannot be reused
+	nc.Caches["default"].Provider = providers.BBolt
+	nc.Caches["default"].ProviderID = providers.BBoltID
+	nc.Caches["default"].BBolt.Filename = filepath.Join(t.TempDir(), "test.db")
+	nc.MgmtConfig.ReloadDrainTimeout = 0
+
+	caches := applyCachingConfig(si, nc)
+	if caches["default"] == replaced {
+		t.Error("a cache whose provider changed should not be reused")
+	}
+	if _, ok := caches["gone"]; ok {
+		t.Error("a cache absent from the new config should not carry over")
+	}
+	// the old caches are closed on background goroutines
+	time.Sleep(50 * time.Millisecond)
+	for _, c := range caches {
+		_ = c.Close()
+	}
+}
+
+func TestDelayedLogCloser(t *testing.T) {
+	delayedLogCloser(nil, 0) // must not panic
+	// a real file, not os.Stdout: Close() closes the underlying writer
+	f, err := os.Create(filepath.Join(t.TempDir(), "delayed.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	delayedLogCloser(logging.StreamLogger(f, level.Info), time.Millisecond)
+}
+
+func TestHandleStartupIssue(t *testing.T) {
+	var calls int
+	errorFunc := func() { calls++ }
+
+	handleStartupIssue("", nil, nil)
+	if calls != 0 {
+		t.Errorf("calls = %d, want 0", calls)
+	}
+
+	handleStartupIssue("", nil, errorFunc)
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+
+	handleStartupIssue("some event", logging.Pairs{"detail": "x"}, errorFunc)
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+
+	handleStartupIssue("some event", logging.Pairs{"detail": "x"}, nil)
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+}
+
+func TestInitLogger(t *testing.T) {
+	t.Cleanup(func() { logger.SetLogger(logging.NoopLogger()) })
+	c := config.NewConfig()
+	c.Logging.LogFile = filepath.Join(t.TempDir(), "init.log")
+	l := initLogger(c)
+	if l == nil {
+		t.Fatal("expected a logger")
+	}
+	l.Close()
+}

--- a/pkg/daemon/signaling/signaling_test.go
+++ b/pkg/daemon/signaling/signaling_test.go
@@ -98,8 +98,7 @@ func TestWaitContextCancel(t *testing.T) {
 
 func TestWaitSIGHUPReloadsThenSIGTERMReturns(t *testing.T) {
 	guardSignals(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	var sources atomic.Value
 	sources.Store("")
@@ -143,8 +142,7 @@ func TestWaitSIGHUPReloadsThenSIGTERMReturns(t *testing.T) {
 
 func TestWaitSIGINTReturns(t *testing.T) {
 	guardSignals(t)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	done := make(chan struct{})
 	go func() {

--- a/pkg/daemon/signaling/signaling_test.go
+++ b/pkg/daemon/signaling/signaling_test.go
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package signaling
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// guardSignals keeps a test-owned channel registered for the signals Wait
+// handles, so the process default disposition (terminate on SIGINT/SIGTERM,
+// SIGHUP) stays disabled for the entire test, even in the windows before Wait
+// registers its own channel and after Wait unregisters it.
+func guardSignals(t *testing.T) {
+	t.Helper()
+	guard := make(chan os.Signal, 16)
+	signal.Notify(guard, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+	t.Cleanup(func() {
+		signal.Stop(guard)
+		// drain anything still queued so a late delivery can't be observed
+		// by a subsequent test
+		for {
+			select {
+			case <-guard:
+			default:
+				return
+			}
+		}
+	})
+}
+
+// raiseUntil sends sig to this process repeatedly until done is closed or the
+// deadline elapses. Signal delivery races with Wait's own signal.Notify
+// registration, so a single send is not reliable.
+func raiseUntil(t *testing.T, sig syscall.Signal, done <-chan struct{}) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		if err := syscall.Kill(syscall.Getpid(), sig); err != nil {
+			t.Errorf("could not send %v: %v", sig, err)
+			return
+		}
+		select {
+		case <-done:
+			return
+		case <-time.After(25 * time.Millisecond):
+		}
+	}
+	t.Fatalf("timed out waiting for %v to be handled", sig)
+}
+
+func TestWaitContextCancel(t *testing.T) {
+	guardSignals(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		Wait(ctx, func(string) (bool, error) {
+			calls.Add(1)
+			return true, nil
+		})
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait did not return after context cancellation")
+	}
+	if got := calls.Load(); got != 0 {
+		t.Errorf("reloader calls = %d, want 0", got)
+	}
+}
+
+func TestWaitSIGHUPReloadsThenSIGTERMReturns(t *testing.T) {
+	guardSignals(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var sources atomic.Value
+	sources.Store("")
+	reloaded := make(chan struct{})
+	var once atomic.Bool
+	done := make(chan struct{})
+	go func() {
+		Wait(ctx, func(source string) (bool, error) {
+			sources.Store(source)
+			if once.CompareAndSwap(false, true) {
+				close(reloaded)
+			}
+			return true, nil
+		})
+		close(done)
+	}()
+
+	raiseUntil(t, syscall.SIGHUP, reloaded)
+	select {
+	case <-reloaded:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SIGHUP did not invoke the reloader")
+	}
+	if got := sources.Load().(string); got != "sighup" {
+		t.Errorf("reload source = %q, want %q", got, "sighup")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("Wait returned on SIGHUP; it should keep waiting")
+	default:
+	}
+
+	raiseUntil(t, syscall.SIGTERM, done)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait did not return after SIGTERM")
+	}
+}
+
+func TestWaitSIGINTReturns(t *testing.T) {
+	guardSignals(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		Wait(ctx, func(string) (bool, error) { return true, nil })
+		close(done)
+	}()
+
+	raiseUntil(t, syscall.SIGINT, done)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait did not return after SIGINT")
+	}
+}

--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -60,7 +60,7 @@ type Listener struct {
 	tlsSwapper   sw.CertSwapper
 	routeSwapper *switcher.SwitchHandler
 	server       *http.Server
-	exitOnError  bool
+	exitOnError  atomic.Bool
 	state        int32
 	readyCh      chan struct{}
 	readyOnce    sync.Once
@@ -233,9 +233,9 @@ func (lg *Group) StartListener(listenerName, address string, port int, connectio
 ) error {
 	l := &Listener{
 		routeSwapper: switcher.NewSwitchHandler(router),
-		exitOnError:  f != nil,
 		readyCh:      make(chan struct{}),
 	}
+	l.exitOnError.Store(f != nil)
 	l.setState(StateStarting)
 
 	if tlsConfig != nil && len(tlsConfig.Certificates) > 0 {
@@ -261,6 +261,15 @@ func (lg *Group) StartListener(listenerName, address string, port int, connectio
 	logger.Info("http listener starting",
 		logging.Pairs{"listenerName": listenerName, "port": port, "address": address})
 
+	// the server is assigned before the listener is published to the group, so
+	// a DrainAndClose racing this startup always observes a server to shut down
+	svr := &http.Server{
+		Handler:           l.routeSwapper,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: readHeaderTimeout,
+	}
+	l.server = svr
+
 	lg.listenersLock.Lock()
 	lg.members[listenerName] = l
 	lg.listenersLock.Unlock()
@@ -272,40 +281,21 @@ func (lg *Group) StartListener(listenerName, address string, port int, connectio
 	// defer the tracer flush here where the listener connection ends
 	defer handleTracerShutdowns(tracers)
 
-	if tlsConfig != nil {
-		svr := &http.Server{
-			Handler:           l.routeSwapper,
-			TLSConfig:         tlsConfig,
-			ReadHeaderTimeout: readHeaderTimeout,
-		}
-		l.server = svr
-		err = svr.Serve(l)
-		if err != nil {
-			logger.ErrorSynchronous(
-				"https listener stopping", logging.Pairs{"listenerName": listenerName, "detail": err})
-			if l.exitOnError {
-				defer func() {
-					os.Exit(1) // exit via defer to allow prior defers to run
-				}()
-				return nil
-			}
-		}
-		return err
-	}
-
-	svr := &http.Server{
-		Handler:           l.routeSwapper,
-		ReadHeaderTimeout: readHeaderTimeout,
-	}
-	l.server = svr
 	err = svr.Serve(l)
 	if err != nil {
-		logger.ErrorSynchronous("http listener stopping",
+		event := "http listener stopping"
+		if tlsConfig != nil {
+			event = "https listener stopping"
+		}
+		logger.ErrorSynchronous(event,
 			logging.Pairs{"listenerName": listenerName, "detail": err})
-		if l.exitOnError {
+		if l.exitOnError.Load() {
 			defer func() {
 				os.Exit(1) // exit via defer to allow prior defers to run
 			}()
+			if tlsConfig != nil {
+				return nil
+			}
 		}
 	}
 	return err
@@ -343,7 +333,7 @@ func (lg *Group) DrainAndClose(listenerName string, drainWait time.Duration) err
 		lg.listenersLock.Unlock()
 		return trerr.ErrNoSuchListener
 	}
-	l.exitOnError = false
+	l.exitOnError.Store(false)
 	l.setState(StateStopping)
 	delete(lg.members, listenerName)
 	lg.listenersLock.Unlock()

--- a/pkg/proxy/listener/listener_test.go
+++ b/pkg/proxy/listener/listener_test.go
@@ -25,6 +25,8 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -287,9 +289,11 @@ func TestRouteSwapper(t *testing.T) {
 
 func TestGet(t *testing.T) {
 	lg := NewGroup()
-	lg.members["testing"] = &Listener{exitOnError: true}
+	l0 := &Listener{}
+	l0.exitOnError.Store(true)
+	lg.members["testing"] = l0
 	l := lg.Get("testing")
-	if !l.exitOnError {
+	if !l.exitOnError.Load() {
 		t.Error("expected true")
 	}
 	l = lg.Get("invalid")
@@ -397,6 +401,315 @@ func TestObservedConnectionIdempotentClose(t *testing.T) {
 	if finalVal != 9.0 {
 		t.Errorf("expected ProxyActiveConnections metric to be 9.0 after idempotent close, got %f", finalVal)
 	}
+}
+
+func TestListenerState(t *testing.T) {
+	l := &Listener{}
+	if l.State() != StateStopped {
+		t.Errorf("State() = %v, want %v", l.State(), StateStopped)
+	}
+	l.setState(StateReady)
+	if l.State() != StateReady {
+		t.Errorf("State() = %v, want %v", l.State(), StateReady)
+	}
+}
+
+func TestListenerWaitForReadyNilChannel(t *testing.T) {
+	l := &Listener{}
+	if l.WaitForReady(0) {
+		t.Error("expected false when state is not ready and readyCh is nil")
+	}
+	l.setState(StateReady)
+	if !l.WaitForReady(0) {
+		t.Error("expected true when state is ready and readyCh is nil")
+	}
+}
+
+func TestListenerWaitForReadyBlocksUntilReady(t *testing.T) {
+	l := &Listener{readyCh: make(chan struct{})}
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		l.markReady()
+	}()
+	done := make(chan bool, 1)
+	go func() { done <- l.WaitForReady(0) }()
+	select {
+	case ok := <-done:
+		if !ok {
+			t.Error("expected WaitForReady(0) to return true once ready")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady(0) did not return after the listener became ready")
+	}
+}
+
+func TestListenerWaitForReadyTimeoutSuccess(t *testing.T) {
+	l := &Listener{readyCh: make(chan struct{})}
+	l.markReady()
+	if !l.WaitForReady(time.Second) {
+		t.Error("expected true when already ready before the timeout")
+	}
+}
+
+func TestListenerWaitForReadyTimeoutExpires(t *testing.T) {
+	l := &Listener{readyCh: make(chan struct{})}
+	t.Cleanup(l.markReady)
+	if l.WaitForReady(20 * time.Millisecond) {
+		t.Error("expected false when the listener never becomes ready")
+	}
+}
+
+func TestGroupWaitForReadyEmpty(t *testing.T) {
+	lg := NewGroup()
+	if err := lg.WaitForReady(time.Second); err != nil {
+		t.Errorf("err = %v, want nil for an empty group", err)
+	}
+}
+
+func TestGroupWaitForReadySkipsNilMembers(t *testing.T) {
+	lg := NewGroup()
+	lg.members["nil-member"] = nil
+	l := &Listener{readyCh: make(chan struct{})}
+	l.markReady()
+	lg.members["ready-member"] = l
+	if err := lg.WaitForReady(time.Second); err != nil {
+		t.Errorf("err = %v, want nil", err)
+	}
+}
+
+func TestGroupWaitForReadyNoTimeoutBlocksUntilReady(t *testing.T) {
+	lg := NewGroup()
+	l := &Listener{readyCh: make(chan struct{})}
+	lg.members["member"] = l
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		l.markReady()
+	}()
+	done := make(chan error, 1)
+	go func() { done <- lg.WaitForReady(0) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("err = %v, want nil", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WaitForReady(0) did not return after the listener became ready")
+	}
+}
+
+func TestGroupWaitForReadyTimeoutExpires(t *testing.T) {
+	lg := NewGroup()
+	l := &Listener{readyCh: make(chan struct{})}
+	t.Cleanup(l.markReady)
+	lg.members["never-ready"] = l
+	if err := lg.WaitForReady(20 * time.Millisecond); err == nil {
+		t.Error("expected a timeout error when a listener never becomes ready")
+	}
+}
+
+func TestGroupShutdownAggregatesErrorsAndClosesDone(t *testing.T) {
+	lg := NewGroup()
+	lg.members["nil-listener"] = &Listener{}
+	lg.members["ok-listener"] = &Listener{Listener: testListener(), server: &http.Server{}}
+
+	if err := lg.Shutdown(0); !stderrors.Is(err, errors.ErrNilListener) {
+		t.Errorf("err = %v, want %v", err, errors.ErrNilListener)
+	}
+	select {
+	case <-lg.done:
+	default:
+		t.Error("expected the done channel to be closed")
+	}
+
+	// Shutdown must be idempotent: a second call must not panic closing an
+	// already-closed done channel, and an empty group shuts down cleanly.
+	if err := lg.Shutdown(0); err != nil {
+		t.Errorf("second Shutdown err = %v, want nil", err)
+	}
+}
+
+func TestDrainAndCloseServerShutdownError(t *testing.T) {
+	logger.SetLogger(logging.NoopLogger())
+	inHandler := make(chan struct{})
+	release := make(chan struct{})
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(inHandler)
+		<-release
+		w.WriteHeader(http.StatusOK)
+	})
+
+	lg := NewGroup()
+	errs := make(chan error, 1)
+	go func() {
+		errs <- lg.StartListener("blocking", "127.0.0.1", 0, 0, nil, handler, nil, nil, 0, 0)
+	}()
+
+	var l *Listener
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if l = lg.Get("blocking"); l != nil && l.State() == StateReady {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if l == nil {
+		t.Fatal("listener did not become ready")
+	}
+
+	go func() {
+		resp, err := http.Get(fmt.Sprintf("http://%s/", l.Addr().String()))
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+
+	select {
+	case <-inHandler:
+	case <-time.After(5 * time.Second):
+		t.Fatal("request never reached the handler")
+	}
+
+	// A drainWait of 0 means the shutdown context is already expired. With
+	// an in-flight (non-idle) connection, Shutdown must observe ctx.Done()
+	// rather than waiting indefinitely for the handler to finish.
+	if err := lg.DrainAndClose("blocking", 0); err == nil {
+		t.Error("expected an error from a shutdown that outlives its drain deadline")
+	}
+
+	close(release)
+	if err := <-errs; err != nil && !stderrors.Is(err, http.ErrServerClosed) {
+		t.Errorf("StartListener returned unexpected error: %v", err)
+	}
+}
+
+func TestHandleTracerShutdowns(t *testing.T) {
+	logger.SetLogger(logging.ConsoleLogger(level.Error))
+	var called bool
+	trs := tracing.Tracers{
+		"nil-tracer":        nil,
+		"nil-shutdown-func": {},
+		"errors": {
+			ShutdownFunc: func(context.Context) error {
+				called = true
+				return stderrors.New("shutdown failed")
+			},
+		},
+	}
+	handleTracerShutdowns(trs)
+	if !called {
+		t.Error("expected the tracer's ShutdownFunc to be invoked")
+	}
+}
+
+func TestAcceptUnwrapsTLSConn(t *testing.T) {
+	keyPEM, certPEM, err := tlstest.GetTestKeyAndCert(false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := tls.X509KeyPair(certPEM, keyPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer raw.Close()
+	l := &Listener{Listener: raw}
+
+	go func() {
+		if c, derr := net.Dial("tcp", raw.Addr().String()); derr == nil {
+			defer c.Close()
+			// hold the raw connection open briefly; a completed handshake
+			// is not required for the server side to hand back a *tls.Conn
+			time.Sleep(100 * time.Millisecond)
+		}
+	}()
+
+	conn, err := l.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	if _, ok := conn.(*tls.Conn); !ok {
+		t.Errorf("Accept did not return a *tls.Conn unwrapped: got %T", conn)
+	}
+}
+
+func TestStartListenerCallsFOnBindFailure(t *testing.T) {
+	logger.SetLogger(logging.ConsoleLogger(level.Error))
+	var called bool
+	lg := NewGroup()
+	err := lg.StartListener("testBadPort", "", -31, 0, nil, http.NewServeMux(),
+		nil, func() { called = true }, 0, 0)
+	if err == nil {
+		t.Error("expected an error for an invalid port")
+	}
+	if !called {
+		t.Error("expected f to be called when the listener fails to bind")
+	}
+}
+
+// TestStartListenerExitOnServeError verifies that a listener created with a
+// non-nil f treats a post-startup Serve() failure as fatal to the whole
+// process, for both the HTTP and HTTPS code paths. This calls os.Exit(1)
+// directly, so it must run in a subprocess.
+func TestStartListenerExitOnServeError(t *testing.T) {
+	scenarios := []struct {
+		name string
+		tls  bool
+	}{
+		{"http", false},
+		{"https", true},
+	}
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			if os.Getenv("LISTENER_EXIT_TEST") == sc.name {
+				runExitOnServeErrorChild(sc.tls)
+				return
+			}
+			cmd := exec.Command(os.Args[0], "-test.run=^TestStartListenerExitOnServeError/"+sc.name+"$", "-test.v")
+			cmd.Env = append(os.Environ(), "LISTENER_EXIT_TEST="+sc.name)
+			err := cmd.Run()
+			var ee *exec.ExitError
+			if !stderrors.As(err, &ee) {
+				t.Fatalf("expected an ExitError, got %v", err)
+			}
+			if ee.ExitCode() != 1 {
+				t.Fatalf("exit code = %d, want 1", ee.ExitCode())
+			}
+		})
+	}
+}
+
+// runExitOnServeErrorChild starts a listener with a non-nil f (so
+// exitOnError is set), then forces Serve() to fail by closing the raw
+// socket out from under it. StartListener should then call os.Exit(1)
+// itself; if it doesn't within the deadline, exit non-zero so the parent's
+// exit-code assertion fails loudly instead of hanging.
+func runExitOnServeErrorChild(useTLS bool) {
+	logger.SetLogger(logging.NoopLogger())
+	lg := NewGroup()
+	var tc *tls.Config
+	if useTLS {
+		tc = &tls.Config{Certificates: make([]tls.Certificate, 1)}
+	}
+	go func() {
+		_ = lg.StartListener("child", "", 0, 0, tc, http.NewServeMux(), nil,
+			func() {}, 0, 0)
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if l := lg.Get("child"); l != nil && l.State() == StateReady {
+			l.Close()
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	time.Sleep(2 * time.Second)
+	os.Exit(2)
 }
 
 func TestAcceptWrapsLimitListenerConn(t *testing.T) {

--- a/pkg/timeseries/dataset/point_aggregate_test.go
+++ b/pkg/timeseries/dataset/point_aggregate_test.go
@@ -155,3 +155,202 @@ func TestFinalizeAvgNumeric(t *testing.T) {
 	finalizeAvg(&p, 3)
 	require.Equal(t, "4", p.Values[0])
 }
+
+type stubValueOps struct {
+	mergeHandled  bool
+	divideHandled bool
+	merged        any
+	divided       any
+}
+
+func (s *stubValueOps) MergeValues(dst, src any, _ merge.Strategy) (any, bool) {
+	if !s.mergeHandled {
+		return nil, false
+	}
+	return s.merged, true
+}
+
+func (s *stubValueOps) DivideValue(value any, _ float64) (any, bool) {
+	if !s.divideHandled {
+		return nil, false
+	}
+	return s.divided, true
+}
+
+func (s *stubValueOps) PairingHash(_ *SeriesHeader, _ string) Hash { return 0 }
+
+func (s *stubValueOps) FinalizeMerge(_ *DataSet, _ merge.Strategy) {}
+
+func TestSortAndAggregateTolerantEdges(t *testing.T) {
+	t.Run("dedup delegates", func(t *testing.T) {
+		p := makeStringPoints(ev{100, "1"}, ev{100, "2"}, ev{200, "3"})
+		out := sortAndAggregateTolerant(p, merge.StrategyDedup, 0, nil)
+		require.Len(t, out, 2)
+		require.Equal(t, "2", out[0].Values[0])
+	})
+
+	t.Run("single point early return", func(t *testing.T) {
+		p := makeStringPoints(ev{100, "1"})
+		out := sortAndAggregateTolerant(p, merge.StrategySum, 0, nil)
+		require.Len(t, out, 1)
+		require.Equal(t, "1", out[0].Values[0])
+	})
+
+	t.Run("empty early return", func(t *testing.T) {
+		out := sortAndAggregateTolerant(Points{}, merge.StrategySum, 0, nil)
+		require.Empty(t, out)
+	})
+}
+
+func TestAggregateValuesWithOperationsEdges(t *testing.T) {
+	t.Run("empty values no-op", func(t *testing.T) {
+		dst := Point{Epoch: 1, Values: nil}
+		src := Point{Epoch: 1, Values: []any{"1"}}
+		aggregateValuesWithOperations(&dst, &src, merge.StrategySum, nil)
+		require.Nil(t, dst.Values)
+
+		dst = Point{Epoch: 1, Values: []any{"1"}}
+		src = Point{Epoch: 1, Values: nil}
+		aggregateValuesWithOperations(&dst, &src, merge.StrategySum, nil)
+		require.Equal(t, "1", dst.Values[0])
+	})
+
+	t.Run("both non-numeric with ops", func(t *testing.T) {
+		ops := &stubValueOps{mergeHandled: true, merged: "merged-hist"}
+		dst := Point{Epoch: 1, Size: 40, Values: []any{"hist-a"}}
+		src := Point{Epoch: 1, Values: []any{"hist-b"}}
+		aggregateValuesWithOperations(&dst, &src, merge.StrategySum, ops)
+		require.Equal(t, "merged-hist", dst.Values[0])
+		require.Equal(t, 40+len("merged-hist")-len("hist-a"), dst.Size)
+	})
+
+	t.Run("both non-numeric ops not handled", func(t *testing.T) {
+		ops := &stubValueOps{mergeHandled: false}
+		dst := Point{Epoch: 1, Values: []any{"hist-a"}}
+		src := Point{Epoch: 1, Values: []any{"hist-b"}}
+		aggregateValuesWithOperations(&dst, &src, merge.StrategySum, ops)
+		require.Equal(t, "hist-a", dst.Values[0])
+	})
+
+	t.Run("min max and default strategies", func(t *testing.T) {
+		dst := Point{Epoch: 1, Values: []any{"5"}}
+		src := Point{Epoch: 1, Values: []any{"2"}}
+		aggregateValues(&dst, &src, merge.StrategyMin)
+		require.Equal(t, "2", dst.Values[0])
+
+		dst = Point{Epoch: 1, Values: []any{"5"}}
+		src = Point{Epoch: 1, Values: []any{"9"}}
+		aggregateValues(&dst, &src, merge.StrategyMax)
+		require.Equal(t, "9", dst.Values[0])
+
+		dst = Point{Epoch: 1, Values: []any{"5"}}
+		src = Point{Epoch: 1, Values: []any{"9"}}
+		aggregateValues(&dst, &src, merge.Strategy(255))
+		require.Equal(t, "9", dst.Values[0])
+	})
+}
+
+func TestFinalizeAvgWithOperationsEdges(t *testing.T) {
+	t.Run("count le 1 or empty", func(t *testing.T) {
+		p := Point{Epoch: 1, Values: []any{"10"}}
+		finalizeAvgWithOperations(&p, 1, nil)
+		require.Equal(t, "10", p.Values[0])
+
+		p = Point{Epoch: 1, Values: nil}
+		finalizeAvgWithOperations(&p, 3, nil)
+		require.Nil(t, p.Values)
+	})
+
+	t.Run("nan with ops", func(t *testing.T) {
+		ops := &stubValueOps{divideHandled: true, divided: "avg-hist"}
+		p := Point{Epoch: 1, Size: 30, Values: []any{"hist"}}
+		finalizeAvgWithOperations(&p, 2, ops)
+		require.Equal(t, "avg-hist", p.Values[0])
+		require.Equal(t, 30+len("avg-hist")-len("hist"), p.Size)
+	})
+
+	t.Run("nan ops not handled", func(t *testing.T) {
+		ops := &stubValueOps{divideHandled: false}
+		p := Point{Epoch: 1, Values: []any{"hist"}}
+		finalizeAvgWithOperations(&p, 2, ops)
+		require.Equal(t, "hist", p.Values[0])
+	})
+}
+
+func TestSetPointValue(t *testing.T) {
+	p := Point{Size: 10, Values: []any{"abc"}}
+	setPointValue(&p, 0, "abcdef")
+	require.Equal(t, "abcdef", p.Values[0])
+	require.Equal(t, 13, p.Size)
+
+	p = Point{Size: 0, Values: []any{"abc"}}
+	setPointValue(&p, 0, "xyz")
+	require.Equal(t, "xyz", p.Values[0])
+	require.Equal(t, 0, p.Size)
+
+	p = Point{Size: 5, Values: []any{1}}
+	setPointValue(&p, 0, 2)
+	require.Equal(t, 2, p.Values[0])
+	require.Equal(t, 5, p.Size)
+}
+
+func TestMergePointsWithOptsNonDedupEdges(t *testing.T) {
+	t.Run("nil both", func(t *testing.T) {
+		require.Nil(t, MergePointsWithOpts(nil, nil, MergeOpts{Strategy: merge.StrategySum}))
+	})
+
+	t.Run("empty both", func(t *testing.T) {
+		out := MergePointsWithOpts(Points{}, Points{}, MergeOpts{Strategy: merge.StrategySum})
+		require.NotNil(t, out)
+		require.Empty(t, out)
+	})
+
+	t.Run("only p2 empty sorts", func(t *testing.T) {
+		p1 := makeStringPoints(ev{200, "2"}, ev{100, "1"}, ev{100, "3"})
+		out := MergePointsWithOpts(p1, Points{}, MergeOpts{
+			SortPoints: true,
+			Strategy:   merge.StrategySum,
+		})
+		require.Len(t, out, 2)
+		require.Equal(t, epoch.Epoch(100), out[0].Epoch)
+		require.Equal(t, "4", out[0].Values[0])
+	})
+
+	t.Run("only p1 empty sorts", func(t *testing.T) {
+		p2 := makeStringPoints(ev{200, "2"}, ev{100, "1"})
+		out := MergePointsWithOpts(Points{}, p2, MergeOpts{
+			SortPoints: true,
+			Strategy:   merge.StrategyMin,
+		})
+		require.Len(t, out, 2)
+		require.Equal(t, epoch.Epoch(100), out[0].Epoch)
+	})
+
+	t.Run("count with empty values", func(t *testing.T) {
+		p1 := Points{{Epoch: 100, Values: nil}, {Epoch: 100, Values: []any{"9"}}}
+		p2 := Points{}
+		out := MergePointsWithOpts(p1, p2, MergeOpts{
+			SortPoints: true,
+			Strategy:   merge.StrategyCount,
+		})
+		require.Len(t, out, 1)
+		// The empty-values point is kept as-is during initCountValues; when it
+		// is the aggregate destination, aggregateValues no-ops on empty Values.
+		if len(out[0].Values) > 0 {
+			require.Equal(t, "1", out[0].Values[0])
+		}
+	})
+
+	t.Run("avg with value operations", func(t *testing.T) {
+		ops := &stubValueOps{mergeHandled: true, merged: "h", divideHandled: true, divided: "h/2"}
+		p1 := makeStringPoints(ev{100, "hist-a"})
+		p2 := makeStringPoints(ev{100, "hist-b"})
+		out := MergePointsWithOpts(p1, p2, MergeOpts{
+			SortPoints:      true,
+			Strategy:        merge.StrategyAvg,
+			ValueOperations: ops,
+		})
+		require.Len(t, out, 1)
+		require.Equal(t, "h/2", out[0].Values[0])
+	})
+}

--- a/pkg/timeseries/epoch/epoch_extended_test.go
+++ b/pkg/timeseries/epoch/epoch_extended_test.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package epoch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+)
+
+func TestFromConverters(t *testing.T) {
+	t.Parallel()
+	if got := FromSecs(1577836800); got != Epoch(1577836800)*BillionNS {
+		t.Errorf("FromSecs: got %d", got)
+	}
+	if got := FromMilliSecs(1577836800000); got != Epoch(1577836800000)*MillionNS {
+		t.Errorf("FromMilliSecs: got %d", got)
+	}
+	if got := FromNanoSecs(1577836800000000000); got != Epoch(1577836800000000000) {
+		t.Errorf("FromNanoSecs: got %d", got)
+	}
+}
+
+func TestFormatRFC3339(t *testing.T) {
+	t.Parallel()
+	e := FromSecs(1577836800)
+	got := e.Format(timeseries.DateTimeRFC3339, false)
+	want := "2020-01-01T00:00:00Z"
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+	got = e.Format(timeseries.DateTimeRFC3339Nano, false)
+	if got != want {
+		t.Errorf("got %q want %q", got, want)
+	}
+}
+
+func TestFormatTimeDirect(t *testing.T) {
+	t.Parallel()
+	ts := time.Unix(1577836800, 0).UTC()
+	tests := []struct {
+		name  string
+		typ   timeseries.FieldDataType
+		quote bool
+		want  string
+	}{
+		{name: "unix secs", typ: timeseries.DateTimeUnixSecs, want: "1577836800"},
+		{name: "unix milli", typ: timeseries.DateTimeUnixMilli, want: "1577836800000"},
+		{name: "unix nano", typ: timeseries.DateTimeUnixNano, want: "1577836800000000000"},
+		{name: "sql datetime quoted", typ: timeseries.DateTimeSQL, quote: true, want: "'2020-01-01 00:00:00'"},
+		{name: "sql date", typ: timeseries.DateSQL, quote: true, want: "'2020-01-01'"},
+		{name: "sql time", typ: timeseries.TimeSQL, quote: true, want: "'00:00:00'"},
+		{name: "rfc3339", typ: timeseries.DateTimeRFC3339, want: "2020-01-01T00:00:00Z"},
+		{name: "unknown", typ: timeseries.Unknown, want: "0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatTime(ts, tc.typ, tc.quote)
+			if got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/timeseries/field_definition_test.go
+++ b/pkg/timeseries/field_definition_test.go
@@ -114,4 +114,55 @@ func TestFieldDefinitionsString(t *testing.T) {
 			t.Errorf("expected [] got %s", s)
 		}
 	})
+
+	t.Run("full fields", func(t *testing.T) {
+		fd := FieldDefinitions{
+			{
+				Name:           "ts",
+				DataType:       DateTimeUnixMilli,
+				SDataType:      "UInt64",
+				OutputPosition: 0,
+				DefaultValue:   "0",
+				Role:           RoleTimestamp,
+				ProviderData1:  1,
+			},
+			{
+				Name:           "val",
+				DataType:       Float64,
+				SDataType:      "Float64",
+				OutputPosition: 1,
+				Role:           RoleValue,
+			},
+		}
+		s := fd.String()
+		if s == "" || s == "[]" {
+			t.Fatalf("unexpected empty serialization: %s", s)
+		}
+		lookup := fd.ToLookup()
+		if lookup["ts"].Role != RoleTimestamp {
+			t.Error("expected timestamp role in lookup")
+		}
+		if lookup["val"].DataType != Float64 {
+			t.Error("expected float64 value field")
+		}
+	})
+}
+
+func TestFieldDefinitionStringFull(t *testing.T) {
+	fd := FieldDefinition{
+		Name:           "metric",
+		DataType:       Float64,
+		SDataType:      "Float64",
+		OutputPosition: 2,
+		DefaultValue:   "NaN",
+		Role:           RoleValue,
+		ProviderData1:  3,
+	}
+	s := fd.String()
+	if s == "" {
+		t.Fatal("expected non-empty string")
+	}
+	if size := fd.Size(); size <= 0 {
+		t.Errorf("expected positive size, got %d", size)
+	}
 }


### PR DESCRIPTION
## Description
<!-- Describe changes and the problem solved -->
- Add test coverage to `daemon` package and subpackages
- fixes possible data race in `listener.exitOnError`
- fixes missing type assertion guard config reload via hup that could cause panics
- removes orphaned listener swap code in daemon setup

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
