### PR TITLE
fix: honor MySQL no-backslash-escapes comments

### DIFF
--- a/integration/mysql_test.go
+++ b/integration/mysql_test.go
@@ -41,6 +41,7 @@ import (
 	gomysql "github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/require"
 	vtmysql "vitess.io/vitess/go/mysql"
+	"vitess.io/vitess/go/mysql/sqlerror"
 )
 
 const (
@@ -172,6 +173,38 @@ func TestMySQLRealServerCompatibility(t *testing.T) {
 			require.ErrorAs(t, proxyErr, &proxyMySQL)
 			require.Equal(t, directMySQL.Number, proxyMySQL.Number)
 		}
+	})
+
+	t.Run("no-backslash-escapes preserves executable comment policy", func(t *testing.T) {
+		const modeSensitiveQuery = `SELECT 'x\' /*!80400 INTO @answer */`
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+
+		directConn, err := direct.Conn(ctx)
+		require.NoError(t, err)
+		defer directConn.Close()
+		_, err = directConn.ExecContext(ctx, "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'")
+		require.NoError(t, err)
+		_, err = directConn.ExecContext(ctx, modeSensitiveQuery)
+		require.NoError(t, err)
+		var directAnswer string
+		require.NoError(t, directConn.QueryRowContext(ctx, "SELECT @answer").Scan(&directAnswer))
+		require.Equal(t, `x\`, directAnswer)
+
+		proxyConn, err := proxied.Conn(ctx)
+		require.NoError(t, err)
+		defer proxyConn.Close()
+		_, err = proxyConn.ExecContext(ctx, "SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'")
+		require.NoError(t, err)
+		_, err = proxyConn.ExecContext(ctx, modeSensitiveQuery)
+		require.Error(t, err)
+		var mysqlErr *gomysql.MySQLError
+		require.ErrorAs(t, err, &mysqlErr)
+		require.Equal(t, uint16(sqlerror.ERNotSupportedYet), mysqlErr.Number)
+
+		var proxyAnswer sql.NullString
+		require.NoError(t, proxyConn.QueryRowContext(ctx, "SELECT @answer").Scan(&proxyAnswer))
+		require.False(t, proxyAnswer.Valid)
 	})
 
 	t.Run("reset and quit preserve synchronization", func(t *testing.T) {

--- a/pkg/backends/mysql/protocol.go
+++ b/pkg/backends/mysql/protocol.go
@@ -1092,7 +1092,8 @@ func (h *protocolHandler) ComQuery(c *vtmysql.Conn, query string,
 		return sqlerror.NewSQLError(sqlerror.ERNetPacketTooLarge, sqlerror.SSNetError,
 			"MySQL query exceeds Trickster's configured limit")
 	}
-	if feature := unsupportedTextFeature(query); feature != "" {
+	noBackslashEscapes := c.StatusFlags&vtmysql.ServerStatusNoBackslashEscapes != 0
+	if feature := unsupportedTextFeature(query, noBackslashEscapes); feature != "" {
 		return h.unsupported(feature)
 	}
 	if multiple, err := hasMultipleStatements(query); err != nil {
@@ -1323,8 +1324,8 @@ func classifyResponseShape(query string, parsed parsedQuery) (queryResponseShape
 	}
 }
 
-func unsupportedTextFeature(query string) string {
-	if hasExecutableComment(query) {
+func unsupportedTextFeature(query string, noBackslashEscapes bool) string {
+	if hasExecutableComment(query, noBackslashEscapes) {
 		return "versioned executable comments"
 	}
 	trimmed := strings.TrimSpace(vtparser.StripLeadingComments(query))
@@ -1348,11 +1349,17 @@ func unsupportedTextFeature(query string) string {
 	}
 }
 
-func hasExecutableComment(query string) bool {
+func hasExecutableComment(query string, noBackslashEscapes bool) bool {
 	// Keep the common path allocation-free; only text containing the executable
 	// comment opener needs tokenization to distinguish comments from literals.
 	if !strings.Contains(query, "/*!") {
 		return false
+	}
+	if noBackslashEscapes && strings.Contains(query, `\`) {
+		// Vitess always treats backslashes as string escapes. Pairing each one
+		// makes it a literal for tokenization, matching NO_BACKSLASH_ESCAPES
+		// quote boundaries without changing the query sent to the origin.
+		query = strings.ReplaceAll(query, `\`, `\\`)
 	}
 	tokenizer := defaultAnalyzer.parser.NewStringTokenizer(query)
 	tokenizer.SkipSpecialComments = true

--- a/pkg/backends/mysql/protocol_fuzz_test.go
+++ b/pkg/backends/mysql/protocol_fuzz_test.go
@@ -58,7 +58,8 @@ func FuzzCommandDispatchClassification(f *testing.F) {
 	f.Add("/*!80000 SET @tenant = 1 */")
 	f.Add("\"\\;0")
 	f.Fuzz(func(t *testing.T, query string) {
-		_ = unsupportedTextFeature(query)
+		_ = unsupportedTextFeature(query, false)
+		_ = unsupportedTextFeature(query, true)
 		_, _ = hasMultipleStatements(query)
 	})
 }

--- a/pkg/backends/mysql/protocol_test.go
+++ b/pkg/backends/mysql/protocol_test.go
@@ -315,8 +315,9 @@ func TestStatementBoundaryParserPanicReturnsParseError(t *testing.T) {
 
 func TestUnsupportedTextFeature(t *testing.T) {
 	for _, tc := range []struct {
-		query string
-		want  string
+		query              string
+		noBackslashEscapes bool
+		want               string
 	}{
 		{query: "SELECT 1"},
 		{query: "/* Grafana */ SELECT 1"},
@@ -325,6 +326,14 @@ func TestUnsupportedTextFeature(t *testing.T) {
 		{query: "SELECT /*!80400 @tenant := 1, */ 1", want: "versioned executable comments"},
 		{query: "SELECT '/*!80400 INTO @answer */'"},
 		{query: "SELECT \"/*!80400 INTO @answer */\""},
+		{query: `SELECT 'x\' /*!80400 INTO @answer */`},
+		{query: `SELECT 'x\' /*!80400 INTO @answer */`, noBackslashEscapes: true,
+			want: "versioned executable comments"},
+		{query: `SELECT 'it''s /*!80400 INTO @answer */'`, noBackslashEscapes: true},
+		{query: "SELECT `/*!80400 INTO @answer */`", noBackslashEscapes: true},
+		{query: "SELECT 1 /* ordinary /*!80400 INTO @answer */", noBackslashEscapes: true},
+		{query: "SELECT 1 # /*!80400 INTO @answer */", noBackslashEscapes: true},
+		{query: "SELECT 1 -- /*!80400 INTO @answer */", noBackslashEscapes: true},
 		{query: "PREPARE statement FROM 'SELECT 1'", want: "prepared statements"},
 		{query: "EXECUTE statement", want: "prepared statements"},
 		{query: "DEALLOCATE PREPARE statement", want: "prepared statements"},
@@ -332,9 +341,19 @@ func TestUnsupportedTextFeature(t *testing.T) {
 		{query: "CALL report()", want: "stored procedures and multi-results"},
 		{query: "LOAD DATA LOCAL INFILE '/tmp/data' INTO TABLE events", want: "LOAD DATA and local-file operations"},
 	} {
-		if got := unsupportedTextFeature(tc.query); got != tc.want {
+		if got := unsupportedTextFeature(tc.query, tc.noBackslashEscapes); got != tc.want {
 			t.Errorf("unsupportedTextFeature(%q) = %q, want %q", tc.query, got, tc.want)
 		}
+	}
+}
+
+func TestExecutableCommentDetectionHonorsNoBackslashEscapes(t *testing.T) {
+	const query = `SELECT 'x\' /*!80400 INTO @answer */`
+	c := &vtmysql.Conn{StatusFlags: vtmysql.ServerStatusAutocommit |
+		vtmysql.ServerStatusNoBackslashEscapes}
+	err := (&protocolHandler{}).ComQuery(c, query, nil)
+	if err == nil || !strings.Contains(err.Error(), "versioned executable comments") {
+		t.Fatalf("ComQuery() error = %v, want executable-comment rejection", err)
 	}
 }
 
@@ -1179,7 +1198,7 @@ func TestReconnectReplaysTrackedDatabaseAndTimeZone(t *testing.T) {
 	}
 }
 
-func TestLiveQueriesPreserveOriginStatusFlagsAndWarnings(t *testing.T) {
+func TestLiveQueriesPreserveAndHonorOriginStatusFlags(t *testing.T) {
 	const (
 		originFlags    = vtmysql.ServerStatusAutocommit | vtmysql.ServerStatusNoBackslashEscapes
 		originWarnings = 7
@@ -1226,7 +1245,10 @@ func TestLiveQueriesPreserveOriginStatusFlagsAndWarnings(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, query := range []string{"UPDATE events SET value = value", "SELECT value FROM events"} {
+	for _, query := range []string{
+		"SET SESSION sql_mode = 'NO_BACKSLASH_ESCAPES'",
+		"SELECT value FROM events",
+	} {
 		result, warnings, queryErr := client.ExecuteFetchWithWarningCount(query,
 			vtmysql.FETCH_ALL_ROWS, true)
 		if queryErr != nil {
@@ -1236,6 +1258,15 @@ func TestLiveQueriesPreserveOriginStatusFlagsAndWarnings(t *testing.T) {
 			t.Fatalf("%s protocol state = flags %#x, warnings %d; want %#x, %d",
 				query, result.StatusFlags, warnings, originFlags, originWarnings)
 		}
+	}
+	originQueries := originHandler.queryCount.Load()
+	_, queryErr := client.ExecuteFetch(`SELECT 'x\' /*!80400 INTO @answer */`,
+		vtmysql.FETCH_ALL_ROWS, true)
+	if queryErr == nil || !strings.Contains(queryErr.Error(), "versioned executable comments") {
+		t.Fatalf("mode-sensitive query error = %v, want executable-comment rejection", queryErr)
+	}
+	if got := originHandler.queryCount.Load(); got != originQueries {
+		t.Fatalf("origin query count = %d, want %d after local rejection", got, originQueries)
 	}
 	client.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -1616,6 +1647,7 @@ func (h *protocolStateOriginHandler) ComQuery(c *vtmysql.Conn, query string,
 	if isWarningCountQuery(query) {
 		return callback(warningCountResult(h.warnings))
 	}
+	h.queryCount.Add(1)
 	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(query)), "SELECT") {
 		return callback(&sqltypes.Result{
 			Fields: []*querypb.Field{{Name: "value", Type: querypb.Type_INT64}},


### PR DESCRIPTION
## Description
Trickster rejects MySQL versioned executable comments, but the check always tokenized statements with normal backslash escaping. After the same client enables `NO_BACKSLASH_ESCAPES`, that can give Trickster and the origin different quote boundaries and let an executable comment pass the contract check.

This change reads the `SERVER_STATUS_NO_BACKSLASH_ESCAPES` flag already propagated from the origin and adjusts only the tokenizer input used by the comment check. The SQL sent to the origin is unchanged. Unit, protocol, fuzz, and MySQL 8.4 integration coverage verify both modes, including a same-connection rejection that does not set the origin session variable.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.

## Validation

- Focused unit and protocol tests, 100 repetitions
- Focused race tests, 10 repetitions
- Command-dispatch fuzzing for 10 seconds
- MySQL package vet and golangci-lint
- Linux integration-module compile and vet
