### PR TITLE
refactor: migrate UnmarshalYAML to v3

### DIFF
--- a/pkg/backends/alb/mech/ur/options/options.go
+++ b/pkg/backends/alb/mech/ur/options/options.go
@@ -24,6 +24,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // import ct "github.com/trickstercache/trickster/v2/pkg/config/types"
@@ -129,10 +131,10 @@ func (o *Options) Validate(backendTypes map[string]string) error {
 	return nil
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/backends/alb/options/options.go
+++ b/pkg/backends/alb/options/options.go
@@ -30,6 +30,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options defines options for ALBs
@@ -306,10 +308,10 @@ func albEdges(o *Options) []string {
 	return edges
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/backends/alb/options/options_test.go
+++ b/pkg/backends/alb/options/options_test.go
@@ -238,7 +238,7 @@ func TestValidatePool(t *testing.T) {
 
 func TestUnmarshalYAMLError(t *testing.T) {
 	o := New()
-	want := errors.New("boom")
-	err := o.UnmarshalYAML(func(any) error { return want })
-	require.ErrorIs(t, err, want)
+	// a sequence cannot be decoded into the options struct
+	err := yaml.Unmarshal([]byte("- boom"), o)
+	require.Error(t, err)
 }

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -52,6 +52,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
 
 	"github.com/prometheus/common/sigv4"
+	"go.yaml.in/yaml/v3"
 )
 
 var restrictedOriginNames = sets.New([]string{"", "frontend"})
@@ -705,10 +706,10 @@ func (o *Options) ToYAML() string {
 	return string(b)
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/backends/prometheus/options/options.go
+++ b/pkg/backends/prometheus/options/options.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options stores information about Prometheus Options
@@ -40,10 +42,10 @@ func (o *Options) Clone() *Options {
 	return out
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/backends/rule/options/options.go
+++ b/pkg/backends/rule/options/options.go
@@ -25,6 +25,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options defines the options for a Rule
@@ -205,20 +207,20 @@ func (l Lookup) Validate() error {
 	return nil
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)
 	return nil
 }
 
-func (o *CaseOptions) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *CaseOptions) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions CaseOptions
 	lo := loadOptions(CaseOptions{})
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = CaseOptions(lo)

--- a/pkg/cache/badger/options/options.go
+++ b/pkg/cache/badger/options/options.go
@@ -18,6 +18,8 @@ package options
 
 import (
 	d "github.com/trickstercache/trickster/v2/pkg/cache/options/defaults"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options is a collection of Configurations for storing cached data on the Filesystem in a Badger key-value store
@@ -33,10 +35,10 @@ func New() *Options {
 	return &Options{Directory: d.DefaultCachePath, ValueDirectory: d.DefaultCachePath}
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/cache/badger/options/options_test.go
+++ b/pkg/cache/badger/options/options_test.go
@@ -17,7 +17,6 @@
 package options
 
 import (
-	"errors"
 	"testing"
 
 	d "github.com/trickstercache/trickster/v2/pkg/cache/options/defaults"
@@ -110,9 +109,9 @@ value_directory: /tmp/badger-val
 
 func TestUnmarshalYAMLError(t *testing.T) {
 	o := &Options{}
-	want := errors.New("boom")
-	err := o.UnmarshalYAML(func(any) error { return want })
-	if !errors.Is(err, want) {
-		t.Fatalf("expected %v, got %v", want, err)
+	// a sequence cannot be decoded into the options struct
+	err := yaml.Unmarshal([]byte("- boom"), o)
+	if err == nil {
+		t.Fatal("expected an error")
 	}
 }

--- a/pkg/cache/bbolt/options/options.go
+++ b/pkg/cache/bbolt/options/options.go
@@ -16,6 +16,10 @@
 
 package options
 
+import (
+	"go.yaml.in/yaml/v3"
+)
+
 // Options is a collection of Configurations for storing cached data on the Filesystem
 type Options struct {
 	// Filename represents the filename (including path) of the BotlDB database
@@ -29,10 +33,10 @@ func New() *Options {
 	return &Options{Filename: DefaultBBoltFile, Bucket: DefaultBBoltBucket}
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/cache/bbolt/options/options_test.go
+++ b/pkg/cache/bbolt/options/options_test.go
@@ -17,7 +17,6 @@
 package options
 
 import (
-	"errors"
 	"testing"
 
 	"go.yaml.in/yaml/v3"
@@ -108,9 +107,9 @@ bucket: custom_bucket
 
 func TestUnmarshalYAMLError(t *testing.T) {
 	o := &Options{}
-	want := errors.New("boom")
-	err := o.UnmarshalYAML(func(any) error { return want })
-	if !errors.Is(err, want) {
-		t.Fatalf("expected %v, got %v", want, err)
+	// a sequence cannot be decoded into the options struct
+	err := yaml.Unmarshal([]byte("- boom"), o)
+	if err == nil {
+		t.Fatal("expected an error")
 	}
 }

--- a/pkg/cache/filesystem/options/options.go
+++ b/pkg/cache/filesystem/options/options.go
@@ -18,6 +18,8 @@ package options
 
 import (
 	d "github.com/trickstercache/trickster/v2/pkg/cache/options/defaults"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options is a collection of Configurations for storing cached data on the Filesystem
@@ -31,10 +33,10 @@ func New() *Options {
 	return &Options{CachePath: d.DefaultCachePath}
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/cache/filesystem/options/options_test.go
+++ b/pkg/cache/filesystem/options/options_test.go
@@ -17,7 +17,6 @@
 package options
 
 import (
-	"errors"
 	"testing"
 
 	d "github.com/trickstercache/trickster/v2/pkg/cache/options/defaults"
@@ -84,9 +83,9 @@ cache_path: /tmp/fs-cache
 
 func TestUnmarshalYAMLError(t *testing.T) {
 	o := &Options{}
-	want := errors.New("boom")
-	err := o.UnmarshalYAML(func(any) error { return want })
-	if !errors.Is(err, want) {
-		t.Fatalf("expected %v, got %v", want, err)
+	// a sequence cannot be decoded into the options struct
+	err := yaml.Unmarshal([]byte("- boom"), o)
+	if err == nil {
+		t.Fatal("expected an error")
 	}
 }

--- a/pkg/cache/index/options/options.go
+++ b/pkg/cache/index/options/options.go
@@ -18,6 +18,8 @@ package options
 
 import (
 	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options defines the operation of the Cache Indexer
@@ -70,10 +72,10 @@ func (o *Options) Equal(o2 *Options) bool {
 		o.MaxSizeBackoffObjects == o2.MaxSizeBackoffObjects
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/cache/memory/options/options.go
+++ b/pkg/cache/memory/options/options.go
@@ -16,6 +16,10 @@
 
 package options
 
+import (
+	"go.yaml.in/yaml/v3"
+)
+
 const (
 	// DefaultMaxSizeBytes is the default maximum byte cost memory provider will admit to the cache (512 MB)
 	DefaultMaxSizeBytes = int64(512 * 1024 * 1024)
@@ -51,10 +55,10 @@ func (o *Options) Equal(o2 *Options) bool {
 }
 
 // UnmarshalYAML applies defaults before overlaying YAML-parsed values.
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/cache/memory/options/options_test.go
+++ b/pkg/cache/memory/options/options_test.go
@@ -17,7 +17,6 @@
 package options
 
 import (
-	"errors"
 	"testing"
 
 	"go.yaml.in/yaml/v3"
@@ -102,9 +101,9 @@ num_counters: 1000
 
 func TestUnmarshalYAMLError(t *testing.T) {
 	o := &Options{}
-	want := errors.New("boom")
-	err := o.UnmarshalYAML(func(any) error { return want })
-	if !errors.Is(err, want) {
-		t.Fatalf("expected %v, got %v", want, err)
+	// a sequence cannot be decoded into the options struct
+	err := yaml.Unmarshal([]byte("- boom"), o)
+	if err == nil {
+		t.Fatal("expected an error")
 	}
 }

--- a/pkg/cache/options/options.go
+++ b/pkg/cache/options/options.go
@@ -32,6 +32,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Lookup is a map of Options
@@ -280,10 +282,10 @@ func (l Lookup) Validate() error {
 	return nil
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/cache/redis/options/options.go
+++ b/pkg/cache/redis/options/options.go
@@ -19,6 +19,8 @@ package options
 import (
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options is a collection of Configurations for Connecting to Redis
@@ -79,10 +81,10 @@ func New() *Options {
 	}
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/observability/tracing/exporters/stdout/options/options.go
+++ b/pkg/observability/tracing/exporters/stdout/options/options.go
@@ -16,7 +16,11 @@
 
 package options
 
-import "github.com/trickstercache/trickster/v2/pkg/util/pointers"
+import (
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
+
+	"go.yaml.in/yaml/v3"
+)
 
 // Options is a collection of Stdout-specific options
 type Options struct {
@@ -33,10 +37,10 @@ func (o *Options) Clone() *Options {
 	return pointers.Clone(o)
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/observability/tracing/options/options.go
+++ b/pkg/observability/tracing/options/options.go
@@ -25,6 +25,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options is a Tracing Options collection
@@ -127,10 +129,10 @@ func (l Lookup) Validate() error {
 	return nil
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/parsing/timeconv/timeconv.go
+++ b/pkg/parsing/timeconv/timeconv.go
@@ -25,6 +25,8 @@ import (
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/util/strings"
+
+	"go.yaml.in/yaml/v3"
 )
 
 const (
@@ -250,13 +252,13 @@ func SleepRandomMS(min, max int) {
 type Duration time.Duration
 
 // UnmarshalYAML unmarshals a string into a timeconv.Duration
-func (d *Duration) UnmarshalYAML(unmarshal func(any) error) error {
-	var value string
-	if err := unmarshal(&value); err != nil {
+func (d *Duration) UnmarshalYAML(value *yaml.Node) error {
+	var s string
+	if err := value.Decode(&s); err != nil {
 		return err
 	}
 
-	parsed, err := ParseDuration(value)
+	parsed, err := ParseDuration(s)
 	if err != nil {
 		return err
 	}

--- a/pkg/proxy/authenticator/options/options.go
+++ b/pkg/proxy/authenticator/options/options.go
@@ -27,6 +27,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/util/files"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+
+	"go.yaml.in/yaml/v3"
 )
 
 var restrictedNames = sets.New([]string{"", "none"})
@@ -102,10 +104,10 @@ func (l Lookup) Validate(f types.IsRegisteredFunc) error {
 	return nil
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/proxy/cors/options/options.go
+++ b/pkg/proxy/cors/options/options.go
@@ -26,6 +26,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 
+	"go.yaml.in/yaml/v3"
 	"golang.org/x/net/http/httpguts"
 )
 
@@ -160,10 +161,10 @@ func (o *Options) IsLegacy() bool {
 }
 
 // UnmarshalYAML applies defaults before decoding a CORS configuration block.
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/proxy/paths/options/options.go
+++ b/pkg/proxy/paths/options/options.go
@@ -34,6 +34,8 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request/rewriter"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 	strutil "github.com/trickstercache/trickster/v2/pkg/util/strings"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options defines a URL Path that is associated with an HTTP Handler
@@ -321,10 +323,10 @@ func (l List) Overlay(l2 List) List {
 	return out
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/proxy/request/rewriter/options/options.go
+++ b/pkg/proxy/request/rewriter/options/options.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/util/sets"
+
+	"go.yaml.in/yaml/v3"
 )
 
 const MaxRewriterChainExecutions int32 = 32
@@ -99,10 +101,10 @@ func (rl RewriteList) Clone() RewriteList {
 	return rl2
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/proxy/tls/options/options.go
+++ b/pkg/proxy/tls/options/options.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
+
+	"go.yaml.in/yaml/v3"
 )
 
 // Options is a collection of TLS-related client and server configurations
@@ -119,10 +121,10 @@ func (o *Options) Validate() (bool, error) {
 	return true, nil
 }
 
-func (o *Options) UnmarshalYAML(unmarshal func(any) error) error {
+func (o *Options) UnmarshalYAML(value *yaml.Node) error {
 	type loadOptions Options
 	lo := loadOptions(*(New()))
-	if err := unmarshal(&lo); err != nil {
+	if err := value.Decode(&lo); err != nil {
 		return err
 	}
 	*o = Options(lo)

--- a/pkg/proxy/tls/options/options_test.go
+++ b/pkg/proxy/tls/options/options_test.go
@@ -20,6 +20,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"go.yaml.in/yaml/v3"
 )
 
 func writeTempFile(t *testing.T, dir, name, content string) string {
@@ -127,12 +129,26 @@ func TestInitialize(t *testing.T) {
 }
 
 func TestUnmarshalYAML(t *testing.T) {
-	o := New()
-	err := o.UnmarshalYAML(func(v any) error {
-		return nil
-	})
-	if err != nil {
+	o := &Options{}
+	if err := yaml.Unmarshal([]byte("full_chain_cert_path: /cert"), o); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if o.FullChainCertPath != "/cert" {
+		t.Errorf("expected FullChainCertPath /cert, got %q", o.FullChainCertPath)
+	}
+
+	// an empty mapping retains the defaults applied by UnmarshalYAML
+	o2 := &Options{}
+	if err := yaml.Unmarshal([]byte("{}"), o2); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !o2.Equal(New()) {
+		t.Errorf("expected defaults, got %+v", o2)
+	}
+
+	// a sequence cannot be decoded into the options struct
+	if err := yaml.Unmarshal([]byte("- boom"), &Options{}); err == nil {
+		t.Error("expected an error")
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Describe changes and the problem solved -->
This refactors yaml v2 UnmarshalYAML implementations (`UnmarshalYAML(unmarshal func(any) error) error`) to support the yaml v3 prototype (`UnmarshalYAML(value *yaml.Node) error`) application wide. This is a follow-on to #908 that updated from yaml v2 to v3 without adjusting the prototypes. They still work in the legacy format but will eventually break.


## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [ ] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [ ] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure
- - [x] Refactor

## AI Disclosure
<!-- [x] exactly one option below -->

- - [x] This contribution DOES NOT include AI-generated changes
- - [ ] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
