### PR TITLE
test: guard synchronous DPC cache writes

### DIFF
--- a/pkg/proxy/engines/deltaproxycache_chunk_test.go
+++ b/pkg/proxy/engines/deltaproxycache_chunk_test.go
@@ -647,9 +647,7 @@ func TestDeltaProxyCacheRequestRangeMissChunks(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Give time for the object to be written to cache in a separate goroutine from response
-	time.Sleep(time.Millisecond * 10)
-
+	// Issue the next request immediately: the prior cache write must complete before the handler returns.
 	// Test Range Miss Low End
 
 	extr.Start = extr.Start.Add(time.Duration(-3) * time.Hour)


### PR DESCRIPTION
## Description

#930 made DPC cache writes synchronous inside the singleflight executor, removing the background access reported in #765. The chunked range-miss test still slept for 10 ms to wait for that old goroutine.

Remove the delay and issue the next request immediately. The existing `kmiss` to `rmiss` assertions now guard that the first handler does not return before its cache write completes. As a mutation check, moving `WriteCache` back into a goroutine made the test fail with `status=kmiss`.

Closes #765.

Tests:
- `go test ./pkg/proxy/engines -count=1`
- `go test -race ./pkg/proxy/engines -count=1`
- `go test -race ./pkg/proxy/engines -run '^TestDeltaProxyCacheRequestRangeMissChunks$' -count=1000`
- `go tool golangci-lint run -c .golangci.yml ./pkg/proxy/engines/...`

## Type of Change

- - [ ] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.