### PR TITLE
tests: add clickhouse query parse benchmarks

### DIFF
--- a/pkg/backends/clickhouse/parsing_benchmark_test.go
+++ b/pkg/backends/clickhouse/parsing_benchmark_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package clickhouse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/timeseries"
+)
+
+// BenchmarkClickHouseParseAndTokenize matches the end-to-end benchmark used
+// by the generated-AST implementation: parse a representative query, analyze
+// its cache eligibility, extract its extent, and produce its tokenized form.
+func BenchmarkClickHouseParseAndTokenize(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		trq, _, _, err := parse(tq03)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if trq.Statement == "" {
+			b.Fatal("empty tokenized statement")
+		}
+	}
+}
+
+// BenchmarkClickHouseRenderExtent measures the legacy cache-miss interpolation
+// path independently from parsing, matching the generated-AST render benchmark.
+func BenchmarkClickHouseRenderExtent(b *testing.B) {
+	trq, _, _, err := parse(tq03)
+	if err != nil {
+		b.Fatal(err)
+	}
+	extent := &timeseries.Extent{
+		Start: time.Unix(1516665600, 0),
+		End:   time.Unix(1516687200, 0),
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		rendered := interpolateTimeQuery(trq.Statement, trq.TimestampDefinition, extent)
+		if rendered == "" {
+			b.Fatal("empty rendered statement")
+		}
+	}
+}

--- a/pkg/backends/prometheus/tsm_limitk_finalize_test.go
+++ b/pkg/backends/prometheus/tsm_limitk_finalize_test.go
@@ -340,7 +340,7 @@ func BenchmarkFinalizeTSMMergeLimitK(b *testing.B) {
 	series := make([]*dataset.Series, 0, seriesCount)
 	for i := range seriesCount {
 		points := make(dataset.Points, 0, pointCount)
-		for j := 0; j < pointCount; j++ {
+		for j := range pointCount {
 			value := strconv.Itoa(i*pointCount + j)
 			points = append(points, dataset.Point{
 				Epoch: epoch.Epoch(j + 1), Size: len(value) + 32, Values: []any{value},


### PR DESCRIPTION
## Description
- add benchmarks for ClickHouse parsing using test query 03
- fix unrelated linter nit

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [ ] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
