### PR TITLE
feat: add Grafana origin provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Trickster works with virtually any Dashboard application that makes queries to a
 
 <img src="./docs/images/external/influx_logo_60.png" width=16 /> InfluxDB
 
+Trickster can also use [Grafana as an origin](./docs/grafana.md), automatically dispatching supported Grafana-proxied data sources through the matching time series accelerator.
+
 See the [Supported TSDB Providers](./docs/supported-backend-providers.md) document for full details
 
 ### How Trickster Accelerates Time Series

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -17,7 +17,7 @@ See [`simple.grafana.yaml`](../examples/conf/simple.grafana.yaml) for a runnable
 
 ## Data Source Discovery
 
-At startup, Trickster makes a best-effort request to Grafana's `/api/datasources` endpoint. When it receives an unrecognized data source proxy path later, it looks up that data source by numeric ID or UID and remembers the result for subsequent requests.
+At startup, Trickster makes a best-effort request to Grafana's `/api/datasources` endpoint. When it receives an unrecognized data source proxy path later, it looks up a UID through `/api/datasources/uid/:uid`, or refreshes the data source list to resolve a legacy numeric ID, and remembers the result for subsequent requests.
 
 Trickster recognizes both Grafana data source proxy path forms:
 
@@ -51,6 +51,8 @@ Grafana-proxied data sources using the following types are dispatched through th
 | `vertamedia-clickhouse-datasource` | ClickHouse |
 
 Only data sources configured with Grafana's `proxy` access mode are accelerated. Unsupported data source types, browser-access data sources, and all other Grafana UI and API traffic are transparently proxied without caching.
+
+Grafana Live WebSocket connections require a separate WebSocket-capable route; Trickster's HTTP proxy does not tunnel protocol upgrades.
 
 Grafana's `/api/ds/query` endpoint is also transparently proxied. That endpoint can contain multiple queries and data sources in a Grafana data-frame envelope, so it cannot safely reuse a single Trickster time series provider without a dedicated request and response modeler.
 

--- a/docs/grafana.md
+++ b/docs/grafana.md
@@ -1,0 +1,59 @@
+# Grafana Origin Support
+
+Trickster can use Grafana as an origin while continuing to accelerate supported time series data sources. In this mode, clients connect to Trickster instead of Grafana directly. Trickster transparently proxies the Grafana UI and API, and dynamically dispatches recognized data source proxy requests through its existing time series backend providers.
+
+## Configuration
+
+Configure a backend with `provider: grafana` and set `origin_url` to the Grafana base URL:
+
+```yaml
+backends:
+  default:
+    provider: grafana
+    origin_url: http://grafana:3000
+```
+
+See [`simple.grafana.yaml`](../examples/conf/simple.grafana.yaml) for a runnable configuration example.
+
+## Data Source Discovery
+
+At startup, Trickster makes a best-effort request to Grafana's `/api/datasources` endpoint. When it receives an unrecognized data source proxy path later, it looks up that data source by numeric ID or UID and remembers the result for subsequent requests.
+
+Trickster recognizes both Grafana data source proxy path forms:
+
+- `/api/datasources/proxy/:id/*`
+- `/api/datasources/proxy/uid/:uid/*`
+
+Discovery uses the incoming `Authorization`, `Cookie`, `X-Grafana-Org-Id`, `X-WEBAUTH-USER`, and `X-JWT-Assertion` headers. This lets lazy discovery use the same Grafana identity as the proxied request. For startup discovery or service-to-service use, a header can be configured on the root path:
+
+```yaml
+backends:
+  default:
+    provider: grafana
+    origin_url: http://grafana:3000
+    paths:
+      - path: /
+        match_type: prefix
+        methods: [ '*' ]
+        handler: grafana
+        request_headers:
+          Authorization: Bearer ${GRAFANA_SERVICE_TOKEN}
+```
+
+## Acceleration Boundary
+
+Grafana-proxied data sources using the following types are dispatched through the corresponding Trickster provider:
+
+| Grafana data source type | Trickster provider |
+| --- | --- |
+| `prometheus` | Prometheus |
+| `influxdb` | InfluxDB |
+| `vertamedia-clickhouse-datasource` | ClickHouse |
+
+Only data sources configured with Grafana's `proxy` access mode are accelerated. Unsupported data source types, browser-access data sources, and all other Grafana UI and API traffic are transparently proxied without caching.
+
+Grafana's `/api/ds/query` endpoint is also transparently proxied. That endpoint can contain multiple queries and data sources in a Grafana data-frame envelope, so it cannot safely reuse a single Trickster time series provider without a dedicated request and response modeler.
+
+Cached data source responses are separated by the listed Grafana identity headers to prevent data from being shared across users or organizations.
+
+If Grafana uses a custom authentication or tenant header, add that header to the root path's `cache_key_headers`. Trickster will then forward it during data source discovery and include it when separating cached responses.

--- a/docs/supported-backend-providers.md
+++ b/docs/supported-backend-providers.md
@@ -8,6 +8,14 @@ Trickster operates as a fully-featured and highly-customizable reverse proxy cac
 
 ---
 
+## Dashboard Origins
+
+### Grafana
+
+Trickster can transparently proxy Grafana and dynamically dispatch supported Grafana-proxied data sources through its time series accelerators. Specify `'grafana'` as the Provider when configuring Trickster. See the [Grafana Origin Support Document](./grafana.md) for supported paths, data source types, and authentication behavior.
+
+---
+
 ## Time Series Databases
 
 ### <img src="./images/external/prom_logo_60.png" width=16 /> Prometheus

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -252,7 +252,7 @@ backends:
     listener_name: default
 
     # provider identifies the backend provider.
-    # Valid options are: prometheus, influxdb, clickhouse, reverseproxycache (or just rpc)
+    # Valid options are: prometheus, influxdb, clickhouse, grafana, reverseproxycache (or just rpc)
     # provider is a required configuration value
     provider: prometheus
 

--- a/examples/conf/simple.grafana.yaml
+++ b/examples/conf/simple.grafana.yaml
@@ -1,0 +1,23 @@
+#
+# Trickster 2.0 Example Configuration File - Example Grafana Origin
+#
+# To use this, run: trickster -config /path/to/simple.grafana.yaml
+#
+# Copyright 2018 The Trickster Authors
+#
+
+listeners:
+  grafana_port:
+    protocol: http
+    address: ""
+    port: 8480
+
+backends:
+  default:
+    # Update the FQDN and port to match your Grafana instance.
+    origin_url: 'http://grafana:3000'
+    provider: 'grafana'
+    listener_name: grafana_port
+
+logging:
+  log_level: 'info'

--- a/integration/grafana_test.go
+++ b/integration/grafana_test.go
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package integration
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const grafanaAPIBaseURL = "http://127.0.0.1:3000"
+
+func TestGrafanaOrigin(t *testing.T) {
+	waitForGrafana(t)
+	waitForPrometheusData(t, "127.0.0.1:9090")
+
+	h := grafanaIntegrationHarness(t)
+	h.start(t)
+
+	uid := "trickster-" + strconv.FormatInt(time.Now().UnixNano(), 36)
+	id := createGrafanaPrometheusDataSource(t, uid)
+	t.Cleanup(func() { deleteGrafanaDataSource(t, uid) })
+
+	end := time.Now().Add(-30 * time.Second).Truncate(15 * time.Second)
+	params := url.Values{
+		"query": {fmt.Sprintf("up + 0*%d", time.Now().UnixNano())},
+		"start": {strconv.FormatInt(end.Add(-time.Minute).Unix(), 10)},
+		"end":   {strconv.FormatInt(end.Unix(), 10)},
+		"step":  {"15"},
+	}
+	authorization := "Basic " + base64.StdEncoding.EncodeToString([]byte("admin:admin"))
+	path := fmt.Sprintf("/grafana/api/datasources/proxy/%d/api/v1/query_range", id)
+
+	resp, body := h.do(t, path, withParams(params), withHeader("Authorization", authorization))
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected Grafana proxy response: %s", body)
+	requirePrometheusMatrix(t, body)
+	requireTricksterResult(t, resp.Header, map[string]string{
+		"engine": "DeltaProxyCache",
+		"status": "kmiss",
+	})
+
+	resp, body = h.do(t, path, withParams(params), withHeader("Authorization", authorization))
+	require.Equal(t, http.StatusOK, resp.StatusCode, "unexpected Grafana proxy response: %s", body)
+	requirePrometheusMatrix(t, body)
+	requireTricksterResult(t, resp.Header, map[string]string{"status": "hit"})
+}
+
+func grafanaIntegrationHarness(t *testing.T) tricksterHarness {
+	t.Helper()
+	const config = `listeners:
+  grafana_test:
+    address: 127.0.0.1
+    port: 8560
+  metrics:
+    address: 127.0.0.1
+    port: 8561
+  mgmt:
+    address: 127.0.0.1
+    port: 8564
+backends:
+  grafana:
+    provider: grafana
+    origin_url: http://127.0.0.1:3000
+    listener_name: grafana_test
+caches:
+  default:
+    provider: memory
+`
+	configPath := filepath.Join(t.TempDir(), "trickster.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+	return tricksterHarness{
+		ConfigPath:  configPath,
+		BaseAddr:    "127.0.0.1:8560",
+		MetricsAddr: "127.0.0.1:8561",
+	}
+}
+
+func waitForGrafana(t *testing.T) {
+	t.Helper()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		status, _, err := doGrafanaAPIRequest(http.MethodGet, "/api/health", nil)
+		if !assert.NoError(collect, err) {
+			return
+		}
+		assert.Equal(collect, http.StatusOK, status)
+	}, time.Minute, time.Second, "Grafana did not become ready")
+}
+
+func createGrafanaPrometheusDataSource(t *testing.T, uid string) int64 {
+	t.Helper()
+	payload, err := json.Marshal(map[string]any{
+		"name": uid, "uid": uid, "type": "prometheus", "access": "proxy",
+		"url":      "http://prometheus:9090",
+		"jsonData": map[string]any{"httpMethod": http.MethodGet},
+	})
+	require.NoError(t, err)
+	status, body, err := doGrafanaAPIRequest(http.MethodPost, "/api/datasources", payload)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status, "create Grafana data source: %s", body)
+	var created struct {
+		ID         int64 `json:"id"`
+		DataSource struct {
+			ID int64 `json:"id"`
+		} `json:"datasource"`
+	}
+	require.NoError(t, json.Unmarshal(body, &created))
+	if created.ID == 0 {
+		created.ID = created.DataSource.ID
+	}
+	require.Positive(t, created.ID, "Grafana data source response: %s", body)
+	return created.ID
+}
+
+func deleteGrafanaDataSource(t *testing.T, uid string) {
+	t.Helper()
+	status, body, err := doGrafanaAPIRequest(http.MethodDelete, "/api/datasources/uid/"+uid, nil)
+	if err != nil {
+		t.Errorf("delete Grafana data source: %v", err)
+		return
+	}
+	if status != http.StatusOK {
+		t.Errorf("delete Grafana data source: status=%d body=%s", status, body)
+	}
+}
+
+func doGrafanaAPIRequest(method, path string, body []byte) (int, []byte, error) {
+	req, err := http.NewRequest(method, grafanaAPIBaseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, err
+	}
+	req.SetBasicAuth("admin", "admin")
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	responseBody, err := io.ReadAll(resp.Body)
+	return resp.StatusCode, responseBody, err
+}
+
+func requirePrometheusMatrix(t *testing.T, body []byte) {
+	t.Helper()
+	var response promResponse
+	require.NoError(t, json.Unmarshal(body, &response))
+	require.Equal(t, "success", response.Status)
+	var data promQueryData
+	require.NoError(t, json.Unmarshal(response.Data, &data))
+	require.Equal(t, "matrix", data.ResultType)
+	var series []json.RawMessage
+	require.NoError(t, json.Unmarshal(data.Result, &series))
+	require.NotEmpty(t, series)
+}

--- a/pkg/backends/grafana/discovery.go
+++ b/pkg/backends/grafana/discovery.go
@@ -37,13 +37,14 @@ import (
 )
 
 const (
-	dataSourceResponseLimit = 4 * 1024 * 1024
-	metadataRequestTimeout  = 10 * time.Second
-	dataSourceCacheTTL      = 5 * time.Minute
-	maxDataSourceCacheKeys  = 4096
-	grafanaOrgHeader        = "X-Grafana-Org-Id"
-	grafanaAuthProxyHeader  = "X-WEBAUTH-USER"
-	grafanaJWTHeader        = "X-JWT-Assertion"
+	dataSourceResponseLimit  = 4 * 1024 * 1024
+	metadataRequestTimeout   = 10 * time.Second
+	dataSourceCacheTTL       = 5 * time.Minute
+	maxDataSourceCacheKeys   = 4096
+	maxDataSourceDispatchers = 4096
+	grafanaOrgHeader         = "X-Grafana-Org-Id"
+	grafanaAuthProxyHeader   = "X-WEBAUTH-USER"
+	grafanaJWTHeader         = "X-JWT-Assertion"
 )
 
 var errInvalidDataSourceResponse = errors.New("invalid Grafana data source response")
@@ -56,7 +57,7 @@ var grafanaDiscoveryIdentityHeaders = []string{
 	grafanaJWTHeader,
 }
 
-var grafanaCacheIdentityHeaders = grafanaDiscoveryIdentityHeaders[1:]
+var grafanaCacheIdentityHeaders = slices.Clone(grafanaDiscoveryIdentityHeaders)
 
 type dataSource struct {
 	ID        int64          `json:"id"`
@@ -99,8 +100,8 @@ func (c *Client) metadataTimeout() time.Duration {
 }
 
 func (c *Client) preloadDataSources(ctx context.Context, headers http.Header) error {
-	var dataSources []*dataSource
-	if err := c.getJSON(ctx, "/api/datasources", headers, &dataSources); err != nil {
+	dataSources, err := c.listDataSources(ctx, headers)
+	if err != nil {
 		return err
 	}
 	identity := discoveryIdentity(headers)
@@ -131,13 +132,23 @@ func (c *Client) resolveDataSource(ctx context.Context, ref dataSourceRef,
 			return ds, nil
 		}
 
-		endpoint := "/api/datasources/" + ref.value
+		var ds *dataSource
 		if ref.kind == dataSourceRefUID {
-			endpoint = "/api/datasources/uid/" + ref.value
-		}
-		ds := &dataSource{}
-		if err := c.getJSON(ctx, endpoint, headers, ds); err != nil {
-			return nil, err
+			ds = &dataSource{}
+			if err := c.getJSON(ctx, "/api/datasources/uid/"+ref.value, headers, ds); err != nil {
+				return nil, err
+			}
+		} else {
+			dataSources, err := c.listDataSources(ctx, headers)
+			if err != nil {
+				return nil, err
+			}
+			for _, candidate := range dataSources {
+				if validDataSource(candidate) && ref.matches(candidate) {
+					ds = candidate
+					break
+				}
+			}
 		}
 		if !validDataSource(ds) || !ref.matches(ds) {
 			return nil, errInvalidDataSourceResponse
@@ -153,6 +164,14 @@ func (c *Client) resolveDataSource(ctx context.Context, ref dataSourceRef,
 		return nil, errInvalidDataSourceResponse
 	}
 	return ds, nil
+}
+
+func (c *Client) listDataSources(ctx context.Context, headers http.Header) ([]*dataSource, error) {
+	var dataSources []*dataSource
+	if err := c.getJSON(ctx, "/api/datasources", headers, &dataSources); err != nil {
+		return nil, err
+	}
+	return dataSources, nil
 }
 
 func (c *Client) getJSON(ctx context.Context, endpoint string, headers http.Header, out any) error {

--- a/pkg/backends/grafana/discovery.go
+++ b/pkg/backends/grafana/discovery.go
@@ -1,0 +1,320 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grafana
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	proxyheaders "github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+)
+
+const (
+	dataSourceResponseLimit = 4 * 1024 * 1024
+	metadataRequestTimeout  = 10 * time.Second
+	dataSourceCacheTTL      = 5 * time.Minute
+	maxDataSourceCacheKeys  = 4096
+	grafanaOrgHeader        = "X-Grafana-Org-Id"
+	grafanaAuthProxyHeader  = "X-WEBAUTH-USER"
+	grafanaJWTHeader        = "X-JWT-Assertion"
+)
+
+var errInvalidDataSourceResponse = errors.New("invalid Grafana data source response")
+
+var grafanaDiscoveryIdentityHeaders = []string{
+	proxyheaders.NameAuthorization,
+	"Cookie",
+	grafanaOrgHeader,
+	grafanaAuthProxyHeader,
+	grafanaJWTHeader,
+}
+
+var grafanaCacheIdentityHeaders = grafanaDiscoveryIdentityHeaders[1:]
+
+type dataSource struct {
+	ID        int64          `json:"id"`
+	UID       string         `json:"uid"`
+	OrgID     int64          `json:"orgId"`
+	Type      string         `json:"type"`
+	Access    string         `json:"access"`
+	URL       string         `json:"url"`
+	User      string         `json:"user"`
+	Database  string         `json:"database"`
+	BasicAuth bool           `json:"basicAuth"`
+	JSONData  map[string]any `json:"jsonData"`
+}
+
+type dataSourceCacheEntry struct {
+	dataSource *dataSource
+	expiresAt  time.Time
+}
+
+func (c *Client) startPreload() {
+	c.preloadOnce.Do(func() {
+		headers := c.discoveryHeaders(nil)
+		go func() {
+			ctx, cancel := context.WithTimeout(context.Background(), c.metadataTimeout())
+			defer cancel()
+			if err := c.preloadDataSources(ctx, headers); err != nil {
+				logger.Debug("Grafana data source preload unavailable",
+					logging.Pairs{"backendName": c.Name(), "detail": err.Error()})
+			}
+		}()
+	})
+}
+
+func (c *Client) metadataTimeout() time.Duration {
+	d := metadataRequestTimeout
+	if o := c.Configuration(); o != nil && o.Timeout > 0 && time.Duration(o.Timeout) < d {
+		d = time.Duration(o.Timeout)
+	}
+	return d
+}
+
+func (c *Client) preloadDataSources(ctx context.Context, headers http.Header) error {
+	var dataSources []*dataSource
+	if err := c.getJSON(ctx, "/api/datasources", headers, &dataSources); err != nil {
+		return err
+	}
+	identity := discoveryIdentity(headers)
+	stored := 0
+	for _, ds := range dataSources {
+		if validDataSource(ds) {
+			c.storeDataSource(identity, ds)
+			stored++
+			if stored >= maxDataSourceCacheKeys/2 {
+				break
+			}
+		}
+	}
+	return nil
+}
+
+func (c *Client) resolveDataSource(ctx context.Context, ref dataSourceRef,
+	headers http.Header,
+) (*dataSource, error) {
+	identity := discoveryIdentity(headers)
+	key := dataSourceKey(identity, ref.kind, ref.value)
+	if ds := c.loadDataSource(key); ds != nil {
+		return ds, nil
+	}
+
+	v, err, _ := c.lookupGroup.Do(key, func() (any, error) {
+		if ds := c.loadDataSource(key); ds != nil {
+			return ds, nil
+		}
+
+		endpoint := "/api/datasources/" + ref.value
+		if ref.kind == dataSourceRefUID {
+			endpoint = "/api/datasources/uid/" + ref.value
+		}
+		ds := &dataSource{}
+		if err := c.getJSON(ctx, endpoint, headers, ds); err != nil {
+			return nil, err
+		}
+		if !validDataSource(ds) || !ref.matches(ds) {
+			return nil, errInvalidDataSourceResponse
+		}
+		c.storeDataSource(identity, ds)
+		return ds, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	ds, ok := v.(*dataSource)
+	if !ok || ds == nil {
+		return nil, errInvalidDataSourceResponse
+	}
+	return ds, nil
+}
+
+func (c *Client) getJSON(ctx context.Context, endpoint string, headers http.Header, out any) error {
+	base := c.BaseUpstreamURL()
+	if base == nil || base.Scheme == "" || base.Host == "" {
+		return errors.New("grafana origin URL is not configured")
+	}
+	u := *base
+	u.Path = strings.TrimRight(u.Path, "/") + endpoint
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return err
+	}
+	for name, values := range headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+	if host := req.Header.Get(proxyheaders.NameHost); host != "" {
+		req.Host = host
+		req.Header.Del(proxyheaders.NameHost)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	client := c.HTTPClient()
+	if client == nil {
+		return errors.New("grafana HTTP client is not configured")
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return fmt.Errorf("grafana data source API returned %s", resp.Status)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, dataSourceResponseLimit+1))
+	if err != nil {
+		return err
+	}
+	if len(body) > dataSourceResponseLimit {
+		return errors.New("grafana data source response exceeds limit")
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("decode Grafana data source response: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) discoveryHeaders(r *http.Request) http.Header {
+	out := make(http.Header)
+	var pathConfigHeaders map[string]string
+	identityHeaders := slices.Clone(grafanaDiscoveryIdentityHeaders)
+	if r != nil {
+		if rsc := request.GetResources(r); rsc != nil && rsc.PathConfig != nil {
+			pathConfigHeaders = rsc.PathConfig.RequestHeaders
+			identityHeaders = appendUnique(identityHeaders, rsc.PathConfig.CacheKeyHeaders...)
+		}
+		for _, name := range identityHeaders {
+			if name == "" || name == "*" {
+				continue
+			}
+			for _, value := range r.Header.Values(name) {
+				out.Add(name, value)
+			}
+		}
+	}
+
+	if r == nil {
+		if o := c.Configuration(); o != nil {
+			for _, p := range o.Paths {
+				if p != nil && p.Path == "/" {
+					pathConfigHeaders = p.RequestHeaders
+					break
+				}
+			}
+		}
+	}
+	proxyheaders.UpdateHeaders(out, pathConfigHeaders)
+	return out
+}
+
+func discoveryIdentity(headers http.Header) string {
+	if len(headers) == 0 {
+		return "anonymous"
+	}
+	names := make([]string, 0, len(headers))
+	for name := range headers {
+		if strings.EqualFold(name, "Accept") || strings.EqualFold(name, "Content-Type") {
+			continue
+		}
+		names = append(names, http.CanonicalHeaderKey(name))
+	}
+	slices.Sort(names)
+	h := sha256.New()
+	for _, name := range names {
+		h.Write([]byte(strings.ToLower(name)))
+		h.Write([]byte{0})
+		values := slices.Clone(headers.Values(name))
+		slices.Sort(values)
+		for _, value := range values {
+			h.Write([]byte(value))
+			h.Write([]byte{0})
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func validDataSource(ds *dataSource) bool {
+	return ds != nil && ds.ID > 0 && strings.TrimSpace(ds.Type) != ""
+}
+
+func dataSourceKey(identity string, kind dataSourceRefKind, value string) string {
+	return identity + "|" + string(kind) + "|" + value
+}
+
+func (c *Client) loadDataSource(key string) *dataSource {
+	c.mu.Lock()
+	entry, ok := c.dataSources[key]
+	if ok && time.Now().Before(entry.expiresAt) {
+		c.mu.Unlock()
+		return entry.dataSource
+	}
+	if ok {
+		delete(c.dataSources, key)
+	}
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *Client) storeDataSource(identity string, ds *dataSource) {
+	if !validDataSource(ds) {
+		return
+	}
+	entry := dataSourceCacheEntry{dataSource: ds, expiresAt: time.Now().Add(dataSourceCacheTTL)}
+	c.mu.Lock()
+	c.storeDataSourceKey(dataSourceKey(identity, dataSourceRefID,
+		strconv.FormatInt(ds.ID, 10)), entry)
+	if ds.UID != "" {
+		c.storeDataSourceKey(dataSourceKey(identity, dataSourceRefUID, ds.UID), entry)
+	}
+	c.mu.Unlock()
+}
+
+func (c *Client) storeDataSourceKey(key string, entry dataSourceCacheEntry) {
+	if _, ok := c.dataSources[key]; !ok && len(c.dataSources) >= maxDataSourceCacheKeys {
+		now := time.Now()
+		for existingKey, existing := range c.dataSources {
+			if !now.Before(existing.expiresAt) {
+				delete(c.dataSources, existingKey)
+			}
+		}
+		if len(c.dataSources) >= maxDataSourceCacheKeys {
+			for existingKey := range c.dataSources {
+				delete(c.dataSources, existingKey)
+				break
+			}
+		}
+	}
+	c.dataSources[key] = entry
+}

--- a/pkg/backends/grafana/discovery_test.go
+++ b/pkg/backends/grafana/discovery_test.go
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grafana
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+)
+
+func TestDiscoveryIdentityIsStableAndCredentialScoped(t *testing.T) {
+	first := make(http.Header)
+	first.Add("Cookie", "session=a")
+	first.Add("X-Custom-Auth", "two")
+	first.Add("X-Custom-Auth", "one")
+	second := make(http.Header)
+	second.Add("X-Custom-Auth", "one")
+	second.Add("X-Custom-Auth", "two")
+	second.Add("Cookie", "session=a")
+	if got, want := discoveryIdentity(first), discoveryIdentity(second); got != want {
+		t.Fatalf("equivalent headers produced different identities: %q != %q", got, want)
+	}
+	second.Set("Cookie", "session=b")
+	if discoveryIdentity(first) == discoveryIdentity(second) {
+		t.Fatal("different Grafana sessions produced the same discovery identity")
+	}
+}
+
+func TestDiscoveryHeadersApplyConfiguredIdentityHeaders(t *testing.T) {
+	client, cache := newGrafanaTestClient(t, "http://127.0.0.1")
+	defer cache.Close()
+
+	pathConfig := client.Configuration().Paths[0]
+	pathConfig.CacheKeyHeaders = []string{"X-Custom-User"}
+	pathConfig.RequestHeaders = map[string]string{
+		"-Cookie": "removed",
+		"+X-Role": "editor",
+	}
+	r := httptest.NewRequest(http.MethodGet, "http://trickster.example/", nil)
+	r.Header.Set("Cookie", "grafana_session=user-a")
+	r.Header.Set("X-Custom-User", "alice")
+	rsc := request.NewResources(client.Configuration(), pathConfig,
+		cache.Configuration(), cache, client, nil)
+	r = request.SetResources(r, rsc)
+
+	headers := client.discoveryHeaders(r)
+	if got := headers.Get("Cookie"); got != "" {
+		t.Fatalf("Cookie = %q, want configured removal", got)
+	}
+	if got := headers.Get("X-Custom-User"); got != "alice" {
+		t.Fatalf("X-Custom-User = %q, want alice", got)
+	}
+	if got := headers.Get("X-Role"); got != "editor" {
+		t.Fatalf("X-Role = %q, want editor", got)
+	}
+}
+
+func TestResolveDataSourceSingleflightsNumericLookup(t *testing.T) {
+	var requests atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/datasources/7" {
+			http.NotFound(w, r)
+			return
+		}
+		requests.Add(1)
+		time.Sleep(20 * time.Millisecond)
+		fmt.Fprint(w, `{"id":7,"uid":"prom-seven","orgId":2,"type":"prometheus","access":"proxy"}`)
+	}))
+	defer origin.Close()
+
+	client, cache := newGrafanaTestClient(t, origin.URL)
+	defer cache.Close()
+	headers := make(http.Header)
+	headers.Set("Cookie", "grafana_session=user-a")
+	ref := dataSourceRef{kind: dataSourceRefID, value: "7"}
+
+	const callers = 20
+	start := make(chan struct{})
+	errs := make(chan error, callers)
+	var wg sync.WaitGroup
+	for range callers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			ds, err := client.resolveDataSource(context.Background(), ref, headers)
+			if err == nil && (ds.ID != 7 || ds.UID != "prom-seven") {
+				err = fmt.Errorf("unexpected data source: %#v", ds)
+			}
+			errs <- err
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("metadata requests = %d, want 1", got)
+	}
+
+	uidRef := dataSourceRef{kind: dataSourceRefUID, value: "prom-seven"}
+	if _, err := client.resolveDataSource(context.Background(), uidRef, headers); err != nil {
+		t.Fatal(err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("UID lookup did not reuse numeric metadata; requests = %d", got)
+	}
+}
+
+func TestRegisterHandlersPreloadsDataSourcesWithConfiguredHeaders(t *testing.T) {
+	var requests atomic.Int32
+	preloaded := make(chan struct{})
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		if r.URL.Path != "/api/datasources" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer startup-token" {
+			http.Error(w, "missing token", http.StatusUnauthorized)
+			return
+		}
+		if r.Host != "grafana.internal" {
+			http.Error(w, "unexpected host", http.StatusBadRequest)
+			return
+		}
+		fmt.Fprint(w, `[{"id":3,"uid":"startup-prom","orgId":1,"type":"prometheus","access":"proxy"}]`)
+		close(preloaded)
+	}))
+	defer origin.Close()
+
+	client, cache := newGrafanaTestClient(t, origin.URL)
+	defer cache.Close()
+	client.Configuration().Paths[0].RequestHeaders = map[string]string{
+		"Authorization": "Bearer startup-token",
+		"Host":          "grafana.internal",
+	}
+	client.Handlers()
+	select {
+	case <-preloaded:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for Grafana data source preload")
+	}
+
+	headers := client.discoveryHeaders(nil)
+	ref := dataSourceRef{kind: dataSourceRefUID, value: "startup-prom"}
+	key := dataSourceKey(discoveryIdentity(headers), ref.kind, ref.value)
+	deadline := time.Now().Add(2 * time.Second)
+	for client.loadDataSource(key) == nil && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if client.loadDataSource(key) == nil {
+		t.Fatal("preloaded data source was not published")
+	}
+	if _, err := client.resolveDataSource(context.Background(), ref, headers); err != nil {
+		t.Fatal(err)
+	}
+	if got := requests.Load(); got != 1 {
+		t.Fatalf("preloaded lookup made an additional API request; got %d", got)
+	}
+}

--- a/pkg/backends/grafana/discovery_test.go
+++ b/pkg/backends/grafana/discovery_test.go
@@ -76,16 +76,17 @@ func TestDiscoveryHeadersApplyConfiguredIdentityHeaders(t *testing.T) {
 	}
 }
 
-func TestResolveDataSourceSingleflightsNumericLookup(t *testing.T) {
+func TestResolveDataSourceSingleflightsNumericListLookup(t *testing.T) {
 	var requests atomic.Int32
 	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/datasources/7" {
+		if r.URL.Path != "/api/datasources" {
 			http.NotFound(w, r)
 			return
 		}
 		requests.Add(1)
 		time.Sleep(20 * time.Millisecond)
-		fmt.Fprint(w, `{"id":7,"uid":"prom-seven","orgId":2,"type":"prometheus","access":"proxy"}`)
+		fmt.Fprint(w, `[{"id":3,"uid":"prom-three","orgId":2,"type":"prometheus","access":"proxy"},`+
+			`{"id":7,"uid":"prom-seven","orgId":2,"type":"prometheus","access":"proxy"}]`)
 	}))
 	defer origin.Close()
 

--- a/pkg/backends/grafana/dispatch.go
+++ b/pkg/backends/grafana/dispatch.go
@@ -77,6 +77,12 @@ type dataSourceDispatcher struct {
 	routes  []*dispatchRoute
 }
 
+type dataSourceDispatcherKey struct {
+	dataSource string
+	proxyPath  string
+	parentPath *po.Options
+}
+
 // GrafanaHandler accelerates supported Grafana data source proxy calls and
 // transparently proxies every other Grafana request.
 func (c *Client) GrafanaHandler(w http.ResponseWriter, r *http.Request) {
@@ -186,11 +192,11 @@ func providerForDataSource(ds *dataSource) (string, bool) {
 func (c *Client) getDispatcher(ref dataSourceRef, ds *dataSource,
 	provider string, parentPath *po.Options,
 ) (*dataSourceDispatcher, error) {
-	parentPathKey := ""
-	if parentPath != nil {
-		parentPathKey = parentPath.Path
+	key := dataSourceDispatcherKey{
+		dataSource: dataSourceIdentity(provider, ds),
+		proxyPath:  ref.proxyPrefix,
+		parentPath: parentPath,
 	}
-	key := dataSourceIdentity(provider, ds) + "|" + ref.proxyPrefix + "|" + parentPathKey
 	c.mu.RLock()
 	dispatcher := c.dispatchers[key]
 	c.mu.RUnlock()
@@ -206,6 +212,12 @@ func (c *Client) getDispatcher(ref dataSourceRef, ds *dataSource,
 	dispatcher, err := c.newDispatcher(ref, ds, provider, parentPath)
 	if err != nil {
 		return nil, err
+	}
+	if len(c.dispatchers) >= maxDataSourceDispatchers {
+		for existingKey := range c.dispatchers {
+			delete(c.dispatchers, existingKey)
+			break
+		}
 	}
 	c.dispatchers[key] = dispatcher
 	return dispatcher, nil
@@ -251,7 +263,9 @@ func (c *Client) newDispatcher(ref dataSourceRef, ds *dataSource, provider strin
 	if err != nil {
 		return nil, err
 	}
-	o.HTTPClient = backend.HTTPClient()
+	// Every dynamic backend still calls Grafana, so share the parent transport
+	// instead of retaining one connection pool per discovered data source.
+	o.HTTPClient = c.HTTPClient()
 	paths := backend.DefaultPathConfigs(o)
 	for _, path := range paths {
 		configureDataSourcePath(path, parentPath)

--- a/pkg/backends/grafana/dispatch.go
+++ b/pkg/backends/grafana/dispatch.go
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grafana
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
+	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
+	"github.com/trickstercache/trickster/v2/pkg/util/middleware"
+)
+
+type dataSourceRefKind string
+
+const (
+	dataSourceRefID  dataSourceRefKind = "id"
+	dataSourceRefUID dataSourceRefKind = "uid"
+)
+
+type dataSourceRef struct {
+	kind        dataSourceRefKind
+	value       string
+	proxyPrefix string
+	innerPath   string
+}
+
+func (r dataSourceRef) matches(ds *dataSource) bool {
+	if ds == nil {
+		return false
+	}
+	if r.kind == dataSourceRefUID {
+		return ds.UID == r.value
+	}
+	id, err := strconv.ParseInt(r.value, 10, 64)
+	return err == nil && ds.ID == id
+}
+
+type dispatchRoute struct {
+	options *po.Options
+	handler http.Handler
+}
+
+type dataSourceDispatcher struct {
+	backend backends.Backend
+	options *bo.Options
+	routes  []*dispatchRoute
+}
+
+// GrafanaHandler accelerates supported Grafana data source proxy calls and
+// transparently proxies every other Grafana request.
+func (c *Client) GrafanaHandler(w http.ResponseWriter, r *http.Request) {
+	ref, ok := parseDataSourceProxyPath(r.URL.Path)
+	if !ok {
+		c.ProxyHandler(w, r)
+		return
+	}
+
+	discoveryHeaders := c.discoveryHeaders(r)
+	ds, err := c.resolveDataSource(r.Context(), ref, discoveryHeaders)
+	if err != nil {
+		logger.Debug("Grafana data source lookup unavailable",
+			logging.Pairs{"backendName": c.Name(), "detail": err.Error()})
+		c.ProxyHandler(w, r)
+		return
+	}
+	provider, ok := providerForDataSource(ds)
+	if !ok {
+		c.ProxyHandler(w, r)
+		return
+	}
+
+	dispatcher, err := c.getDispatcher(ref, ds, provider, configuredPathOptions(r))
+	if err != nil {
+		logger.Error("could not configure Grafana data source dispatcher",
+			logging.Pairs{"backendName": c.Name(), "provider": provider, "detail": err.Error()})
+		c.ProxyHandler(w, r)
+		return
+	}
+	route := dispatcher.match(ref.innerPath, r.Method)
+	if route == nil {
+		c.ProxyHandler(w, r)
+		return
+	}
+
+	r.URL.Path = ref.innerPath
+	r.URL.RawPath = ""
+	parentResources := request.GetResources(r)
+	h := middleware.LimitQueryRange(route.handler)
+	if parentResources == nil {
+		h = middleware.WithResourcesContext(dispatcher.backend, dispatcher.options,
+			c.Cache(), route.options, nil, h)
+		h.ServeHTTP(w, r)
+		return
+	}
+	h = middleware.WithResourcesContext(dispatcher.backend, dispatcher.options,
+		c.Cache(), route.options, parentResources.Tracer, h)
+	h.ServeHTTP(w, r)
+}
+
+func parseDataSourceProxyPath(requestPath string) (dataSourceRef, bool) {
+	const prefix = "/api/datasources/proxy/"
+	if !strings.HasPrefix(requestPath, prefix) {
+		return dataSourceRef{}, false
+	}
+	remainder := strings.TrimPrefix(requestPath, prefix)
+	parts := strings.Split(remainder, "/")
+	if len(parts) == 0 {
+		return dataSourceRef{}, false
+	}
+
+	ref := dataSourceRef{kind: dataSourceRefID}
+	innerIndex := 1
+	if parts[0] == "uid" {
+		if len(parts) < 2 || parts[1] == "" {
+			return dataSourceRef{}, false
+		}
+		ref.kind = dataSourceRefUID
+		ref.value = parts[1]
+		innerIndex = 2
+	} else {
+		id, err := strconv.ParseInt(parts[0], 10, 64)
+		if err != nil || id <= 0 {
+			return dataSourceRef{}, false
+		}
+		ref.value = parts[0]
+	}
+	if strings.Contains(ref.value, "/") || ref.value == "" {
+		return dataSourceRef{}, false
+	}
+
+	ref.proxyPrefix = prefix + strings.Join(parts[:innerIndex], "/")
+	ref.innerPath = "/"
+	if len(parts) > innerIndex {
+		ref.innerPath += strings.Join(parts[innerIndex:], "/")
+	}
+	return ref, true
+}
+
+func providerForDataSource(ds *dataSource) (string, bool) {
+	if ds == nil || !strings.EqualFold(ds.Access, "proxy") {
+		return "", false
+	}
+	switch strings.ToLower(ds.Type) {
+	case providers.Prometheus:
+		return providers.Prometheus, true
+	case providers.InfluxDB:
+		return providers.InfluxDB, true
+	case "vertamedia-clickhouse-datasource":
+		return providers.ClickHouse, true
+	default:
+		return "", false
+	}
+}
+
+func (c *Client) getDispatcher(ref dataSourceRef, ds *dataSource,
+	provider string, parentPath *po.Options,
+) (*dataSourceDispatcher, error) {
+	parentPathKey := ""
+	if parentPath != nil {
+		parentPathKey = parentPath.Path
+	}
+	key := dataSourceIdentity(provider, ds) + "|" + ref.proxyPrefix + "|" + parentPathKey
+	c.mu.RLock()
+	dispatcher := c.dispatchers[key]
+	c.mu.RUnlock()
+	if dispatcher != nil {
+		return dispatcher, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if dispatcher = c.dispatchers[key]; dispatcher != nil {
+		return dispatcher, nil
+	}
+	dispatcher, err := c.newDispatcher(ref, ds, provider, parentPath)
+	if err != nil {
+		return nil, err
+	}
+	c.dispatchers[key] = dispatcher
+	return dispatcher, nil
+}
+
+func (c *Client) newDispatcher(ref dataSourceRef, ds *dataSource, provider string,
+	parentPath *po.Options,
+) (*dataSourceDispatcher, error) {
+	parent := c.Configuration()
+	if parent == nil {
+		return nil, errors.New("grafana backend options are not configured")
+	}
+	factory := c.factories[provider]
+	if factory == nil {
+		return nil, fmt.Errorf("backend provider %q is not registered", provider)
+	}
+
+	name, cachePrefix := dataSourceBackendIdentity(c.Name(), provider, ds)
+	o := parent.Clone()
+	o.Name = name
+	o.Provider = provider
+	o.ReplicaGroup = ""
+	o.Paths = nil
+	o.FastForwardPath = nil
+	o.HTTPClient = nil
+	o.HealthCheck = nil
+	o.Hosts = nil
+	o.IsDefault = false
+	o.PathRoutingDisabled = true
+	o.AuthenticatorName = ""
+	o.AuthOptions = nil
+	o.ReqRewriterName = ""
+	o.ReqRewriter = nil
+	o.LatencyMin = 0
+	o.LatencyMax = 0
+	o.CacheKeyPrefix = cachePrefix
+	o.OriginURL = dataSourceOriginURL(c.BaseUpstreamURL(), ref.proxyPrefix)
+	if err := o.Initialize(name); err != nil {
+		return nil, err
+	}
+
+	backend, err := factory(name, o, lm.NewRouter(), c.Cache(), c.clients, c.factories)
+	if err != nil {
+		return nil, err
+	}
+	o.HTTPClient = backend.HTTPClient()
+	paths := backend.DefaultPathConfigs(o)
+	for _, path := range paths {
+		configureDataSourcePath(path, parentPath)
+	}
+	if o.FastForwardPath != nil {
+		configureDataSourcePath(o.FastForwardPath, parentPath)
+	}
+	if err := paths.Initialize(); err != nil {
+		return nil, err
+	}
+	o.Paths = paths
+
+	handlerLookup := backend.Handlers()
+	routes := make([]*dispatchRoute, 0, len(paths))
+	for _, path := range paths {
+		if path == nil {
+			continue
+		}
+		h := handlerLookup[path.HandlerName]
+		if h != nil {
+			routes = append(routes, &dispatchRoute{options: path, handler: h})
+		}
+	}
+	return &dataSourceDispatcher{backend: backend, options: o, routes: routes}, nil
+}
+
+func (d *dataSourceDispatcher) match(requestPath, method string) *dispatchRoute {
+	if d == nil {
+		return nil
+	}
+	for _, route := range d.routes {
+		if route == nil || route.options == nil || !slices.Contains(route.options.Methods, method) {
+			continue
+		}
+		if route.options.MatchType == matching.PathMatchTypePrefix {
+			if strings.HasPrefix(requestPath, route.options.Path) {
+				return route
+			}
+		} else if requestPath == route.options.Path {
+			return route
+		}
+	}
+	return nil
+}
+
+func configureDataSourcePath(path, parent *po.Options) {
+	if path == nil {
+		return
+	}
+	if path.RequestHeaders == nil {
+		path.RequestHeaders = make(map[string]string)
+	}
+	if parent != nil {
+		maps.Copy(path.RequestHeaders, parent.RequestHeaders)
+		if path.RequestParams == nil {
+			path.RequestParams = make(map[string]string)
+		}
+		maps.Copy(path.RequestParams, parent.RequestParams)
+		if path.ResponseHeaders == nil {
+			path.ResponseHeaders = make(map[string]string)
+		}
+		maps.Copy(path.ResponseHeaders, parent.ResponseHeaders)
+		if slices.Contains(parent.CacheKeyParams, "*") {
+			path.CacheKeyParams = []string{"*"}
+		} else {
+			path.CacheKeyParams = appendUnique(path.CacheKeyParams, parent.CacheKeyParams...)
+		}
+		path.CacheKeyHeaders = appendUnique(path.CacheKeyHeaders, parent.CacheKeyHeaders...)
+		path.CacheKeyFormFields = appendUnique(path.CacheKeyFormFields, parent.CacheKeyFormFields...)
+		path.NoMetrics = parent.NoMetrics
+		if parent.CollapsedForwardingName != "" {
+			path.CollapsedForwardingName = parent.CollapsedForwardingName
+			path.CollapsedForwardingType = parent.CollapsedForwardingType
+		}
+		if parent.ResponseCode != 0 {
+			path.ResponseCode = parent.ResponseCode
+		}
+		if parent.ResponseBody != nil {
+			path.ResponseBody = parent.ResponseBody
+			path.ResponseBodyBytes = slices.Clone(parent.ResponseBodyBytes)
+		}
+	}
+	path.CacheKeyHeaders = appendUnique(path.CacheKeyHeaders, grafanaCacheIdentityHeaders...)
+}
+
+func configuredPathOptions(r *http.Request) *po.Options {
+	if r == nil {
+		return nil
+	}
+	rsc := request.GetResources(r)
+	if rsc == nil || rsc.PathConfig == nil {
+		return nil
+	}
+	return rsc.PathConfig
+}
+
+func appendUnique(values []string, additions ...string) []string {
+	for _, addition := range additions {
+		if !slices.ContainsFunc(values, func(value string) bool {
+			return strings.EqualFold(value, addition)
+		}) {
+			values = append(values, addition)
+		}
+	}
+	return values
+}
+
+func dataSourceOriginURL(base *url.URL, proxyPrefix string) string {
+	if base == nil {
+		return ""
+	}
+	u := *base
+	u.Path = strings.TrimRight(u.Path, "/") + proxyPrefix
+	u.RawPath = ""
+	u.RawQuery = ""
+	u.Fragment = ""
+	return u.String()
+}
+
+func dataSourceIdentity(provider string, ds *dataSource) string {
+	logicalID := ds.UID
+	if logicalID == "" {
+		logicalID = strconv.FormatInt(ds.ID, 10)
+	}
+	identity := struct {
+		OrgID     int64          `json:"orgId"`
+		LogicalID string         `json:"logicalId"`
+		Provider  string         `json:"provider"`
+		URL       string         `json:"url"`
+		User      string         `json:"user"`
+		Database  string         `json:"database"`
+		BasicAuth bool           `json:"basicAuth"`
+		JSONData  map[string]any `json:"jsonData"`
+	}{
+		OrgID: ds.OrgID, LogicalID: logicalID, Provider: provider,
+		URL: ds.URL, User: ds.User, Database: ds.Database,
+		BasicAuth: ds.BasicAuth, JSONData: ds.JSONData,
+	}
+	b, _ := json.Marshal(identity)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:8])
+}
+
+func dataSourceBackendIdentity(parentName, provider string, ds *dataSource) (string, string) {
+	suffix := dataSourceIdentity(provider, ds)
+	return parentName + "-datasource-" + suffix, parentName + ".grafana." + suffix
+}

--- a/pkg/backends/grafana/dispatch_test.go
+++ b/pkg/backends/grafana/dispatch_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/cache/memory"
 	cacheoptions "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 )
@@ -140,6 +141,50 @@ func TestDataSourceBackendIdentityIncludesProviderAndConfiguration(t *testing.T)
 	}
 }
 
+func TestGetDispatcherSeparatesParentPathOptions(t *testing.T) {
+	client, cache := newGrafanaTestClient(t, "http://127.0.0.1")
+	defer cache.Close()
+	ds := &dataSource{
+		ID: 1, UID: "prom-main", OrgID: 1,
+		Type: providers.Prometheus, Access: "proxy",
+	}
+	ref := dataSourceRef{
+		kind: dataSourceRefUID, value: ds.UID,
+		proxyPrefix: "/api/datasources/proxy/uid/" + ds.UID,
+	}
+	firstPath := po.New()
+	firstPath.Path = "/"
+	firstPath.RequestHeaders = map[string]string{"X-Tenant": "first"}
+	secondPath := firstPath.Clone()
+	secondPath.RequestHeaders["X-Tenant"] = "second"
+
+	first, err := client.getDispatcher(ref, ds, providers.Prometheus, firstPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := client.getDispatcher(ref, ds, providers.Prometheus, secondPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("different parent path options reused the same dispatcher")
+	}
+	if first.options.HTTPClient != client.HTTPClient() || second.options.HTTPClient != client.HTTPClient() {
+		t.Fatal("data source dispatchers did not reuse the Grafana HTTP client")
+	}
+	firstRoute := first.match("/api/v1/query_range", http.MethodGet)
+	secondRoute := second.match("/api/v1/query_range", http.MethodGet)
+	if firstRoute == nil || secondRoute == nil {
+		t.Fatal("Prometheus query range route was not configured")
+	}
+	if got := firstRoute.options.RequestHeaders["X-Tenant"]; got != "first" {
+		t.Fatalf("first dispatcher tenant = %q, want first", got)
+	}
+	if got := secondRoute.options.RequestHeaders["X-Tenant"]; got != "second" {
+		t.Fatalf("second dispatcher tenant = %q, want second", got)
+	}
+}
+
 func TestGrafanaHandlerCachesPrometheusPerIdentity(t *testing.T) {
 	var metadataRequests atomic.Int32
 	var queryRequests atomic.Int32
@@ -200,12 +245,28 @@ func TestGrafanaHandlerCachesPrometheusPerIdentity(t *testing.T) {
 	if got := sixth.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "kmiss") {
 		t.Fatalf("different auth-proxy user result header = %q, want kmiss", got)
 	}
-
-	if got := queryRequests.Load(); got != 4 {
-		t.Fatalf("Grafana data proxy requests = %d, want 4", got)
+	bearerUserA := make(http.Header)
+	bearerUserA.Set(headers.NameAuthorization, "Bearer user-a")
+	seventh := serveGrafanaRequestWithHeaders(t, client, cache, http.MethodGet, path, bearerUserA, "")
+	if got := seventh.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "kmiss") {
+		t.Fatalf("first bearer user result header = %q, want kmiss", got)
 	}
-	if got := metadataRequests.Load(); got != 4 {
-		t.Fatalf("Grafana metadata requests = %d, want 4", got)
+	eighth := serveGrafanaRequestWithHeaders(t, client, cache, http.MethodGet, path, bearerUserA, "")
+	if got := eighth.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "hit") {
+		t.Fatalf("second bearer user result header = %q, want hit", got)
+	}
+	bearerUserB := make(http.Header)
+	bearerUserB.Set(headers.NameAuthorization, "Bearer user-b")
+	ninth := serveGrafanaRequestWithHeaders(t, client, cache, http.MethodGet, path, bearerUserB, "")
+	if got := ninth.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "kmiss") {
+		t.Fatalf("different bearer user result header = %q, want kmiss", got)
+	}
+
+	if got := queryRequests.Load(); got != 6 {
+		t.Fatalf("Grafana data proxy requests = %d, want 6", got)
+	}
+	if got := metadataRequests.Load(); got != 6 {
+		t.Fatalf("Grafana metadata requests = %d, want 6", got)
 	}
 	client.mu.RLock()
 	dispatcherCount := len(client.dispatchers)

--- a/pkg/backends/grafana/dispatch_test.go
+++ b/pkg/backends/grafana/dispatch_test.go
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grafana
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	registrytypes "github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
+	cachepkg "github.com/trickstercache/trickster/v2/pkg/cache"
+	"github.com/trickstercache/trickster/v2/pkg/cache/manager"
+	"github.com/trickstercache/trickster/v2/pkg/cache/memory"
+	cacheoptions "github.com/trickstercache/trickster/v2/pkg/cache/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
+)
+
+func TestParseDataSourceProxyPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		path      string
+		want      dataSourceRef
+		wantMatch bool
+	}{
+		{
+			name: "uid",
+			path: "/api/datasources/proxy/uid/prom-main/api/v1/query_range",
+			want: dataSourceRef{
+				kind:        dataSourceRefUID,
+				value:       "prom-main",
+				proxyPrefix: "/api/datasources/proxy/uid/prom-main",
+				innerPath:   "/api/v1/query_range",
+			},
+			wantMatch: true,
+		},
+		{
+			name: "numeric id",
+			path: "/api/datasources/proxy/42/query",
+			want: dataSourceRef{
+				kind:        dataSourceRefID,
+				value:       "42",
+				proxyPrefix: "/api/datasources/proxy/42",
+				innerPath:   "/query",
+			},
+			wantMatch: true,
+		},
+		{
+			name:      "datasource root",
+			path:      "/api/datasources/proxy/uid/prom-main",
+			want:      dataSourceRef{kind: dataSourceRefUID, value: "prom-main", proxyPrefix: "/api/datasources/proxy/uid/prom-main", innerPath: "/"},
+			wantMatch: true,
+		},
+		{name: "missing uid", path: "/api/datasources/proxy/uid/", wantMatch: false},
+		{name: "invalid id", path: "/api/datasources/proxy/not-an-id/query", wantMatch: false},
+		{name: "query API", path: "/api/ds/query", wantMatch: false},
+		{name: "Grafana UI", path: "/d/example/dashboard", wantMatch: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, ok := parseDataSourceProxyPath(test.path)
+			if ok != test.wantMatch {
+				t.Fatalf("parse match = %v, want %v", ok, test.wantMatch)
+			}
+			if ok && got != test.want {
+				t.Fatalf("parse result = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestProviderForDataSource(t *testing.T) {
+	tests := []struct {
+		typeName string
+		access   string
+		want     string
+		ok       bool
+	}{
+		{typeName: "prometheus", access: "proxy", want: providers.Prometheus, ok: true},
+		{typeName: "InfluxDB", access: "proxy", want: providers.InfluxDB, ok: true},
+		{typeName: "vertamedia-clickhouse-datasource", access: "proxy", want: providers.ClickHouse, ok: true},
+		{typeName: "loki", access: "proxy"},
+		{typeName: "prometheus", access: "direct"},
+	}
+	for _, test := range tests {
+		got, ok := providerForDataSource(&dataSource{Type: test.typeName, Access: test.access})
+		if got != test.want || ok != test.ok {
+			t.Errorf("providerForDataSource(%q, %q) = %q, %v; want %q, %v",
+				test.typeName, test.access, got, ok, test.want, test.ok)
+		}
+	}
+}
+
+func TestDataSourceBackendIdentityIncludesProviderAndConfiguration(t *testing.T) {
+	ds := &dataSource{
+		ID: 1, UID: "metrics", OrgID: 2, Type: providers.Prometheus,
+		Access: "proxy", URL: "http://prometheus-a:9090",
+		JSONData: map[string]any{"httpMethod": "POST"},
+	}
+	name, prefix := dataSourceBackendIdentity("grafana", providers.Prometheus, ds)
+	if name == "" || prefix == "" {
+		t.Fatal("data source backend identity must not be empty")
+	}
+
+	changedURL := *ds
+	changedURL.URL = "http://prometheus-b:9090"
+	changedName, changedPrefix := dataSourceBackendIdentity("grafana", providers.Prometheus, &changedURL)
+	if changedName == name || changedPrefix == prefix {
+		t.Fatal("data source URL change reused the previous backend identity")
+	}
+
+	changedName, changedPrefix = dataSourceBackendIdentity("grafana", providers.InfluxDB, ds)
+	if changedName == name || changedPrefix == prefix {
+		t.Fatal("data source provider change reused the previous backend identity")
+	}
+}
+
+func TestGrafanaHandlerCachesPrometheusPerIdentity(t *testing.T) {
+	var metadataRequests atomic.Int32
+	var queryRequests atomic.Int32
+	now := time.Now().Add(-time.Minute).Truncate(time.Second)
+
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/datasources/uid/prom-main":
+			metadataRequests.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"id":1,"uid":"prom-main","orgId":1,"type":"prometheus","access":"proxy"}`)
+		case "/api/datasources/proxy/uid/prom-main/api/v1/query_range":
+			queryRequests.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"up"},"values":[[%d,"1"]]}]}}`, now.Unix())
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer origin.Close()
+
+	client, cache := newGrafanaTestClient(t, origin.URL)
+	defer cache.Close()
+
+	query := url.Values{
+		"query": {"up"},
+		"start": {fmt.Sprint(now.Unix())},
+		"end":   {fmt.Sprint(now.Unix())},
+		"step":  {"60"},
+	}.Encode()
+	path := "/api/datasources/proxy/uid/prom-main/api/v1/query_range?" + query
+
+	first := serveGrafanaRequest(t, client, cache, http.MethodGet, path, "grafana_session=user-a", "")
+	if got := first.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "kmiss") {
+		t.Fatalf("first result header = %q, want kmiss", got)
+	}
+	second := serveGrafanaRequest(t, client, cache, http.MethodGet, path, "grafana_session=user-a", "")
+	if got := second.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "hit") {
+		t.Fatalf("second result header = %q, want hit", got)
+	}
+	third := serveGrafanaRequest(t, client, cache, http.MethodGet, path, "grafana_session=user-b", "")
+	if got := third.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "kmiss") {
+		t.Fatalf("different-session result header = %q, want kmiss", got)
+	}
+	proxyUserA := make(http.Header)
+	proxyUserA.Set(grafanaAuthProxyHeader, "user-a")
+	fourth := serveGrafanaRequestWithHeaders(t, client, cache, http.MethodGet, path, proxyUserA, "")
+	if got := fourth.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "kmiss") {
+		t.Fatalf("first auth-proxy result header = %q, want kmiss", got)
+	}
+	fifth := serveGrafanaRequestWithHeaders(t, client, cache, http.MethodGet, path, proxyUserA, "")
+	if got := fifth.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "hit") {
+		t.Fatalf("second auth-proxy result header = %q, want hit", got)
+	}
+	proxyUserB := make(http.Header)
+	proxyUserB.Set(grafanaAuthProxyHeader, "user-b")
+	sixth := serveGrafanaRequestWithHeaders(t, client, cache, http.MethodGet, path, proxyUserB, "")
+	if got := sixth.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "kmiss") {
+		t.Fatalf("different auth-proxy user result header = %q, want kmiss", got)
+	}
+
+	if got := queryRequests.Load(); got != 4 {
+		t.Fatalf("Grafana data proxy requests = %d, want 4", got)
+	}
+	if got := metadataRequests.Load(); got != 4 {
+		t.Fatalf("Grafana metadata requests = %d, want 4", got)
+	}
+	client.mu.RLock()
+	dispatcherCount := len(client.dispatchers)
+	client.mu.RUnlock()
+	if dispatcherCount != 1 {
+		t.Fatalf("data source dispatchers = %d, want one shared dispatcher", dispatcherCount)
+	}
+}
+
+func TestGrafanaHandlerFallsBackWithoutCaching(t *testing.T) {
+	var metadataRequests atomic.Int32
+	var proxyRequests atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/datasources/uid/logs":
+			metadataRequests.Add(1)
+			fmt.Fprint(w, `{"id":2,"uid":"logs","orgId":1,"type":"loki","access":"proxy"}`)
+		case "/api/datasources/proxy/uid/logs/loki/api/v1/query_range":
+			proxyRequests.Add(1)
+			fmt.Fprint(w, `{"data":"uncached"}`)
+		case "/api/ds/query":
+			proxyRequests.Add(1)
+			fmt.Fprint(w, `{"results":{}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer origin.Close()
+
+	client, cache := newGrafanaTestClient(t, origin.URL)
+	defer cache.Close()
+	path := "/api/datasources/proxy/uid/logs/loki/api/v1/query_range"
+	for range 2 {
+		response := serveGrafanaRequest(t, client, cache, http.MethodGet, path,
+			"grafana_session=user-a", "")
+		if got := response.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "proxy-only") {
+			t.Fatalf("fallback result header = %q, want proxy-only", got)
+		}
+	}
+	response := serveGrafanaRequest(t, client, cache, http.MethodPost, "/api/ds/query",
+		"grafana_session=user-a", `{"queries":[]}`)
+	if got := response.Header().Get(headers.NameTricksterResult); !strings.Contains(got, "proxy-only") {
+		t.Fatalf("query API result header = %q, want proxy-only", got)
+	}
+
+	if got := metadataRequests.Load(); got != 1 {
+		t.Fatalf("Grafana metadata requests = %d, want 1", got)
+	}
+	if got := proxyRequests.Load(); got != 3 {
+		t.Fatalf("transparent proxy requests = %d, want 3", got)
+	}
+}
+
+func newGrafanaTestClient(t *testing.T, originURL string) (*Client, cachepkg.Cache) {
+	t.Helper()
+	cacheConfig := cacheoptions.New()
+	if err := cacheConfig.Initialize("default"); err != nil {
+		t.Fatal(err)
+	}
+	cache := manager.NewCache(memory.New("default", cacheConfig), manager.CacheOptions{}, cacheConfig)
+	if err := cache.Connect(); err != nil {
+		t.Fatal(err)
+	}
+
+	o := bo.New()
+	o.Provider = providers.Grafana
+	o.OriginURL = originURL
+	o.FastForwardDisable = true
+	o.HealthCheck = nil
+	if err := o.Initialize("grafana"); err != nil {
+		t.Fatal(err)
+	}
+	factories := registrytypes.Lookup{providers.Prometheus: prometheus.NewClient}
+	backend, err := NewClient("grafana", o, lm.NewRouter(), nil, nil, factories)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := backend.(*Client)
+	client.SetCache(cache)
+	o.HTTPClient = client.HTTPClient()
+	paths := client.DefaultPathConfigs(o)
+	if err := paths.Initialize(); err != nil {
+		t.Fatal(err)
+	}
+	o.Paths = paths
+	return client, cache
+}
+
+func serveGrafanaRequest(t *testing.T, client *Client, cache cachepkg.Cache,
+	method, path, cookie, body string,
+) *httptest.ResponseRecorder {
+	requestHeaders := make(http.Header)
+	if cookie != "" {
+		requestHeaders.Set("Cookie", cookie)
+	}
+	return serveGrafanaRequestWithHeaders(t, client, cache, method, path, requestHeaders, body)
+}
+
+func serveGrafanaRequestWithHeaders(t *testing.T, client *Client, cache cachepkg.Cache,
+	method, path string, requestHeaders http.Header, body string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	r := httptest.NewRequest(method, "http://trickster.example"+path, reader)
+	if body != "" {
+		r.Header.Set("Content-Type", "application/json")
+	}
+	for name, values := range requestHeaders {
+		for _, value := range values {
+			r.Header.Add(name, value)
+		}
+	}
+	o := client.Configuration()
+	p := o.Paths[0]
+	rsc := request.NewResources(o, p, cache.Configuration(), cache, client, nil)
+	r = request.SetResources(r, rsc)
+	w := httptest.NewRecorder()
+	client.GrafanaHandler(w, r)
+	return w
+}

--- a/pkg/backends/grafana/grafana.go
+++ b/pkg/backends/grafana/grafana.go
@@ -44,7 +44,7 @@ type Client struct {
 
 	mu          sync.RWMutex
 	dataSources map[string]dataSourceCacheEntry
-	dispatchers map[string]*dataSourceDispatcher
+	dispatchers map[dataSourceDispatcherKey]*dataSourceDispatcher
 	lookupGroup singleflight.Group
 	preloadOnce sync.Once
 }
@@ -57,7 +57,7 @@ func NewClient(name string, o *bo.Options, router http.Handler,
 		clients:     clients,
 		factories:   factories,
 		dataSources: make(map[string]dataSourceCacheEntry),
-		dispatchers: make(map[string]*dataSourceDispatcher),
+		dispatchers: make(map[dataSourceDispatcherKey]*dataSourceDispatcher),
 	}
 	b, err := backends.New(name, o, c.RegisterHandlers, router, cache)
 	c.Backend = b

--- a/pkg/backends/grafana/grafana.go
+++ b/pkg/backends/grafana/grafana.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package grafana provides a Grafana origin backend provider.
+package grafana
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers/registry/types"
+	"github.com/trickstercache/trickster/v2/pkg/cache"
+
+	"golang.org/x/sync/singleflight"
+)
+
+var (
+	_ backends.Backend           = (*Client)(nil)
+	_ types.NewBackendClientFunc = NewClient
+)
+
+// Client proxies Grafana normally and dispatches recognized data source proxy
+// paths through the corresponding Trickster backend provider.
+type Client struct {
+	backends.Backend
+
+	clients   backends.Backends
+	factories types.Lookup
+
+	mu          sync.RWMutex
+	dataSources map[string]dataSourceCacheEntry
+	dispatchers map[string]*dataSourceDispatcher
+	lookupGroup singleflight.Group
+	preloadOnce sync.Once
+}
+
+// NewClient returns a new Grafana origin client.
+func NewClient(name string, o *bo.Options, router http.Handler,
+	cache cache.Cache, clients backends.Backends, factories types.Lookup,
+) (backends.Backend, error) {
+	c := &Client{
+		clients:     clients,
+		factories:   factories,
+		dataSources: make(map[string]dataSourceCacheEntry),
+		dispatchers: make(map[string]*dataSourceDispatcher),
+	}
+	b, err := backends.New(name, o, c.RegisterHandlers, router, cache)
+	c.Backend = b
+	return c, err
+}

--- a/pkg/backends/grafana/health.go
+++ b/pkg/backends/grafana/health.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grafana
+
+import (
+	"net/http"
+
+	ho "github.com/trickstercache/trickster/v2/pkg/backends/healthcheck/options"
+)
+
+// DefaultHealthCheckConfig probes Grafana's built-in health endpoint.
+func (c *Client) DefaultHealthCheckConfig() *ho.Options {
+	o := ho.New()
+	u := c.BaseUpstreamURL()
+	if u == nil {
+		return o
+	}
+	o.Verb = http.MethodGet
+	o.Scheme = u.Scheme
+	o.Host = u.Host
+	o.Path = u.Path + "/api/health"
+	o.ExpectedCodes = []int{http.StatusOK}
+	return o
+}

--- a/pkg/backends/grafana/routes.go
+++ b/pkg/backends/grafana/routes.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package grafana
+
+import (
+	"net/http"
+
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/engines"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/methods"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
+	po "github.com/trickstercache/trickster/v2/pkg/proxy/paths/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/urls"
+)
+
+func (c *Client) RegisterHandlers(handlers.Lookup) {
+	c.Backend.RegisterHandlers(handlers.Lookup{
+		"health":          http.HandlerFunc(c.HealthHandler),
+		providers.Grafana: http.HandlerFunc(c.GrafanaHandler),
+		providers.Proxy:   http.HandlerFunc(c.ProxyHandler),
+	})
+	c.startPreload()
+}
+
+// DefaultPathConfigs proxies the complete Grafana HTTP surface. The handler
+// selectively accelerates supported data source proxy calls at request time.
+func (c *Client) DefaultPathConfigs(_ *bo.Options) po.List {
+	return po.List{
+		{
+			Path:          "/",
+			HandlerName:   providers.Grafana,
+			Methods:       methods.AllHTTPMethods(),
+			MatchType:     matching.PathMatchTypePrefix,
+			MatchTypeName: matching.PathMatchNamePrefix,
+		},
+	}
+}
+
+// ProxyHandler transparently proxies a request to Grafana.
+func (c *Client) ProxyHandler(w http.ResponseWriter, r *http.Request) {
+	r.URL = urls.BuildUpstreamURL(r, c.BaseUpstreamURL())
+	engines.DoProxy(w, r, true)
+}

--- a/pkg/backends/providers/providers.go
+++ b/pkg/backends/providers/providers.go
@@ -40,6 +40,8 @@ const (
 	InfluxDBID
 	// ClickHouse represents the ClickHouse backend provider
 	ClickHouseID
+	// Grafana represents the Grafana origin backend provider
+	GrafanaID
 
 	Backends = "backends"
 
@@ -55,6 +57,7 @@ const (
 	Prometheus = "prometheus"
 	ClickHouse = "clickhouse"
 	InfluxDB   = "influxdb"
+	Grafana    = "grafana"
 )
 
 // Names is a map of Providers keyed by string name
@@ -66,6 +69,7 @@ var Names = map[string]Provider{
 	Prometheus:             PrometheusID,
 	InfluxDB:               InfluxDBID,
 	ClickHouse:             ClickHouseID,
+	Grafana:                GrafanaID,
 	Proxy:                  RPID,
 	ReverseProxy:           RPID,
 	ReverseProxyShort:      RPID,

--- a/pkg/backends/providers/providers_test.go
+++ b/pkg/backends/providers/providers_test.go
@@ -24,6 +24,7 @@ import (
 func TestProviderString(t *testing.T) {
 	t1 := RPCID
 	t2 := PrometheusID
+	tGrafana := GrafanaID
 	var t3 Provider = 13
 
 	if t1.String() != ReverseProxyCacheShort {
@@ -32,6 +33,10 @@ func TestProviderString(t *testing.T) {
 
 	if t2.String() != Prometheus {
 		t.Errorf("expected %s got %s", Prometheus, t2.String())
+	}
+
+	if tGrafana.String() != Grafana {
+		t.Errorf("expected %s got %s", Grafana, tGrafana.String())
 	}
 
 	if t3.String() != "13" {
@@ -49,6 +54,7 @@ func TestIsValidProvider(t *testing.T) {
 		{"", false},
 		{"invalid", false},
 		{InfluxDB, true},
+		{Grafana, true},
 	}
 
 	for i, test := range tests {

--- a/pkg/backends/providers/registry/registry.go
+++ b/pkg/backends/providers/registry/registry.go
@@ -19,6 +19,7 @@ package registry
 import (
 	"github.com/trickstercache/trickster/v2/pkg/backends/alb"
 	"github.com/trickstercache/trickster/v2/pkg/backends/clickhouse"
+	"github.com/trickstercache/trickster/v2/pkg/backends/grafana"
 	"github.com/trickstercache/trickster/v2/pkg/backends/influxdb"
 	"github.com/trickstercache/trickster/v2/pkg/backends/prometheus"
 	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
@@ -32,6 +33,7 @@ func SupportedProviders() types.Lookup {
 	return types.Lookup{
 		providers.ALB:                    alb.NewClient,
 		providers.ClickHouse:             clickhouse.NewClient,
+		providers.Grafana:                grafana.NewClient,
 		providers.InfluxDB:               influxdb.NewClient,
 		providers.Prometheus:             prometheus.NewClient,
 		providers.Rule:                   rule.NewClient,

--- a/pkg/config/testdata/simple.grafana.yaml
+++ b/pkg/config/testdata/simple.grafana.yaml
@@ -1,0 +1,127 @@
+main:
+  server_name: trickster-test
+backends:
+  default:
+    provider: grafana
+    listener_name: grafana_port
+    origin_url: http://grafana:3000
+    timeout: 1m0s
+    keep_alive_timeout: 2m0s
+    max_concurrent_conns: 20
+    max_idle_conns: 20
+    cache_name: default
+    cache_key_prefix: grafana:3000
+    chunk_read_concurrency_limit: 16
+    fetch_concurrency_limit: 16
+    chunk_write_concurrency_limit: 16
+    healthcheck: {}
+    timeseries_retention_factor: 1024
+    timeseries_eviction_method: oldest
+    negative_cache_name: default
+    timeseries_ttl: 6h0m0s
+    fastforward_ttl: 15s
+    max_ttl: 25h0m0s
+    revalidation_factor: 2
+    max_object_size_bytes: 524288
+    max_capture_bytes: 268435456
+    compressible_types:
+    - text/html
+    - text/javascript
+    - text/css
+    - text/plain
+    - text/xml
+    - text/json
+    - application/json
+    - application/javascript
+    - application/xml
+    tracing_name: default
+    tls: {}
+    forwarded_headers: standard
+    latency_min: 0s
+    latency_max: 0s
+caches:
+  default:
+    provider: memory
+    index:
+      reap_interval: 3s
+      flush_interval: 5s
+      index_expiry: 8760h0m0s
+      max_size_bytes: 536870912
+      max_size_backoff_bytes: 16777216
+      max_size_backoff_objects: 100
+    redis:
+      client_type: standard
+      protocol: tcp
+      endpoint: redis:6379
+      endpoints:
+      - redis:6379
+    filesystem:
+      cache_path: /tmp/trickster
+    bbolt:
+      filename: trickster.db
+      bucket: trickster
+    badger:
+      directory: /tmp/trickster
+      value_directory: /tmp/trickster
+    memory:
+      max_size_bytes: 536870912
+      num_counters: 500000
+    timeseries_chunk_factor: 420
+    byterange_chunk_size: 4096
+frontend:
+  listen_port: 8480
+  tls_listen_port: 8483
+  max_request_body_size_bytes: 10485760
+  truncate_request_body_too_large: false
+  read_header_timeout: 10s
+listeners:
+  default:
+    port: 8480
+    tls_port: 8483
+    max_request_body_size_bytes: 10485760
+    truncate_request_body_too_large: false
+    read_header_timeout: 10s
+    protocol: http
+  grafana_port:
+    port: 8480
+    max_request_body_size_bytes: 10485760
+    truncate_request_body_too_large: false
+    read_header_timeout: 10s
+    protocol: http
+  metrics:
+    port: 8481
+    max_request_body_size_bytes: 10485760
+    truncate_request_body_too_large: false
+    read_header_timeout: 10s
+    protocol: http
+  mgmt:
+    address: 127.0.0.1
+    port: 8484
+    max_request_body_size_bytes: 10485760
+    truncate_request_body_too_large: false
+    read_header_timeout: 10s
+    protocol: http
+logging:
+  log_level: info
+metrics:
+  listen_port: 8481
+tracing:
+  default:
+    provider: none
+    service_name: trickster
+    stdout: {}
+negative_caches:
+  default: {}
+mgmt:
+  listen_address: 127.0.0.1
+  listen_port: 8484
+  config_handler_path: /trickster/config
+  config_handler_listener: mgmt
+  ping_handler_path: /trickster/ping
+  health_handler_path: /trickster/health
+  purge_by_key_path: /trickster/purge/key/
+  purge_by_path_path: /trickster/purge/path/
+  pprof_listener: both
+  reload_handler_path: /trickster/config/reload
+  reload_drain_timeout: 30s
+  reload_rate_limit: 3s

--- a/pkg/routing/grafana_test.go
+++ b/pkg/routing/grafana_test.go
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package routing
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/backends"
+	"github.com/trickstercache/trickster/v2/pkg/backends/providers"
+	cacheRegistry "github.com/trickstercache/trickster/v2/pkg/cache/registry"
+	"github.com/trickstercache/trickster/v2/pkg/config"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
+)
+
+func TestGrafanaOriginRoutesDataSourceProxy(t *testing.T) {
+	var queryRequests atomic.Int32
+	now := time.Now().Add(-10 * time.Minute).Truncate(time.Second)
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/datasources":
+			fmt.Fprint(w, `[{"id":1,"uid":"prom-main","orgId":1,"type":"prometheus","access":"proxy","url":"http://prometheus:9090"}]`)
+		case "/api/datasources/uid/prom-main":
+			fmt.Fprint(w, `{"id":1,"uid":"prom-main","orgId":1,"type":"prometheus","access":"proxy","url":"http://prometheus:9090"}`)
+		case "/api/datasources/proxy/uid/prom-main/api/v1/query_range":
+			queryRequests.Add(1)
+			fmt.Fprintf(w, `{"status":"success","data":{"resultType":"matrix","result":[{"metric":{"__name__":"up"},"values":[[%d,"1"]]}]}}`, now.Unix())
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer origin.Close()
+
+	conf, err := config.Load([]string{"-log-level", "error", "-origin-url", origin.URL,
+		"-provider", providers.Grafana})
+	if err != nil {
+		t.Fatal(err)
+	}
+	caches := cacheRegistry.LoadCachesFromConfig(conf)
+	defer cacheRegistry.CloseCaches(caches)
+	clients := make(backends.Backends)
+	frontendRouter := lm.NewRouter()
+	metricsRouter := lm.NewRouter()
+	if err := RegisterProxyRoutes(conf, clients, frontendRouter, metricsRouter,
+		caches, nil, true); err != nil {
+		t.Fatal(err)
+	}
+	if err := RegisterProxyRoutes(conf, clients, frontendRouter, metricsRouter,
+		caches, nil, false); err != nil {
+		t.Fatal(err)
+	}
+	RegisterDefaultBackendRoutes(frontendRouter, conf, clients, nil)
+
+	query := url.Values{
+		"query": {"up"},
+		"start": {fmt.Sprint(now.Unix())},
+		"end":   {fmt.Sprint(now.Unix())},
+		"step":  {"60"},
+	}.Encode()
+	path := "/api/datasources/proxy/uid/prom-main/api/v1/query_range?" + query
+	wants := []string{"kmiss", "hit"}
+	for i, want := range wants {
+		r := httptest.NewRequest(http.MethodGet, "http://trickster.example"+path, nil)
+		r.Header.Set("Cookie", "grafana_session=user-a")
+		w := httptest.NewRecorder()
+		frontendRouter.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d status = %d, want 200; body=%s", i+1, w.Code, w.Body.String())
+		}
+		if got := w.Header().Get(headers.NameTricksterResult); !strings.Contains(got, want) {
+			t.Fatalf("request %d result header = %q, want %s", i+1, got, want)
+		}
+	}
+	if got := queryRequests.Load(); got != 1 {
+		t.Fatalf("Grafana data proxy requests = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Description

Fixes #8.

Adds a `grafana` backend provider that transparently proxies Grafana's HTTP UI and API while accelerating supported data source proxy requests through Trickster's existing Prometheus, InfluxDB, and ClickHouse providers.

The provider discovers data sources at startup and lazily resolves both UID and legacy numeric proxy paths. Unsupported data source types and request shapes stay on the uncached proxy path. Discovery and response caches are isolated by Grafana authentication and organization identity, custom cache-key headers are preserved, and dynamically created dispatchers are bounded and share the parent Grafana transport.

The supported paths, authentication behavior, WebSocket limitation, and an example configuration are documented.

## Type of Change

- - [ ] Bug fix
- - [x] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [x] Documentation
- - [ ] Infrastructure

## AI Disclosure

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
