### PR TITLE
feat: enhance logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Trickster is a fully-featured HTTP Reverse Proxy Cache for HTTP applications lik
 * High-performance [Collapsed Forwarding](./docs/collapsed-forwarding.md)
 * Best-in-class [Byte Range Request caching and acceleration](./docs/range_request.md).
 * [Distributed Tracing](./docs/tracing.md) via OpenTelemetry, supporting OTLP protocol.
+* Per-backend [Access and Error Logs](./docs/access-logs.md) with Apache-style customizable formats
 * Rules engine for custom request routing and rewriting
 * Configurable [maximum request body size](./docs/body.md).
 

--- a/docs/access-logs.md
+++ b/docs/access-logs.md
@@ -121,8 +121,24 @@ most recent archive, `.2.gz` the next, and so on).
   threshold is reached. Setting both to `0` disables rotation.
 - Sizes accept `KB`, `MB`, `GB` and `TB` suffixes (binary multiples), or a
   plain byte count.
-- `retention.count: 0` deletes the live file's content at rotation without
-  keeping an archive.
+- `retention.count: 0` disables count-based pruning and keeps all archives.
+- Writes are buffered for up to one second or 64 KiB. A process or machine
+  crash can lose the buffered tail; an orderly shutdown flushes it.
+- Interval rotation keeps its epoch in a `<filename>.rotation` sidecar so a
+  restart does not reset the interval clock.
+
+Archives created by older Trickster releases use timestamped lumberjack
+names and are not included in numbered-archive retention. They form a bounded
+legacy set and may be removed manually after upgrading.
+
+When upgrading from the original logging implementation, note these filename
+and retention changes:
+
+- `retention.count: 0` now keeps all archives; configure a positive count to
+  bound archive retention.
+- With `main.instance_id` enabled, filenames without a `.log` suffix now also
+  include the instance ID (`trickster.out` becomes `trickster.2.out`). Update
+  log shippers that still follow the unsuffixed filename.
 
 The same `rotation`, `retention` and `compress` options are also available
 in the main `logging:` config section to control rotation of the Trickster

--- a/docs/access-logs.md
+++ b/docs/access-logs.md
@@ -1,0 +1,148 @@
+# Access and Error Logs
+
+Trickster can write per-backend HTTP access logs and error logs, with
+customizable formats, rotation and retention. Both logs are off by default;
+each is enabled by configuring its filename.
+
+## Basic Configuration
+
+```yaml
+backends:
+  example1:
+    provider: rp
+    origin_url: http://example.com/
+    access_log:
+      filename: /var/log/trickster/example1.access.log
+      error_filename: /var/log/trickster/example1.error.log
+```
+
+- The access log receives one line per request handled by the backend and is
+  written only when `filename` is set.
+- The error log receives one line per request whose response status is at or
+  above `error_threshold` (default `400`) and is written only when
+  `error_filename` is set. An error-logged request also appears in the access
+  log when both are configured.
+- Two backends may share a filename; they will safely share the underlying
+  file and its rotation.
+- When `instance_id` is set in the main config, it is inserted into log
+  filenames just as with the application log (e.g., `example1.access.1.log`).
+
+## Log Format
+
+The `format` option accepts either a named preset or a custom format string
+using Apache-style `%` tokens, so the well-known conventions from Apache
+HTTP Server, Apache Traffic Server, Lighttpd, and similar servers apply
+directly.
+
+### Presets
+
+| Name | Description |
+| ----- | ----- |
+| `common` | NCSA Common Log Format: `%h %l %u %t "%r" %>s %b` |
+| `combined` | Apache/Nginx Combined format: `common` + Referer and User-Agent. This is the default. |
+| `extended` | `combined` + duration (ms), cache status and backend name |
+| `json` | One JSON object per line with a fixed field set (see below) |
+
+### Custom Formats
+
+```yaml
+    access_log:
+      filename: /var/log/trickster/example1.access.log
+      format: '%h %u %t "%r" %>s %b %{ms}T %{cache-status}x'
+```
+
+Supported tokens:
+
+| Token | Description |
+| ----- | ----- |
+| `%h`, `%a` | client IP address |
+| `%l` | remote logname (always `-`) |
+| `%u` | authenticated username (from HTTP Basic Auth), else `-` |
+| `%t` | request start time in CLF format: `[26/Aug/2026:10:30:00 +0000]` |
+| `%{sec}t`, `%{msec}t`, `%{usec}t` | request start time as a Unix epoch value |
+| `%{LAYOUT}t` | request start time in a custom [Go time layout](https://pkg.go.dev/time#pkg-constants) |
+| `%r` | first line of the request: `GET /path?query HTTP/1.1` |
+| `%m` | request method |
+| `%U` | request URL path |
+| `%q` | query string, prefixed with `?`, or empty when none |
+| `%H` | request protocol (e.g., `HTTP/1.1`) |
+| `%s`, `%>s` | response status code |
+| `%b` | response body bytes, or `-` when zero (CLF style) |
+| `%B` | response body bytes, numeric |
+| `%D` | request duration in microseconds |
+| `%T` | request duration in whole seconds |
+| `%{us}T`, `%{ms}T`, `%{s}T` | request duration in the given unit |
+| `%{Name}i` | request header value |
+| `%{Name}o` | response header value |
+| `%{Name}c` | request cookie value |
+| `%v` | requested virtual host |
+| `%p` | listener port that served the request |
+| `%A` | listener IP address that served the request |
+| `%%` | a literal `%` |
+
+Trickster-specific values use the `%{key}x` extension namespace:
+
+| Token | Description |
+| ----- | ----- |
+| `%{backend}x` | backend name |
+| `%{provider}x` | backend provider type |
+| `%{cache-status}x` | cache result (`hit`, `phit`, `kmiss`, ...); see [Cache Status](./caches.md#cache-status) |
+| `%{engine}x` | proxy engine that handled the request (e.g., `DeltaProxyCache`) |
+| `%{path-config}x` | the matched [path config](./paths.md) path |
+
+Missing values render as `-`. Values derived from the request (like headers
+and usernames) are backslash-escaped so they cannot corrupt the log line
+structure. Unknown tokens fail validation at startup.
+
+The `json` preset emits these fields per line: `time`, `client_ip`, `user`,
+`method`, `path`, `query`, `proto`, `status`, `bytes`, `duration_ms`,
+`host`, `referer`, `user_agent`, `backend`, `provider`, `path_config`,
+`cache_status`, `engine`.
+
+## Rotation and Retention
+
+Access and error logs are rotated and pruned automatically, using
+nginx/logrotate-style numbered archives (`example1.access.log.1.gz` is the
+most recent archive, `.2.gz` the next, and so on).
+
+```yaml
+    access_log:
+      filename: /var/log/trickster/example1.access.log
+      rotation:
+        size: 256MB   # rotate when the live file would exceed this size (default 256MB)
+        interval: 1d  # also rotate when the live file is older than this (default off)
+      retention:
+        count: 3      # keep at most 3 archives (default 80)
+        age: 7d       # also prune archives older than this (default 7d)
+      compress: true  # gzip archives (default true)
+```
+
+- `size` and `interval` may be combined; the log rotates when either
+  threshold is reached. Setting both to `0` disables rotation.
+- Sizes accept `KB`, `MB`, `GB` and `TB` suffixes (binary multiples), or a
+  plain byte count.
+- `retention.count: 0` deletes the live file's content at rotation without
+  keeping an archive.
+
+The same `rotation`, `retention` and `compress` options are also available
+in the main `logging:` config section to control rotation of the Trickster
+application log, with the same defaults.
+
+## Error Log Settings
+
+Each `error_*` option inherits its value from the corresponding access log
+option when unset:
+
+```yaml
+    access_log:
+      filename: /var/log/trickster/example1.access.log
+      format: combined
+      error_filename: /var/log/trickster/example1.error.log
+      error_format: ''      # default: inherits format
+      error_threshold: 400  # log responses with status >= this (default 400)
+      error_rotation:       # default: inherits rotation
+        size: 64MB
+      error_retention:      # default: inherits retention
+        count: 7
+      error_compress: true  # default: inherits compress
+```

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -408,7 +408,7 @@ backends:
 #         interval: 1d
 #       # retention controls how many rotated archives (example.access.log.1.gz, .2.gz, ...) are kept
 #       retention:
-#         # count is the maximum number of archives kept. default is 80
+#         # count is the maximum archives kept; 0 is unlimited. default is 80
 #         count: 3
 #         # age prunes archives older than this. default is 7d
 #         age: 7d
@@ -929,7 +929,7 @@ backends:
 
 #   # retention controls how many rotated archives are kept
 #   retention:
-#     # count is the maximum number of archives kept. default is 80
+#     # count is the maximum archives kept; 0 is unlimited. default is 80
 #     count: 80
 #     # age prunes archives older than this. default is 7d
 #     age: 7d

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -392,6 +392,36 @@ backends:
 #     # default is false
 #     path_routing_disabled: false
 
+#     # access_log configures per-backend HTTP access and error logging. Both logs are off by default and
+#     # are each enabled by setting their filename. See docs/access-logs.md for all options and format tokens
+#     access_log:
+#       # filename enables the access log (one line per request served by this backend)
+#       filename: /var/log/trickster/example.access.log
+#       # format is a named preset (common, combined, extended, json) or a custom Apache-style
+#       # %-token format string. default is combined
+#       format: combined
+#       # rotation controls when the log is rotated; a rotation occurs when either threshold is reached
+#       rotation:
+#         # size rotates the log when the live file would exceed this size. default is 256MB
+#         size: 256MB
+#         # interval rotates the log when the live file is older than this. default is 0 (off)
+#         interval: 1d
+#       # retention controls how many rotated archives (example.access.log.1.gz, .2.gz, ...) are kept
+#       retention:
+#         # count is the maximum number of archives kept. default is 80
+#         count: 3
+#         # age prunes archives older than this. default is 7d
+#         age: 7d
+#       # compress gzips rotated archives. default is true
+#       compress: true
+#       # error_filename enables the error log, receiving requests whose response status is >= error_threshold
+#       error_filename: /var/log/trickster/example.error.log
+#       # error_threshold is the minimum response status code written to the error log. default is 400
+#       error_threshold: 400
+#       # error_format, error_rotation, error_retention and error_compress override the error log's
+#       # behaviors; each inherits from the corresponding access log option above when unset
+#       error_format: ''
+
 #     # rule_name provides the name of the rule config to be used by this backend.
 #     # This is only effective if the provider is rule
 #     rule_name: example-rule
@@ -888,3 +918,21 @@ backends:
 #   # log_file defines the file location to store logs. These will be auto-rolled and maintained for you.
 #   # not specifying a log_file (this is the default behavior) will print logs to STDOUT
 #   log_file: /some/path/to/trickster.log
+
+#   # rotation controls when the log file is rotated; a rotation occurs when either threshold is reached.
+#   # rotated archives are kept alongside the live file as trickster.log.1.gz, .2.gz, etc.
+#   rotation:
+#     # size rotates the log when the live file would exceed this size. default is 256MB
+#     size: 256MB
+#     # interval rotates the log when the live file is older than this. default is 0 (off)
+#     interval: 1d
+
+#   # retention controls how many rotated archives are kept
+#   retention:
+#     # count is the maximum number of archives kept. default is 80
+#     count: 80
+#     # age prunes archives older than this. default is 7d
+#     age: 7d
+
+#   # compress gzips rotated archives. default is true
+#   compress: true

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,6 @@ require (
 	golang.org/x/sync v0.22.0
 	google.golang.org/grpc v1.83.0
 	google.golang.org/protobuf v1.36.12
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	pgregory.net/rapid v1.3.0
 	vitess.io/vitess v0.24.2
 )

--- a/go.sum
+++ b/go.sum
@@ -1098,8 +1098,6 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -90,5 +90,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260810153831-ec0a7760b754 // indirect
 	google.golang.org/grpc v1.83.0 // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
-	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 )

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -662,8 +662,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
-gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/backends/alb/client_test.go
+++ b/pkg/backends/alb/client_test.go
@@ -652,8 +652,7 @@ func TestValidateAndStartUserRouterErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = cl.validateAndStartUserRouter(backends.Backends{"tenant-a": member}, nil)
-	var credErr *errors.InvalidALBOptionsError
-	if !goerrors.As(err, &credErr) {
+	if _, ok := goerrors.AsType[*errors.InvalidALBOptionsError](err); !ok {
 		t.Fatalf("validateAndStartUserRouter() = %v, want InvalidALBOptionsError", err)
 	}
 	want := errors.NewErrInvalidUserRouterCreds("ur-edge")

--- a/pkg/backends/alb/errors/errors_test.go
+++ b/pkg/backends/alb/errors/errors_test.go
@@ -25,8 +25,7 @@ import (
 func TestNewErrInvalidALBOptions(t *testing.T) {
 	t.Parallel()
 	err := NewErrInvalidALBOptions("backend1")
-	var e *InvalidALBOptionsError
-	if !errors.As(err, &e) {
+	if _, ok := errors.AsType[*InvalidALBOptionsError](err); !ok {
 		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
 	}
 	if !strings.Contains(err.Error(), "backend1") {
@@ -37,8 +36,7 @@ func TestNewErrInvalidALBOptions(t *testing.T) {
 func TestNewErrInvalidPoolMemberName(t *testing.T) {
 	t.Parallel()
 	err := NewErrInvalidPoolMemberName("alb1", "missing")
-	var e *InvalidALBOptionsError
-	if !errors.As(err, &e) {
+	if _, ok := errors.AsType[*InvalidALBOptionsError](err); !ok {
 		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
 	}
 	msg := err.Error()
@@ -50,8 +48,7 @@ func TestNewErrInvalidPoolMemberName(t *testing.T) {
 func TestNewErrInvalidBackendName(t *testing.T) {
 	t.Parallel()
 	err := NewErrInvalidBackendName("alb1", "bad")
-	var e *InvalidALBOptionsError
-	if !errors.As(err, &e) {
+	if _, ok := errors.AsType[*InvalidALBOptionsError](err); !ok {
 		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
 	}
 	msg := err.Error()
@@ -63,8 +60,7 @@ func TestNewErrInvalidBackendName(t *testing.T) {
 func TestNewErrInvalidUserRouterCreds(t *testing.T) {
 	t.Parallel()
 	err := NewErrInvalidUserRouterCreds("alb1")
-	var e *InvalidALBOptionsError
-	if !errors.As(err, &e) {
+	if _, ok := errors.AsType[*InvalidALBOptionsError](err); !ok {
 		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
 	}
 	if !strings.Contains(err.Error(), "alb1") {

--- a/pkg/backends/alb/mech/ur/options/options_test.go
+++ b/pkg/backends/alb/mech/ur/options/options_test.go
@@ -80,8 +80,7 @@ func TestValidate(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid default backend error")
 	}
-	var ie *InvalidUserRouterOptionsError
-	if !errors.As(err, &ie) {
+	if _, ok := errors.AsType[*InvalidUserRouterOptionsError](err); !ok {
 		t.Fatalf("Validate() = %T, want InvalidUserRouterOptionsError", err)
 	}
 
@@ -131,8 +130,7 @@ func TestNewErrInvalidUserRouterOptions(t *testing.T) {
 	t.Parallel()
 
 	err := NewErrInvalidUserRouterOptions("edge")
-	var ie *InvalidUserRouterOptionsError
-	if !errors.As(err, &ie) {
+	if _, ok := errors.AsType[*InvalidUserRouterOptionsError](err); !ok {
 		t.Fatalf("error type = %T, want InvalidUserRouterOptionsError", err)
 	}
 }

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -39,6 +39,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/listener"
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
 	yamlencoding "github.com/trickstercache/trickster/v2/pkg/encoding/yaml"
+	alo "github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/options"
 	tro "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
 	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
 	autho "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
@@ -183,6 +184,8 @@ type Options struct {
 	ForwardedHeaders string `yaml:"forwarded_headers,omitempty"`
 	// CORS configures downstream CORS response headers for this backend
 	CORS *corso.Options `yaml:"cors,omitempty"`
+	// AccessLog configures access and error logging for this backend
+	AccessLog *alo.Options `yaml:"access_log,omitempty"`
 
 	// IsDefault indicates if this is the d.Default backend for any request not matching a configured route
 	IsDefault bool `yaml:"is_default,omitempty"`
@@ -350,6 +353,10 @@ func (o *Options) Clone() *Options {
 		out.AuthOptions = o.AuthOptions.Clone()
 	}
 
+	if o.AccessLog != nil {
+		out.AccessLog = o.AccessLog.Clone()
+	}
+
 	return out
 }
 
@@ -391,6 +398,11 @@ func (o *Options) Validate() (bool, error) {
 	if o.HealthCheck != nil {
 		_, err := o.HealthCheck.Validate()
 		if err != nil {
+			return false, err
+		}
+	}
+	if o.AccessLog != nil {
+		if _, err := o.AccessLog.Validate(); err != nil {
 			return false, err
 		}
 	}

--- a/pkg/backends/options/options_data_test.go
+++ b/pkg/backends/options/options_data_test.go
@@ -55,6 +55,15 @@ backends:
     cache_key_prefix: test-prefix
     path_routing_disabled: false
     forwarded_headers: x
+    access_log:
+      filename: /tmp/test.access.log
+      format: combined
+      rotation:
+        size: 64MB
+      retention:
+        count: 3
+      error_filename: /tmp/test.error.log
+      error_threshold: 500
     negative_cache_name: test
     rule_name: ''
     shard_max_size_time: 0ms

--- a/pkg/backends/options/options_test.go
+++ b/pkg/backends/options/options_test.go
@@ -146,6 +146,32 @@ backends:
 	}
 }
 
+func TestAccessLogOptionsYAML(t *testing.T) {
+	o, err := fromTestYAML()
+	if err != nil {
+		t.Fatal(err)
+	}
+	al := o.AccessLog
+	if al == nil {
+		t.Fatal("expected access_log options")
+	}
+	if al.Filename != "/tmp/test.access.log" || al.Format != "combined" ||
+		al.Rotation == nil || *al.Rotation.Size != 64*1024*1024 ||
+		al.Retention == nil || *al.Retention.Count != 3 ||
+		al.ErrorFilename != "/tmp/test.error.log" || al.ErrorThreshold != 500 {
+		t.Fatalf("unexpected access_log options: %+v", al)
+	}
+	clone := o.Clone()
+	*clone.AccessLog.Retention.Count = 9
+	if *o.AccessLog.Retention.Count != 3 {
+		t.Fatal("clone mutated access_log retention")
+	}
+	o.AccessLog.Format = "%Z"
+	if _, err := o.Validate(); err == nil {
+		t.Fatal("expected validation error for invalid access log format")
+	}
+}
+
 func TestClone(t *testing.T) {
 	p := po.New()
 	o := New()

--- a/pkg/backends/tree/tree_test.go
+++ b/pkg/backends/tree/tree_test.go
@@ -24,11 +24,11 @@ import (
 
 func TestEntriesValidate(t *testing.T) {
 	tests := []struct {
-		name           string
-		entries        Entries
-		wantErr        bool
-		errContains    string
-		wantTarget     map[string]string // entry name -> expected TargetProvider
+		name        string
+		entries     Entries
+		wantErr     bool
+		errContains string
+		wantTarget  map[string]string // entry name -> expected TargetProvider
 	}{
 		{
 			name: "valid no cycles",
@@ -39,7 +39,7 @@ func TestEntriesValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "empty entries",
+			name:    "empty entries",
 			entries: Entries{},
 			wantErr: false,
 		},
@@ -205,8 +205,7 @@ func TestEntriesValidate(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("Validate() error = %v, want containing %q", err, tt.errContains)
 				}
-				var ibre *InvalidBackendRoutingError
-				if !errors.As(err, &ibre) {
+				if _, ok := errors.AsType[*InvalidBackendRoutingError](err); !ok {
 					t.Errorf("Validate() error type = %T, want *InvalidBackendRoutingError", err)
 				}
 			}
@@ -234,8 +233,7 @@ func findEntry(entries Entries, name string) *Entry {
 
 func TestNewErrInvalidBackendRouting(t *testing.T) {
 	err := NewErrInvalidBackendRouting("entry '%s' bad", "x")
-	var ibre *InvalidBackendRoutingError
-	if !errors.As(err, &ibre) {
+	if _, ok := errors.AsType[*InvalidBackendRoutingError](err); !ok {
 		t.Fatalf("expected *InvalidBackendRoutingError, got %T", err)
 	}
 	if got := err.Error(); got != "entry 'x' bad" {

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import logmanager "github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
+
+// LogManagerOptions returns every configured application, access and error log.
+func (c *Config) LogManagerOptions() []*logmanager.Options {
+	if c == nil {
+		return nil
+	}
+	var instanceID int
+	if c.Main != nil {
+		instanceID = c.Main.InstanceID
+	}
+	options := make([]*logmanager.Options, 0, 1+len(c.Backends)*2)
+	appendOption := func(o *logmanager.Options) {
+		o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
+		options = append(options, o)
+	}
+	if c.Logging != nil && c.Logging.LogFile != "" {
+		appendOption(c.Logging.ManagerOptions())
+	}
+	for _, backend := range c.Backends {
+		if backend == nil || backend.AccessLog == nil {
+			continue
+		}
+		if backend.AccessLog.Filename != "" {
+			appendOption(backend.AccessLog.AccessManagerOptions())
+		}
+		if backend.AccessLog.ErrorFilename != "" {
+			appendOption(backend.AccessLog.ErrorManagerOptions())
+		}
+	}
+	return options
+}

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -32,6 +32,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config/listener"
 	"github.com/trickstercache/trickster/v2/pkg/config/mgmt"
 	"github.com/trickstercache/trickster/v2/pkg/errors"
+	logmanager "github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
 	tr "github.com/trickstercache/trickster/v2/pkg/observability/tracing/registry"
 	ar "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/registry"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener/native"
@@ -80,7 +81,43 @@ func Validate(c *config.Config) error {
 	if err := Backends(c); err != nil {
 		return err
 	}
+	if err := LoggingFiles(c); err != nil {
+		return err
+	}
 	return Listeners(c)
+}
+
+// LoggingFiles validates shared rotation settings across all configured logs.
+func LoggingFiles(c *config.Config) error {
+	if c == nil {
+		return nil
+	}
+	var instanceID int
+	if c.Main != nil {
+		instanceID = c.Main.InstanceID
+	}
+	options := make([]*logmanager.Options, 0, 1+len(c.Backends)*2)
+	if c.Logging != nil && c.Logging.LogFile != "" {
+		o := c.Logging.ManagerOptions()
+		o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
+		options = append(options, o)
+	}
+	for _, backend := range c.Backends {
+		if backend == nil || backend.AccessLog == nil {
+			continue
+		}
+		if backend.AccessLog.Filename != "" {
+			o := backend.AccessLog.AccessManagerOptions()
+			o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
+			options = append(options, o)
+		}
+		if backend.AccessLog.ErrorFilename != "" {
+			o := backend.AccessLog.ErrorManagerOptions()
+			o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
+			options = append(options, o)
+		}
+	}
+	return logmanager.ValidateOptions(options...)
 }
 
 func Rewriters(c *config.Config) error {

--- a/pkg/config/validate/validate.go
+++ b/pkg/config/validate/validate.go
@@ -92,32 +92,7 @@ func LoggingFiles(c *config.Config) error {
 	if c == nil {
 		return nil
 	}
-	var instanceID int
-	if c.Main != nil {
-		instanceID = c.Main.InstanceID
-	}
-	options := make([]*logmanager.Options, 0, 1+len(c.Backends)*2)
-	if c.Logging != nil && c.Logging.LogFile != "" {
-		o := c.Logging.ManagerOptions()
-		o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
-		options = append(options, o)
-	}
-	for _, backend := range c.Backends {
-		if backend == nil || backend.AccessLog == nil {
-			continue
-		}
-		if backend.AccessLog.Filename != "" {
-			o := backend.AccessLog.AccessManagerOptions()
-			o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
-			options = append(options, o)
-		}
-		if backend.AccessLog.ErrorFilename != "" {
-			o := backend.AccessLog.ErrorManagerOptions()
-			o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
-			options = append(options, o)
-		}
-	}
-	return logmanager.ValidateOptions(options...)
+	return logmanager.ValidateOptions(c.LogManagerOptions()...)
 }
 
 func Rewriters(c *config.Config) error {

--- a/pkg/config/validate/validate_unit_test.go
+++ b/pkg/config/validate/validate_unit_test.go
@@ -17,6 +17,8 @@
 package validate
 
 import (
+	stderrors "errors"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -26,6 +28,8 @@ import (
 	co "github.com/trickstercache/trickster/v2/pkg/cache/options"
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	"github.com/trickstercache/trickster/v2/pkg/errors"
+	alo "github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/options"
+	logmanager "github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
 	lo "github.com/trickstercache/trickster/v2/pkg/observability/logging/options"
 	mo "github.com/trickstercache/trickster/v2/pkg/observability/metrics/options"
 	to "github.com/trickstercache/trickster/v2/pkg/observability/tracing/options"
@@ -40,6 +44,23 @@ func TestValidateNilConfig(t *testing.T) {
 
 	if err := Validate(nil); err != errors.ErrInvalidOptions {
 		t.Fatalf("Validate(nil) = %v, want ErrInvalidOptions", err)
+	}
+}
+
+func TestLoggingFilesRejectsConflictingOptions(t *testing.T) {
+	name := filepath.Join(t.TempDir(), "shared.log")
+	c := config.NewConfig()
+	c.Logging.LogFile = name
+	c.Backends = bo.Lookup{
+		"one": {AccessLog: &alo.Options{Filename: name}},
+	}
+	if err := LoggingFiles(c); err != nil {
+		t.Fatalf("matching options failed validation: %v", err)
+	}
+	compress := false
+	c.Backends["one"].AccessLog.Compress = &compress
+	if err := LoggingFiles(c); !stderrors.Is(err, logmanager.ErrConflictingOptions) {
+		t.Fatalf("expected conflicting options error, got %v", err)
 	}
 }
 

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -17,6 +17,8 @@
 package setup
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
 	goruntime "runtime"
@@ -140,7 +142,7 @@ func LoadAndValidate(args ...string) (*config.Config, error) {
 func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	clients backends.Backends, hupFunc dr.Reloader, errorFunc func(),
 	lg *listener.Group,
-) error {
+) (retErr error) {
 	if si == nil || newConf == nil {
 		return nil
 	}
@@ -153,6 +155,10 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	if newConf.MgmtConfig == nil {
 		newConf.MgmtConfig = mgmt.New()
 	}
+	firstStartup := si.Config == nil
+	if firstStartup {
+		applyLoggingConfig(newConf, nil)
+	}
 
 	if err := buildAuthenticators(newConf); err != nil {
 		return err
@@ -163,7 +169,15 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 			logging.Pairs{logKeyDetail: err.Error()}, errorFunc)
 		return err
 	}
-	applyLoggingConfig(newConf, si.Config)
+	rollbackLogWriters := !firstStartup
+	defer func() {
+		if rollbackLogWriters {
+			if err := reconfigureLogWriters(si.Config); err != nil {
+				retErr = errors.Join(retErr,
+					fmt.Errorf("restore previous log writer options: %w", err))
+			}
+		}
+	}()
 
 	// Register Tracing Configurations
 	tracers, err := tr.RegisterAll(newConf, false)
@@ -230,6 +244,10 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 		healthcheck.LogHealthCheckError("", err, 0)
 		return err
 	}
+	rollbackLogWriters = false
+	if !firstStartup {
+		applyLoggingConfig(newConf, si.Config)
+	}
 	alb.StartALBPools(clients, si.HealthChecker.Statuses())
 	routing.RegisterDefaultBackendRoutesForListeners(listenerRouters, newConf, clients, tracers)
 	routing.RegisterHealthHandler(mr, newConf.MgmtConfig.HealthHandlerPath, si.HealthChecker, clients)
@@ -247,35 +265,9 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 }
 
 func reconfigureLogWriters(c *config.Config) error {
-	if c == nil {
-		return nil
-	}
-	var instanceID int
-	if c.Main != nil {
-		instanceID = c.Main.InstanceID
-	}
-	reconfigure := func(o *logmanager.Options) error {
-		o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
-		return logmanager.Reconfigure(o)
-	}
-	if c.Logging != nil && c.Logging.LogFile != "" {
-		if err := reconfigure(c.Logging.ManagerOptions()); err != nil {
+	for _, o := range c.LogManagerOptions() {
+		if err := logmanager.Reconfigure(o); err != nil {
 			return err
-		}
-	}
-	for _, backend := range c.Backends {
-		if backend == nil || backend.AccessLog == nil {
-			continue
-		}
-		if backend.AccessLog.Filename != "" {
-			if err := reconfigure(backend.AccessLog.AccessManagerOptions()); err != nil {
-				return err
-			}
-		}
-		if backend.AccessLog.ErrorFilename != "" {
-			if err := reconfigure(backend.AccessLog.ErrorManagerOptions()); err != nil {
-				return err
-			}
 		}
 	}
 	return nil
@@ -305,14 +297,6 @@ func applyLoggingConfig(c, o *config.Config) {
 		c.MgmtConfig = mgmt.New()
 	}
 	if isReload {
-		rotationChanged := c.Logging.LogFile != "" &&
-			!c.Logging.RotationEqual(o.Logging)
-		if c.Logging.LogFile == o.Logging.LogFile &&
-			c.Logging.LogLevel == o.Logging.LogLevel && !rotationChanged {
-			// no changes in logging config,
-			// so we keep the old logger intact
-			return
-		}
 		if c.Logging.LogFile != o.Logging.LogFile {
 			if o.Logging.LogFile != "" {
 				// if we're changing from file1 -> console or file1 -> file2, close file1 handle
@@ -322,38 +306,12 @@ func applyLoggingConfig(c, o *config.Config) {
 			initLogger(c)
 			return
 		}
-		if rotationChanged {
-			// same file with new rotation settings: rebuild the logger so the
-			// shared writer picks up the new settings, and release the old handle
-			if err := reconfigureApplicationLog(c); err != nil {
-				logger.Error("log writer reconfiguration failed",
-					logging.Pairs{logKeyError: err.Error()})
-				return
-			}
-			go delayedLogCloser(oldLogger, time.Duration(c.MgmtConfig.ReloadDrainTimeout)+(1*time.Millisecond))
-			initLogger(c)
-			return
-		}
 		if c.Logging.LogLevel != o.Logging.LogLevel {
-			// the only change is the log level, so update it and return the original logger
 			oldLogger.SetLogLevel(level.Level(c.Logging.LogLevel))
-			return
 		}
+		return
 	}
 	initLogger(c)
-}
-
-func reconfigureApplicationLog(c *config.Config) error {
-	if c == nil || c.Logging == nil || c.Logging.LogFile == "" {
-		return nil
-	}
-	var instanceID int
-	if c.Main != nil {
-		instanceID = c.Main.InstanceID
-	}
-	o := c.Logging.ManagerOptions()
-	o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
-	return logmanager.Reconfigure(o)
 }
 
 func applyCachingConfig(si *instance.ServerInstance,
@@ -476,7 +434,8 @@ func handleStartupIssue(event string, detail logging.Pairs, errorFunc func()) {
 	metrics.LastReloadSuccessful.Set(0)
 	if event != "" {
 		if errorFunc != nil {
-			logger.Error(event, detail)
+			logger.ErrorSynchronous(event, detail)
+			_ = logger.Flush()
 			errorFunc()
 		}
 		logger.Warn(event, detail)

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -41,6 +41,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/daemon/instance"
 	te "github.com/trickstercache/trickster/v2/pkg/errors"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
@@ -187,8 +188,11 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 
 	caches := applyCachingConfig(si, newConf)
 	rh := reload.HandlerFunc(hupFunc)
+	// retire the old config's access loggers once the new routes are live
+	accesslog.BeginGeneration()
 	err = routing.RegisterProxyRoutesForListeners(newConf, clients, listenerRouters, mr, caches, tracers, false)
 	if err != nil {
+		accesslog.AbortGeneration()
 		handleStartupIssue("route registration failed",
 			logging.Pairs{logKeyDetail: err.Error()}, errorFunc)
 		return err
@@ -215,6 +219,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	}
 	si.HealthChecker, err = clients.StartHealthChecks(oldStatuses)
 	if err != nil {
+		accesslog.AbortGeneration()
 		// logs the error (no status code or target name)
 		healthcheck.LogHealthCheckError("", err, 0)
 		return err
@@ -224,6 +229,8 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	routing.RegisterHealthHandler(mr, newConf.MgmtConfig.HealthHandlerPath, si.HealthChecker, clients)
 	applyListenerConfigs(newConf, si.Config, listenerRouters, rh, mr, tracers, clients, errorFunc, lg)
 
+	accesslog.CommitGeneration(
+		time.Duration(newConf.MgmtConfig.ReloadDrainTimeout) + time.Second)
 	metrics.LastReloadSuccessfulTimestamp.Set(float64(time.Now().Unix()))
 	metrics.LastReloadSuccessful.Set(1)
 	si.Config = newConf
@@ -257,8 +264,10 @@ func applyLoggingConfig(c, o *config.Config) {
 		c.MgmtConfig = mgmt.New()
 	}
 	if isReload {
+		rotationChanged := c.Logging.LogFile != "" &&
+			!c.Logging.RotationEqual(o.Logging)
 		if c.Logging.LogFile == o.Logging.LogFile &&
-			c.Logging.LogLevel == o.Logging.LogLevel {
+			c.Logging.LogLevel == o.Logging.LogLevel && !rotationChanged {
 			// no changes in logging config,
 			// so we keep the old logger intact
 			return
@@ -269,6 +278,13 @@ func applyLoggingConfig(c, o *config.Config) {
 				// the extra 1s allows HTTP listeners to close first and finish their log writes
 				go delayedLogCloser(oldLogger, time.Duration(c.MgmtConfig.ReloadDrainTimeout)+(1*time.Millisecond))
 			}
+			initLogger(c)
+			return
+		}
+		if rotationChanged {
+			// same file with new rotation settings: rebuild the logger so the
+			// shared writer picks up the new settings, and release the old handle
+			go delayedLogCloser(oldLogger, time.Duration(c.MgmtConfig.ReloadDrainTimeout)+(1*time.Millisecond))
 			initLogger(c)
 			return
 		}

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -44,6 +44,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	logmanager "github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	tr "github.com/trickstercache/trickster/v2/pkg/observability/tracing/registry"
 	ar "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/registry"
@@ -157,6 +158,11 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 		return err
 	}
 
+	if err := reconfigureLogWriters(newConf); err != nil {
+		handleStartupIssue("log writer reconfiguration failed",
+			logging.Pairs{logKeyDetail: err.Error()}, errorFunc)
+		return err
+	}
 	applyLoggingConfig(newConf, si.Config)
 
 	// Register Tracing Configurations
@@ -240,6 +246,41 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	return nil
 }
 
+func reconfigureLogWriters(c *config.Config) error {
+	if c == nil {
+		return nil
+	}
+	var instanceID int
+	if c.Main != nil {
+		instanceID = c.Main.InstanceID
+	}
+	reconfigure := func(o *logmanager.Options) error {
+		o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
+		return logmanager.Reconfigure(o)
+	}
+	if c.Logging != nil && c.Logging.LogFile != "" {
+		if err := reconfigure(c.Logging.ManagerOptions()); err != nil {
+			return err
+		}
+	}
+	for _, backend := range c.Backends {
+		if backend == nil || backend.AccessLog == nil {
+			continue
+		}
+		if backend.AccessLog.Filename != "" {
+			if err := reconfigure(backend.AccessLog.AccessManagerOptions()); err != nil {
+				return err
+			}
+		}
+		if backend.AccessLog.ErrorFilename != "" {
+			if err := reconfigure(backend.AccessLog.ErrorManagerOptions()); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 func buildAuthenticators(c *config.Config) error {
 	if c == nil || len(c.Authenticators) == 0 {
 		return nil
@@ -284,6 +325,11 @@ func applyLoggingConfig(c, o *config.Config) {
 		if rotationChanged {
 			// same file with new rotation settings: rebuild the logger so the
 			// shared writer picks up the new settings, and release the old handle
+			if err := reconfigureApplicationLog(c); err != nil {
+				logger.Error("log writer reconfiguration failed",
+					logging.Pairs{logKeyError: err.Error()})
+				return
+			}
 			go delayedLogCloser(oldLogger, time.Duration(c.MgmtConfig.ReloadDrainTimeout)+(1*time.Millisecond))
 			initLogger(c)
 			return
@@ -295,6 +341,19 @@ func applyLoggingConfig(c, o *config.Config) {
 		}
 	}
 	initLogger(c)
+}
+
+func reconfigureApplicationLog(c *config.Config) error {
+	if c == nil || c.Logging == nil || c.Logging.LogFile == "" {
+		return nil
+	}
+	var instanceID int
+	if c.Main != nil {
+		instanceID = c.Main.InstanceID
+	}
+	o := c.Logging.ManagerOptions()
+	o.Filename = logmanager.InstanceFilename(o.Filename, instanceID)
+	return logmanager.Reconfigure(o)
 }
 
 func applyCachingConfig(si *instance.ServerInstance,

--- a/pkg/daemon/setup/setup_test.go
+++ b/pkg/daemon/setup/setup_test.go
@@ -381,12 +381,23 @@ func TestApplyConfigTracingError(t *testing.T) {
 		t.Fatal(err)
 	}
 	quietListeners(conf)
+	old := conf.Clone()
+	old.Logging.LogFile = filepath.Join(t.TempDir(), "reload.log")
+	conf.Logging.LogFile = old.Logging.LogFile
+	count := 5
+	conf.Logging.Retention = &logmgr.RetentionOptions{Count: &count}
+	oldOptions := old.Logging.ManagerOptions()
+	h, err := logmgr.GetWriter(oldOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
 	// a backend pointing at a tracing config that does not exist fails
 	// tracer registration
 	conf.Backends["test"].TracingConfigName = "nonexistent"
 
 	var errorFuncCalls int
-	si := &instance.ServerInstance{}
+	si := &instance.ServerInstance{Config: old}
 	err = ApplyConfig(si, conf, clients, nil, func() { errorFuncCalls++ }, listener.NewGroup())
 	if err == nil {
 		t.Fatal("expected a tracer registration error")
@@ -394,6 +405,11 @@ func TestApplyConfigTracingError(t *testing.T) {
 	if errorFuncCalls != 1 {
 		t.Errorf("errorFunc calls = %d, want 1", errorFuncCalls)
 	}
+	restored, err := logmgr.GetWriter(oldOptions)
+	if err != nil {
+		t.Fatalf("old log options were not restored: %v", err)
+	}
+	restored.Close()
 }
 
 func TestApplyConfigRouteRegistrationError(t *testing.T) {
@@ -402,17 +418,36 @@ func TestApplyConfigRouteRegistrationError(t *testing.T) {
 		t.Fatal(err)
 	}
 	quietListeners(conf)
+	logFile := filepath.Join(t.TempDir(), "startup.log")
+	conf.Logging.LogFile = logFile
 	// an unknown provider is rejected by route registration
 	conf.Backends["test"].Provider = "not-a-provider"
 
 	var errorFuncCalls int
+	var loggedBeforeExit bool
 	si := &instance.ServerInstance{}
-	err = ApplyConfig(si, conf, clients, nil, func() { errorFuncCalls++ }, listener.NewGroup())
+	err = ApplyConfig(si, conf, clients, nil, func() {
+		errorFuncCalls++
+		b, _ := os.ReadFile(logFile)
+		loggedBeforeExit = strings.Contains(string(b), "route registration failed")
+	}, listener.NewGroup())
 	if err == nil {
 		t.Fatal("expected a route registration error")
 	}
 	if errorFuncCalls != 1 {
 		t.Errorf("errorFunc calls = %d, want 1", errorFuncCalls)
+	}
+	if !loggedBeforeExit {
+		t.Error("startup failure was not flushed before the exit callback")
+	}
+	logger.Logger().Close()
+	logger.SetLogger(logging.NoopLogger())
+	b, readErr := os.ReadFile(logFile)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if !strings.Contains(string(b), "route registration failed") {
+		t.Errorf("startup failure missing from configured log: %q", string(b))
 	}
 }
 
@@ -529,16 +564,19 @@ func TestApplyLoggingConfigRotationChange(t *testing.T) {
 	old.MgmtConfig.ReloadDrainTimeout = 0
 	logger.SetLogger(logging.New(old))
 
-	// same file and level with new rotation settings must install a new logger
+	// the shared writer is reconfigured before applying the logging config
 	nc := config.NewConfig()
 	nc.Logging.LogFile = old.Logging.LogFile
 	nc.MgmtConfig.ReloadDrainTimeout = 0
 	count := 5
 	nc.Logging.Retention = &logmgr.RetentionOptions{Count: &count}
 	before := logger.Logger()
+	if err := reconfigureLogWriters(nc); err != nil {
+		t.Fatal(err)
+	}
 	applyLoggingConfig(nc, old)
-	if logger.Logger() == before {
-		t.Error("a rotation change should install a new logger")
+	if logger.Logger() != before {
+		t.Error("a rotation-only change should retain the existing logger")
 	}
 
 	// an identical rotation config must retain the existing logger
@@ -550,8 +588,6 @@ func TestApplyLoggingConfigRotationChange(t *testing.T) {
 	if logger.Logger() != before {
 		t.Error("an equivalent rotation config should retain the existing logger")
 	}
-	// let the delayed closer for the old logger run before TempDir cleanup
-	time.Sleep(20 * time.Millisecond)
 }
 
 func TestApplyCachingConfigNilArgs(t *testing.T) {

--- a/pkg/daemon/setup/setup_test.go
+++ b/pkg/daemon/setup/setup_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	logmgr "github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/providers/basic"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
@@ -512,6 +513,42 @@ func TestApplyLoggingConfigFileChange(t *testing.T) {
 	}
 	if nc.MgmtConfig == nil {
 		t.Error("expected a default mgmt config to be created")
+	}
+	// let the delayed closer for the old logger run before TempDir cleanup
+	time.Sleep(20 * time.Millisecond)
+}
+
+func TestApplyLoggingConfigRotationChange(t *testing.T) {
+	dir := t.TempDir()
+	t.Cleanup(func() {
+		logger.Logger().Close()
+		logger.SetLogger(logging.NoopLogger())
+	})
+	old := config.NewConfig()
+	old.Logging.LogFile = filepath.Join(dir, "trickster.log")
+	old.MgmtConfig.ReloadDrainTimeout = 0
+	logger.SetLogger(logging.New(old))
+
+	// same file and level with new rotation settings must install a new logger
+	nc := config.NewConfig()
+	nc.Logging.LogFile = old.Logging.LogFile
+	nc.MgmtConfig.ReloadDrainTimeout = 0
+	count := 5
+	nc.Logging.Retention = &logmgr.RetentionOptions{Count: &count}
+	before := logger.Logger()
+	applyLoggingConfig(nc, old)
+	if logger.Logger() == before {
+		t.Error("a rotation change should install a new logger")
+	}
+
+	// an identical rotation config must retain the existing logger
+	nc2 := config.NewConfig()
+	nc2.Logging.LogFile = nc.Logging.LogFile
+	nc2.Logging.Retention = &logmgr.RetentionOptions{Count: &count}
+	before = logger.Logger()
+	applyLoggingConfig(nc2, nc)
+	if logger.Logger() != before {
+		t.Error("an equivalent rotation config should retain the existing logger")
 	}
 	// let the delayed closer for the old logger run before TempDir cleanup
 	time.Sleep(20 * time.Millisecond)

--- a/pkg/observability/logging/accesslog/accesslog.go
+++ b/pkg/observability/logging/accesslog/accesslog.go
@@ -45,6 +45,8 @@ var bufPool = sync.Pool{
 	},
 }
 
+const maxPooledBufferSize = 64 * 1024
+
 // NewLogger returns a Logger for the provided options, or nil when neither
 // an access log nor an error log filename is configured
 func NewLogger(o *alo.Options, instanceID int,
@@ -96,12 +98,20 @@ func (l *Logger) Log(f *format.Fields) {
 	}
 }
 
+// NeedsResultHeader reports whether either configured log emits result fields.
+func (l *Logger) NeedsResultHeader() bool {
+	return l != nil && (l.access != nil && l.accessFmt.NeedsResultHeader() ||
+		l.errlog != nil && l.errFmt.NeedsResultHeader())
+}
+
 func (l *Logger) render(w *manager.Handle, fm *format.Formatter, f *format.Fields) {
 	bp := bufPool.Get().(*[]byte)
 	b := fm.Render((*bp)[:0], f)
 	w.Write(b)
-	*bp = b
-	bufPool.Put(bp)
+	if cap(b) <= maxPooledBufferSize {
+		*bp = b
+		bufPool.Put(bp)
+	}
 }
 
 // Close releases the Logger's log file handles

--- a/pkg/observability/logging/accesslog/accesslog.go
+++ b/pkg/observability/logging/accesslog/accesslog.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package accesslog provides per-backend, format-configurable HTTP access
+// and error logging to rotation-managed files.
+package accesslog
+
+import (
+	"sync"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/format"
+	alo "github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/options"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
+)
+
+// Logger writes formatted access log lines for one backend, and error log
+// lines for responses at or above the error threshold
+type Logger struct {
+	access    *manager.Handle
+	errlog    *manager.Handle
+	accessFmt *format.Formatter
+	errFmt    *format.Formatter
+	threshold int
+	backend   string
+	provider  string
+}
+
+var bufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 512)
+		return &b
+	},
+}
+
+// NewLogger returns a Logger for the provided options, or nil when neither
+// an access log nor an error log filename is configured
+func NewLogger(o *alo.Options, instanceID int,
+	backend, provider string,
+) (*Logger, error) {
+	if !o.IsEnabled() {
+		return nil, nil
+	}
+	l := &Logger{
+		backend:   backend,
+		provider:  provider,
+		threshold: o.ResolvedErrorThreshold(),
+	}
+	var err error
+	if l.accessFmt, err = format.ParseFormat(o.ResolvedFormat()); err != nil {
+		return nil, err
+	}
+	if l.errFmt, err = format.ParseFormat(o.ResolvedErrorFormat()); err != nil {
+		return nil, err
+	}
+	if o.Filename != "" {
+		mo := o.AccessManagerOptions()
+		mo.Filename = manager.InstanceFilename(mo.Filename, instanceID)
+		if l.access, err = manager.GetWriter(mo); err != nil {
+			return nil, err
+		}
+	}
+	if o.ErrorFilename != "" {
+		mo := o.ErrorManagerOptions()
+		mo.Filename = manager.InstanceFilename(mo.Filename, instanceID)
+		if l.errlog, err = manager.GetWriter(mo); err != nil {
+			l.Close()
+			return nil, err
+		}
+	}
+	track(l)
+	return l, nil
+}
+
+// Log writes the request described by the Fields to the configured logs
+func (l *Logger) Log(f *format.Fields) {
+	f.Backend = l.backend
+	f.Provider = l.provider
+	if l.access != nil {
+		l.render(l.access, l.accessFmt, f)
+	}
+	if l.errlog != nil && f.Status >= l.threshold {
+		l.render(l.errlog, l.errFmt, f)
+	}
+}
+
+func (l *Logger) render(w *manager.Handle, fm *format.Formatter, f *format.Fields) {
+	bp := bufPool.Get().(*[]byte)
+	b := fm.Render((*bp)[:0], f)
+	w.Write(b)
+	*bp = b
+	bufPool.Put(bp)
+}
+
+// Close releases the Logger's log file handles
+func (l *Logger) Close() {
+	if l == nil {
+		return
+	}
+	if l.access != nil {
+		l.access.Close()
+	}
+	if l.errlog != nil {
+		l.errlog.Close()
+	}
+}

--- a/pkg/observability/logging/accesslog/accesslog_test.go
+++ b/pkg/observability/logging/accesslog/accesslog_test.go
@@ -1,0 +1,289 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accesslog
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	alo "github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/options"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+)
+
+func testLoggerOptions(t *testing.T) *alo.Options {
+	t.Helper()
+	dir := t.TempDir()
+	return &alo.Options{
+		Filename:      filepath.Join(dir, "test.access.log"),
+		ErrorFilename: filepath.Join(dir, "test.error.log"),
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s failed: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestNewLoggerDisabled(t *testing.T) {
+	l, err := NewLogger(nil, 0, "b", "p")
+	if l != nil || err != nil {
+		t.Errorf("expected nil logger for nil options, got %v, %v", l, err)
+	}
+	l, err = NewLogger(&alo.Options{}, 0, "b", "p")
+	if l != nil || err != nil {
+		t.Errorf("expected nil logger for empty options, got %v, %v", l, err)
+	}
+}
+
+func TestNewLoggerBadFormat(t *testing.T) {
+	o := testLoggerOptions(t)
+	o.Format = "%Z"
+	if _, err := NewLogger(o, 0, "b", "p"); err == nil {
+		t.Error("expected format error")
+	}
+	o.Format = ""
+	o.ErrorFormat = "%Z"
+	if _, err := NewLogger(o, 0, "b", "p"); err == nil {
+		t.Error("expected error format error")
+	}
+}
+
+func TestNewLoggerInstanceID(t *testing.T) {
+	o := testLoggerOptions(t)
+	o.ErrorFilename = ""
+	l, err := NewLogger(o, 2, "b", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer l.Close()
+	if !strings.HasSuffix(l.access.Filename(), "test.access.2.log") {
+		t.Errorf("expected instance filename, got %s", l.access.Filename())
+	}
+}
+
+func TestMiddlewareAccessAndErrorLogs(t *testing.T) {
+	o := testLoggerOptions(t)
+	o.Format = `%h %u "%r" %>s %b %{cache-status}x %{backend}x %{provider}x %{path-config}x`
+	l, err := NewLogger(o, 0, "example1", "rp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set(headers.NameTricksterResult, "engine=HTTPProxy; status=hit")
+		if r.URL.Path == "/fail" {
+			w.WriteHeader(http.StatusBadGateway)
+			w.Write([]byte("upstream error"))
+			return
+		}
+		w.Write([]byte("hello"))
+	})
+	h := Middleware(l, "/api", inner)
+
+	r := httptest.NewRequest(http.MethodGet, "/api?q=1", nil)
+	r.RemoteAddr = "203.0.113.9:51234"
+	r.SetBasicAuth("frank", "pw")
+	h.ServeHTTP(httptest.NewRecorder(), r)
+
+	r = httptest.NewRequest(http.MethodGet, "/fail", nil)
+	r.RemoteAddr = "203.0.113.9:51234"
+	h.ServeHTTP(httptest.NewRecorder(), r)
+
+	l.Close()
+
+	access := readFile(t, o.Filename)
+	lines := strings.Split(strings.TrimSpace(access), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 access log lines, got %d: %q", len(lines), access)
+	}
+	expected := `203.0.113.9 frank "GET /api?q=1 HTTP/1.1" 200 5 hit example1 rp /api`
+	if lines[0] != expected {
+		t.Errorf("expected %q, got %q", expected, lines[0])
+	}
+	if !strings.Contains(lines[1], " 502 14 ") {
+		t.Errorf("unexpected error request line: %q", lines[1])
+	}
+
+	// only the 502 goes to the error log
+	errLog := readFile(t, o.ErrorFilename)
+	errLines := strings.Split(strings.TrimSpace(errLog), "\n")
+	if len(errLines) != 1 || !strings.Contains(errLines[0], " 502 ") {
+		t.Errorf("unexpected error log content: %q", errLog)
+	}
+}
+
+func TestMiddlewareAccessOnly(t *testing.T) {
+	o := testLoggerOptions(t)
+	o.ErrorFilename = ""
+	o.Format = "%m %s"
+	l, err := NewLogger(o, 0, "b", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := Middleware(l, "/", http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+	h.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodDelete, "/x", nil))
+	l.Close()
+	if s := readFile(t, o.Filename); s != "DELETE 404\n" {
+		t.Errorf("unexpected access log: %q", s)
+	}
+}
+
+func TestMiddlewareErrorOnlyWithThreshold(t *testing.T) {
+	o := testLoggerOptions(t)
+	o.Filename = ""
+	o.Format = "%m %s"
+	o.ErrorThreshold = 500
+	l, err := NewLogger(o, 0, "b", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := Middleware(l, "/", http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/404" {
+				w.WriteHeader(http.StatusNotFound)
+			} else {
+				w.WriteHeader(http.StatusInternalServerError)
+			}
+		}))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/404", nil))
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/500", nil))
+	l.Close()
+	// 404 is below the 500 threshold, so only the 500 is logged
+	if s := readFile(t, o.ErrorFilename); s != "GET 500\n" {
+		t.Errorf("unexpected error log: %q", s)
+	}
+}
+
+func TestMiddlewareNilLogger(t *testing.T) {
+	var called bool
+	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		called = true
+	})
+	h := Middleware(nil, "/", inner)
+	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
+	if !called {
+		t.Error("expected next handler to be called")
+	}
+}
+
+func TestParseResultHeader(t *testing.T) {
+	engine, status := parseResultHeader(
+		"engine=DeltaProxyCache; status=phit; fetched=[1-2]; ffstatus=hit")
+	if engine != "DeltaProxyCache" || status != "phit" {
+		t.Errorf("unexpected parse result: %s, %s", engine, status)
+	}
+	engine, status = parseResultHeader("")
+	if engine != "" || status != "" {
+		t.Errorf("expected empty results, got %s, %s", engine, status)
+	}
+	engine, status = parseResultHeader("junk; status=hit")
+	if engine != "" || status != "hit" {
+		t.Errorf("unexpected parse result: %s, %s", engine, status)
+	}
+}
+
+func TestClientIPAndSplitAddr(t *testing.T) {
+	if ip := clientIP("203.0.113.9:1234"); ip != "203.0.113.9" {
+		t.Errorf("unexpected ip: %s", ip)
+	}
+	if ip := clientIP("203.0.113.9"); ip != "203.0.113.9" {
+		t.Errorf("unexpected ip: %s", ip)
+	}
+	if ip := clientIP("[::1]:1234"); ip != "::1" {
+		t.Errorf("unexpected ip: %s", ip)
+	}
+	host, port := splitAddr("10.0.0.1:8480")
+	if host != "10.0.0.1" || port != "8480" {
+		t.Errorf("unexpected split: %s, %s", host, port)
+	}
+	host, port = splitAddr("pipe")
+	if host != "pipe" || port != "" {
+		t.Errorf("unexpected split: %s, %s", host, port)
+	}
+}
+
+func TestLoggerClose(t *testing.T) {
+	var nilLogger *Logger
+	nilLogger.Close() // must not panic
+	o := testLoggerOptions(t)
+	l, err := NewLogger(o, 0, "b", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	l.Close()
+	l.Close() // idempotent
+}
+
+func waitClosed(t *testing.T, l *Logger) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := l.access.Write(nil); err != nil {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Error("expected logger to be closed")
+}
+
+func TestGenerations(t *testing.T) {
+	dir := t.TempDir()
+	newGenLogger := func(name string) *Logger {
+		l, err := NewLogger(&alo.Options{
+			Filename: filepath.Join(dir, name)}, 0, "b", "p")
+		if err != nil {
+			t.Fatal(err)
+		}
+		return l
+	}
+	BeginGeneration()
+	l1 := newGenLogger("gen1.access.log")
+	// simulate a reload: l1 moves to previous, l2 is the new generation
+	BeginGeneration()
+	l2 := newGenLogger("gen2.access.log")
+	CommitGeneration(0)
+	waitClosed(t, l1)
+	if _, err := l2.access.Write([]byte("still alive\n")); err != nil {
+		t.Errorf("expected current generation to remain open: %v", err)
+	}
+
+	// abort closes the failed generation and restores the previous one
+	BeginGeneration()
+	l3 := newGenLogger("gen3.access.log")
+	AbortGeneration()
+	if _, err := l3.access.Write(nil); err == nil {
+		t.Error("expected aborted generation's logger to be closed")
+	}
+	if _, err := l2.access.Write([]byte("survivor\n")); err != nil {
+		t.Errorf("expected restored generation to remain open: %v", err)
+	}
+	BeginGeneration()
+	CommitGeneration(0)
+	waitClosed(t, l2)
+}

--- a/pkg/observability/logging/accesslog/accesslog_test.go
+++ b/pkg/observability/logging/accesslog/accesslog_test.go
@@ -29,6 +29,7 @@ import (
 	authtypes "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	utilmiddleware "github.com/trickstercache/trickster/v2/pkg/util/middleware"
 )
 
 func testLoggerOptions(t *testing.T) *alo.Options {
@@ -106,7 +107,7 @@ func TestMiddlewareAccessAndErrorLogs(t *testing.T) {
 		}
 		w.Write([]byte("hello"))
 	})
-	h := Middleware(l, "/api", inner)
+	h := Middleware(l, "/api", true, inner)
 
 	r := httptest.NewRequest(http.MethodGet, "/api?q=1", nil)
 	r.RemoteAddr = "203.0.113.9:51234"
@@ -148,8 +149,11 @@ func TestMiddlewareAccessOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := Middleware(l, "/", http.HandlerFunc(
-		func(w http.ResponseWriter, _ *http.Request) {
+	h := Middleware(l, "/", false, http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if request.GetResources(r) != nil {
+				t.Error("access logging seeded resources without an authenticator")
+			}
 			w.WriteHeader(http.StatusNotFound)
 		}))
 	h.ServeHTTP(httptest.NewRecorder(),
@@ -169,7 +173,7 @@ func TestMiddlewareErrorOnlyWithThreshold(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := Middleware(l, "/", http.HandlerFunc(
+	h := Middleware(l, "/", false, http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/404" {
 				w.WriteHeader(http.StatusNotFound)
@@ -191,7 +195,7 @@ func TestMiddlewareNilLogger(t *testing.T) {
 	inner := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		called = true
 	})
-	h := Middleware(nil, "/", inner)
+	h := Middleware(nil, "/", false, inner)
 	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
 	if !called {
 		t.Error("expected next handler to be called")
@@ -206,7 +210,7 @@ func TestMiddlewareUsesAuthenticatedUsername(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := Middleware(l, "/", http.HandlerFunc(
+	h := Middleware(l, "/", true, http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/verified" {
 				request.GetResources(r).AuthResult = &authtypes.AuthResult{
@@ -236,34 +240,35 @@ func (r *flushRecorder) Flush() {
 
 func TestRecorderUnwrap(t *testing.T) {
 	base := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
-	rec := &recorder{ResponseWriter: base, status: http.StatusOK}
+	rec := utilmiddleware.NewResponseObserver(base)
 	if err := http.NewResponseController(rec).Flush(); err != nil {
 		t.Fatal(err)
 	}
 	if !base.flushed {
 		t.Error("expected flush to reach the underlying writer")
 	}
-	rec2 := &recorder{ResponseWriter: httptest.NewRecorder(), status: http.StatusOK}
+	rec2 := utilmiddleware.NewResponseObserver(httptest.NewRecorder())
+	rec2.WriteHeader(http.StatusEarlyHints)
 	rec2.WriteHeader(http.StatusCreated)
 	rec2.WriteHeader(http.StatusInternalServerError)
-	if rec2.status != http.StatusCreated {
-		t.Errorf("recorded status = %d, want %d", rec2.status, http.StatusCreated)
+	if rec2.StatusCode() != http.StatusCreated {
+		t.Errorf("recorded status = %d, want %d", rec2.StatusCode(), http.StatusCreated)
 	}
 }
 
 func TestParseResultHeader(t *testing.T) {
-	engine, status := parseResultHeader(
+	result := headers.ParseResultHeader(
 		"engine=DeltaProxyCache; status=phit; fetched=[1-2]; ffstatus=hit")
-	if engine != "DeltaProxyCache" || status != "phit" {
-		t.Errorf("unexpected parse result: %s, %s", engine, status)
+	if result.Engine != "DeltaProxyCache" || result.Status != "phit" {
+		t.Errorf("unexpected parse result: %s, %s", result.Engine, result.Status)
 	}
-	engine, status = parseResultHeader("")
-	if engine != "" || status != "" {
-		t.Errorf("expected empty results, got %s, %s", engine, status)
+	result = headers.ParseResultHeader("")
+	if result.Engine != "" || result.Status != "" {
+		t.Errorf("expected empty results, got %s, %s", result.Engine, result.Status)
 	}
-	engine, status = parseResultHeader("junk; status=hit")
-	if engine != "" || status != "hit" {
-		t.Errorf("unexpected parse result: %s, %s", engine, status)
+	result = headers.ParseResultHeader("junk; status=hit")
+	if result.Engine != "" || result.Status != "hit" {
+		t.Errorf("unexpected parse result: %s, %s", result.Engine, result.Status)
 	}
 }
 

--- a/pkg/observability/logging/accesslog/accesslog_test.go
+++ b/pkg/observability/logging/accesslog/accesslog_test.go
@@ -26,7 +26,9 @@ import (
 	"time"
 
 	alo "github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/options"
+	authtypes "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 )
 
 func testLoggerOptions(t *testing.T) *alo.Options {
@@ -92,6 +94,10 @@ func TestMiddlewareAccessAndErrorLogs(t *testing.T) {
 		t.Fatal(err)
 	}
 	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/fail" {
+			request.GetResources(r).AuthResult = &authtypes.AuthResult{
+				Status: authtypes.AuthSuccess, Username: "frank"}
+		}
 		w.Header().Set(headers.NameTricksterResult, "engine=HTTPProxy; status=hit")
 		if r.URL.Path == "/fail" {
 			w.WriteHeader(http.StatusBadGateway)
@@ -189,6 +195,59 @@ func TestMiddlewareNilLogger(t *testing.T) {
 	h.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/", nil))
 	if !called {
 		t.Error("expected next handler to be called")
+	}
+}
+
+func TestMiddlewareUsesAuthenticatedUsername(t *testing.T) {
+	o := testLoggerOptions(t)
+	o.ErrorFilename = ""
+	o.Format = "%u"
+	l, err := NewLogger(o, 0, "b", "p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := Middleware(l, "/", http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/verified" {
+				request.GetResources(r).AuthResult = &authtypes.AuthResult{
+					Status: authtypes.AuthSuccess, Username: "verified"}
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+	unverified := httptest.NewRequest(http.MethodGet, "/unverified", nil)
+	unverified.SetBasicAuth("asserted", "wrong")
+	h.ServeHTTP(httptest.NewRecorder(), unverified)
+	h.ServeHTTP(httptest.NewRecorder(),
+		httptest.NewRequest(http.MethodGet, "/verified", nil))
+	l.Close()
+	if s := readFile(t, o.Filename); s != "-\nverified\n" {
+		t.Errorf("unexpected authenticated users: %q", s)
+	}
+}
+
+type flushRecorder struct {
+	*httptest.ResponseRecorder
+	flushed bool
+}
+
+func (r *flushRecorder) Flush() {
+	r.flushed = true
+}
+
+func TestRecorderUnwrap(t *testing.T) {
+	base := &flushRecorder{ResponseRecorder: httptest.NewRecorder()}
+	rec := &recorder{ResponseWriter: base, status: http.StatusOK}
+	if err := http.NewResponseController(rec).Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if !base.flushed {
+		t.Error("expected flush to reach the underlying writer")
+	}
+	rec2 := &recorder{ResponseWriter: httptest.NewRecorder(), status: http.StatusOK}
+	rec2.WriteHeader(http.StatusCreated)
+	rec2.WriteHeader(http.StatusInternalServerError)
+	if rec2.status != http.StatusCreated {
+		t.Errorf("recorded status = %d, want %d", rec2.status, http.StatusCreated)
 	}
 }
 

--- a/pkg/observability/logging/accesslog/format/errors.go
+++ b/pkg/observability/logging/accesslog/format/errors.go
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import "errors"
+
+// ErrInvalidFormatToken is returned when a format string contains an
+// unknown or malformed %-token
+var ErrInvalidFormatToken = errors.New("invalid access log format token")

--- a/pkg/observability/logging/accesslog/format/fields.go
+++ b/pkg/observability/logging/accesslog/format/fields.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package format compiles Apache-style %-token access log format strings
+// into fast per-request line renderers.
+package format
+
+import (
+	"net/http"
+	"time"
+)
+
+// Fields holds the per-request values available to access log tokens
+type Fields struct {
+	// StartTime is when the request was received
+	StartTime time.Time
+	// Duration is the total time taken to serve the request
+	Duration time.Duration
+	// ClientIP is the requesting client's IP address without port
+	ClientIP string
+	// User is the authenticated username, if any
+	User string
+	// Method is the HTTP request method
+	Method string
+	// RequestURI is the original request URI (path + query)
+	RequestURI string
+	// Path is the request URL path
+	Path string
+	// Query is the raw query string without the leading '?'
+	Query string
+	// Proto is the request protocol (e.g., HTTP/1.1)
+	Proto string
+	// Host is the requested virtual host
+	Host string
+	// LocalIP is the IP of the listener that accepted the request
+	LocalIP string
+	// LocalPort is the port of the listener that accepted the request
+	LocalPort string
+	// Status is the response status code
+	Status int
+	// BytesWritten is the number of response body bytes written
+	BytesWritten int64
+	// ReqHeader is the request header collection
+	ReqHeader http.Header
+	// RespHeader is the response header collection
+	RespHeader http.Header
+	// Backend is the Trickster backend name that served the request
+	Backend string
+	// Provider is the backend provider type
+	Provider string
+	// PathConfig is the matched path configuration's path
+	PathConfig string
+	// CacheStatus is the cache result (hit, phit, kmiss, ...)
+	CacheStatus string
+	// Engine is the proxy engine that handled the request
+	Engine string
+}

--- a/pkg/observability/logging/accesslog/format/format.go
+++ b/pkg/observability/logging/accesslog/format/format.go
@@ -22,12 +22,18 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 )
 
-// clfTimeLayout is the NCSA Common Log Format timestamp layout
 const clfTimeLayout = "02/Jan/2006:15:04:05 -0700"
 
-const dash = "-"
+const (
+	dash          = "-"
+	headerCookie  = "Cookie"
+	headerReferer = "Referer"
+)
 
 // Named format presets; "combined" is the default
 const (
@@ -50,7 +56,8 @@ type emitter func(b []byte, f *Fields) []byte
 
 // Formatter renders a compiled access log format for a request's Fields
 type Formatter struct {
-	emitters []emitter
+	emitters          []emitter
+	needsResultHeader bool
 }
 
 // Render appends the formatted log line, including a trailing newline, to b
@@ -68,7 +75,7 @@ func ParseFormat(input string) (*Formatter, error) {
 		input = DefaultFormatName
 	}
 	if input == JSON {
-		return &Formatter{emitters: jsonEmitters()}, nil
+		return &Formatter{emitters: jsonEmitters(), needsResultHeader: true}, nil
 	}
 	if p, ok := presets[input]; ok {
 		input = p
@@ -124,10 +131,18 @@ func ParseFormat(input string) (*Formatter, error) {
 		}
 		flushLiteral()
 		fm.emitters = append(fm.emitters, e)
+		if hasArg && input[i] == 'x' && (arg == "engine" || arg == "cache-status") {
+			fm.needsResultHeader = true
+		}
 		i++
 	}
 	flushLiteral()
 	return fm, nil
+}
+
+// NeedsResultHeader reports whether this format emits result-header fields.
+func (fm *Formatter) NeedsResultHeader() bool {
+	return fm != nil && fm.needsResultHeader
 }
 
 func compileToken(token byte, arg string, hasArg bool) (emitter, error) {
@@ -332,7 +347,7 @@ func appendHeader(b []byte, h http.Header, key string) []byte {
 
 func appendCookie(b []byte, h http.Header, name string) []byte {
 	if h != nil {
-		if cookies, err := http.ParseCookie(h.Get("Cookie")); err == nil {
+		if cookies, err := http.ParseCookie(h.Get(headerCookie)); err == nil {
 			for _, c := range cookies {
 				if c.Name == name {
 					return appendEscapedOrDash(b, c.Value)
@@ -343,8 +358,6 @@ func appendCookie(b []byte, h http.Header, name string) []byte {
 	return append(b, dash...)
 }
 
-// appendEscaped appends s, backslash-escaping quotes, backslashes and
-// control bytes so untrusted values cannot corrupt the log line structure
 func appendEscaped(b []byte, s string) []byte {
 	if !needsEscape(s) {
 		return append(b, s...)
@@ -380,7 +393,6 @@ func needsEscape(s string) bool {
 	return false
 }
 
-// jsonEmitters returns the emitter chain for the fixed-field json preset
 func jsonEmitters() []emitter {
 	fields := []struct {
 		key  string
@@ -422,10 +434,10 @@ func jsonEmitters() []emitter {
 			return appendJSONString(b, f.Host)
 		}},
 		{"referer", func(b []byte, f *Fields) []byte {
-			return appendJSONHeader(b, f.ReqHeader, "Referer")
+			return appendJSONHeader(b, f.ReqHeader, headerReferer)
 		}},
 		{"user_agent", func(b []byte, f *Fields) []byte {
-			return appendJSONHeader(b, f.ReqHeader, "User-Agent")
+			return appendJSONHeader(b, f.ReqHeader, headers.NameUserAgent)
 		}},
 		{"backend", func(b []byte, f *Fields) []byte {
 			return appendJSONString(b, f.Backend)
@@ -461,12 +473,72 @@ func jsonEmitters() []emitter {
 }
 
 func appendJSONString(b []byte, s string) []byte {
-	return strconv.AppendQuote(b, s)
+	b = append(b, '"')
+	if !needsJSONEscape(s) {
+		b = append(b, s...)
+		return append(b, '"')
+	}
+	for len(s) > 0 {
+		c := s[0]
+		if c < utf8.RuneSelf {
+			s = s[1:]
+			switch c {
+			case '"', '\\':
+				b = append(b, '\\', c)
+			case '\b':
+				b = append(b, `\b`...)
+			case '\f':
+				b = append(b, `\f`...)
+			case '\n':
+				b = append(b, `\n`...)
+			case '\r':
+				b = append(b, `\r`...)
+			case '\t':
+				b = append(b, `\t`...)
+			default:
+				if c < 0x20 {
+					const hex = "0123456789abcdef"
+					b = append(b, '\\', 'u', '0', '0', hex[c>>4], hex[c&0xf])
+				} else {
+					b = append(b, c)
+				}
+			}
+			continue
+		}
+		_, size := utf8.DecodeRuneInString(s)
+		if size == 1 {
+			b = append(b, `\ufffd`...)
+			s = s[1:]
+			continue
+		}
+		b = append(b, s[:size]...)
+		s = s[size:]
+	}
+	return append(b, '"')
+}
+
+func needsJSONEscape(s string) bool {
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c < utf8.RuneSelf {
+			if c < 0x20 || c == '"' || c == '\\' {
+				return true
+			}
+			i++
+			continue
+		}
+		_, size := utf8.DecodeRuneInString(s[i:])
+		if size == 1 {
+			return true
+		}
+		i += size
+	}
+	return false
 }
 
 func appendJSONHeader(b []byte, h http.Header, key string) []byte {
 	if h == nil {
 		return append(b, `""`...)
 	}
-	return strconv.AppendQuote(b, h.Get(key))
+	return appendJSONString(b, h.Get(key))
 }

--- a/pkg/observability/logging/accesslog/format/format.go
+++ b/pkg/observability/logging/accesslog/format/format.go
@@ -1,0 +1,472 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// clfTimeLayout is the NCSA Common Log Format timestamp layout
+const clfTimeLayout = "02/Jan/2006:15:04:05 -0700"
+
+const dash = "-"
+
+// Named format presets; "combined" is the default
+const (
+	Common   = "common"
+	Combined = "combined"
+	Extended = "extended"
+	JSON     = "json"
+
+	DefaultFormatName = Combined
+)
+
+var presets = map[string]string{
+	Common:   `%h %l %u %t "%r" %>s %b`,
+	Combined: `%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"`,
+	Extended: `%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"` +
+		` %{ms}T %{cache-status}x %{backend}x`,
+}
+
+type emitter func(b []byte, f *Fields) []byte
+
+// Formatter renders a compiled access log format for a request's Fields
+type Formatter struct {
+	emitters []emitter
+}
+
+// Render appends the formatted log line, including a trailing newline, to b
+func (fm *Formatter) Render(b []byte, f *Fields) []byte {
+	for _, e := range fm.emitters {
+		b = e(b, f)
+	}
+	return append(b, '\n')
+}
+
+// ParseFormat compiles a named preset or custom %-token format string into
+// a Formatter; unknown tokens return an error
+func ParseFormat(input string) (*Formatter, error) {
+	if input == "" {
+		input = DefaultFormatName
+	}
+	if input == JSON {
+		return &Formatter{emitters: jsonEmitters()}, nil
+	}
+	if p, ok := presets[input]; ok {
+		input = p
+	}
+	fm := &Formatter{emitters: make([]emitter, 0, 16)}
+	var literal strings.Builder
+	flushLiteral := func() {
+		if literal.Len() > 0 {
+			s := literal.String()
+			literal.Reset()
+			fm.emitters = append(fm.emitters, func(b []byte, _ *Fields) []byte {
+				return append(b, s...)
+			})
+		}
+	}
+	for i := 0; i < len(input); {
+		c := input[i]
+		if c != '%' {
+			literal.WriteByte(c)
+			i++
+			continue
+		}
+		i++
+		if i >= len(input) {
+			return nil, fmt.Errorf("%w: trailing %%", ErrInvalidFormatToken)
+		}
+		var arg string
+		var hasArg bool
+		switch input[i] {
+		case '{':
+			end := strings.IndexByte(input[i:], '}')
+			if end < 0 {
+				return nil, fmt.Errorf("%w: unterminated %%{", ErrInvalidFormatToken)
+			}
+			arg = input[i+1 : i+end]
+			hasArg = true
+			i += end + 1
+			if i >= len(input) {
+				return nil, fmt.Errorf("%w: %%{%s} missing token letter",
+					ErrInvalidFormatToken, arg)
+			}
+		case '>':
+			// the Apache "final status" modifier; equivalent to %s here
+			i++
+			if i >= len(input) || input[i] != 's' {
+				return nil, fmt.Errorf("%w: %%> must be followed by s",
+					ErrInvalidFormatToken)
+			}
+		}
+		e, err := compileToken(input[i], arg, hasArg)
+		if err != nil {
+			return nil, err
+		}
+		flushLiteral()
+		fm.emitters = append(fm.emitters, e)
+		i++
+	}
+	flushLiteral()
+	return fm, nil
+}
+
+func compileToken(token byte, arg string, hasArg bool) (emitter, error) {
+	if hasArg {
+		return compileArgToken(token, arg)
+	}
+	switch token {
+	case '%':
+		return func(b []byte, _ *Fields) []byte { return append(b, '%') }, nil
+	case 'h', 'a':
+		return func(b []byte, f *Fields) []byte {
+			return appendOrDash(b, f.ClientIP)
+		}, nil
+	case 'l':
+		return func(b []byte, _ *Fields) []byte { return append(b, dash...) }, nil
+	case 'u':
+		return func(b []byte, f *Fields) []byte {
+			return appendEscapedOrDash(b, f.User)
+		}, nil
+	case 't':
+		return func(b []byte, f *Fields) []byte {
+			b = append(b, '[')
+			b = f.StartTime.AppendFormat(b, clfTimeLayout)
+			return append(b, ']')
+		}, nil
+	case 'r':
+		return func(b []byte, f *Fields) []byte {
+			b = appendEscaped(b, f.Method)
+			b = append(b, ' ')
+			b = appendEscaped(b, f.RequestURI)
+			b = append(b, ' ')
+			return appendEscaped(b, f.Proto)
+		}, nil
+	case 'm':
+		return func(b []byte, f *Fields) []byte {
+			return appendOrDash(b, f.Method)
+		}, nil
+	case 'U':
+		return func(b []byte, f *Fields) []byte {
+			return appendEscapedOrDash(b, f.Path)
+		}, nil
+	case 'q':
+		return func(b []byte, f *Fields) []byte {
+			if f.Query == "" {
+				return b
+			}
+			b = append(b, '?')
+			return appendEscaped(b, f.Query)
+		}, nil
+	case 'H':
+		return func(b []byte, f *Fields) []byte {
+			return appendOrDash(b, f.Proto)
+		}, nil
+	case 's':
+		return func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, int64(f.Status), 10)
+		}, nil
+	case 'b':
+		return func(b []byte, f *Fields) []byte {
+			if f.BytesWritten == 0 {
+				return append(b, dash...)
+			}
+			return strconv.AppendInt(b, f.BytesWritten, 10)
+		}, nil
+	case 'B':
+		return func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, f.BytesWritten, 10)
+		}, nil
+	case 'D':
+		return func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, f.Duration.Microseconds(), 10)
+		}, nil
+	case 'T':
+		return func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, int64(f.Duration/time.Second), 10)
+		}, nil
+	case 'v':
+		return func(b []byte, f *Fields) []byte {
+			return appendEscapedOrDash(b, f.Host)
+		}, nil
+	case 'p':
+		return func(b []byte, f *Fields) []byte {
+			return appendOrDash(b, f.LocalPort)
+		}, nil
+	case 'A':
+		return func(b []byte, f *Fields) []byte {
+			return appendOrDash(b, f.LocalIP)
+		}, nil
+	}
+	return nil, fmt.Errorf("%w: %%%s", ErrInvalidFormatToken, string(token))
+}
+
+func compileArgToken(token byte, arg string) (emitter, error) {
+	switch token {
+	case 'i':
+		key := http.CanonicalHeaderKey(arg)
+		return func(b []byte, f *Fields) []byte {
+			return appendHeader(b, f.ReqHeader, key)
+		}, nil
+	case 'o':
+		key := http.CanonicalHeaderKey(arg)
+		return func(b []byte, f *Fields) []byte {
+			return appendHeader(b, f.RespHeader, key)
+		}, nil
+	case 'c':
+		return func(b []byte, f *Fields) []byte {
+			return appendCookie(b, f.ReqHeader, arg)
+		}, nil
+	case 't':
+		return compileTimeToken(arg)
+	case 'T':
+		switch arg {
+		case "us":
+			return func(b []byte, f *Fields) []byte {
+				return strconv.AppendInt(b, f.Duration.Microseconds(), 10)
+			}, nil
+		case "ms":
+			return func(b []byte, f *Fields) []byte {
+				return strconv.AppendInt(b, f.Duration.Milliseconds(), 10)
+			}, nil
+		case "s":
+			return func(b []byte, f *Fields) []byte {
+				return strconv.AppendInt(b, int64(f.Duration/time.Second), 10)
+			}, nil
+		}
+		return nil, fmt.Errorf("%w: %%{%s}T", ErrInvalidFormatToken, arg)
+	case 'x':
+		return compileExtensionToken(arg)
+	}
+	return nil, fmt.Errorf("%w: %%{%s}%s", ErrInvalidFormatToken, arg, string(token))
+}
+
+func compileTimeToken(arg string) (emitter, error) {
+	switch arg {
+	case "sec":
+		return func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, f.StartTime.Unix(), 10)
+		}, nil
+	case "msec":
+		return func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, f.StartTime.UnixMilli(), 10)
+		}, nil
+	case "usec":
+		return func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, f.StartTime.UnixMicro(), 10)
+		}, nil
+	case "":
+		return nil, fmt.Errorf("%w: %%{}t", ErrInvalidFormatToken)
+	}
+	// any other argument is a Go time layout
+	return func(b []byte, f *Fields) []byte {
+		return f.StartTime.AppendFormat(b, arg)
+	}, nil
+}
+
+func compileExtensionToken(arg string) (emitter, error) {
+	switch arg {
+	case "backend":
+		return func(b []byte, f *Fields) []byte {
+			return appendOrDash(b, f.Backend)
+		}, nil
+	case "provider":
+		return func(b []byte, f *Fields) []byte {
+			return appendOrDash(b, f.Provider)
+		}, nil
+	case "cache-status":
+		return func(b []byte, f *Fields) []byte {
+			return appendOrDash(b, f.CacheStatus)
+		}, nil
+	case "engine":
+		return func(b []byte, f *Fields) []byte {
+			return appendOrDash(b, f.Engine)
+		}, nil
+	case "path-config":
+		return func(b []byte, f *Fields) []byte {
+			return appendEscapedOrDash(b, f.PathConfig)
+		}, nil
+	}
+	return nil, fmt.Errorf("%w: %%{%s}x", ErrInvalidFormatToken, arg)
+}
+
+func appendOrDash(b []byte, s string) []byte {
+	if s == "" {
+		return append(b, dash...)
+	}
+	return append(b, s...)
+}
+
+func appendEscapedOrDash(b []byte, s string) []byte {
+	if s == "" {
+		return append(b, dash...)
+	}
+	return appendEscaped(b, s)
+}
+
+func appendHeader(b []byte, h http.Header, key string) []byte {
+	if h == nil {
+		return append(b, dash...)
+	}
+	return appendEscapedOrDash(b, h.Get(key))
+}
+
+func appendCookie(b []byte, h http.Header, name string) []byte {
+	if h != nil {
+		if cookies, err := http.ParseCookie(h.Get("Cookie")); err == nil {
+			for _, c := range cookies {
+				if c.Name == name {
+					return appendEscapedOrDash(b, c.Value)
+				}
+			}
+		}
+	}
+	return append(b, dash...)
+}
+
+// appendEscaped appends s, backslash-escaping quotes, backslashes and
+// control bytes so untrusted values cannot corrupt the log line structure
+func appendEscaped(b []byte, s string) []byte {
+	if !needsEscape(s) {
+		return append(b, s...)
+	}
+	for i := range len(s) {
+		c := s[i]
+		switch {
+		case c == '"' || c == '\\':
+			b = append(b, '\\', c)
+		case c == '\n':
+			b = append(b, '\\', 'n')
+		case c == '\r':
+			b = append(b, '\\', 'r')
+		case c == '\t':
+			b = append(b, '\\', 't')
+		case c < 0x20:
+			b = append(b, '\\', 'x')
+			const hex = "0123456789abcdef"
+			b = append(b, hex[c>>4], hex[c&0xf])
+		default:
+			b = append(b, c)
+		}
+	}
+	return b
+}
+
+func needsEscape(s string) bool {
+	for i := range len(s) {
+		if s[i] < 0x20 || s[i] == '"' || s[i] == '\\' {
+			return true
+		}
+	}
+	return false
+}
+
+// jsonEmitters returns the emitter chain for the fixed-field json preset
+func jsonEmitters() []emitter {
+	fields := []struct {
+		key  string
+		emit emitter
+	}{
+		{"time", func(b []byte, f *Fields) []byte {
+			b = append(b, '"')
+			b = f.StartTime.UTC().AppendFormat(b, time.RFC3339Nano)
+			return append(b, '"')
+		}},
+		{"client_ip", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.ClientIP)
+		}},
+		{"user", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.User)
+		}},
+		{"method", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.Method)
+		}},
+		{"path", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.Path)
+		}},
+		{"query", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.Query)
+		}},
+		{"proto", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.Proto)
+		}},
+		{"status", func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, int64(f.Status), 10)
+		}},
+		{"bytes", func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, f.BytesWritten, 10)
+		}},
+		{"duration_ms", func(b []byte, f *Fields) []byte {
+			return strconv.AppendInt(b, f.Duration.Milliseconds(), 10)
+		}},
+		{"host", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.Host)
+		}},
+		{"referer", func(b []byte, f *Fields) []byte {
+			return appendJSONHeader(b, f.ReqHeader, "Referer")
+		}},
+		{"user_agent", func(b []byte, f *Fields) []byte {
+			return appendJSONHeader(b, f.ReqHeader, "User-Agent")
+		}},
+		{"backend", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.Backend)
+		}},
+		{"provider", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.Provider)
+		}},
+		{"path_config", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.PathConfig)
+		}},
+		{"cache_status", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.CacheStatus)
+		}},
+		{"engine", func(b []byte, f *Fields) []byte {
+			return appendJSONString(b, f.Engine)
+		}},
+	}
+	out := make([]emitter, 0, len(fields)+1)
+	for i, fd := range fields {
+		prefix := `,"` + fd.key + `":`
+		if i == 0 {
+			prefix = `{"` + fd.key + `":`
+		}
+		emit := fd.emit
+		out = append(out, func(b []byte, f *Fields) []byte {
+			return emit(append(b, prefix...), f)
+		})
+	}
+	out = append(out, func(b []byte, _ *Fields) []byte {
+		return append(b, '}')
+	})
+	return out
+}
+
+func appendJSONString(b []byte, s string) []byte {
+	return strconv.AppendQuote(b, s)
+}
+
+func appendJSONHeader(b []byte, h http.Header, key string) []byte {
+	if h == nil {
+		return append(b, `""`...)
+	}
+	return strconv.AppendQuote(b, h.Get(key))
+}

--- a/pkg/observability/logging/accesslog/format/format_test.go
+++ b/pkg/observability/logging/accesslog/format/format_test.go
@@ -218,6 +218,26 @@ func TestJSONPreset(t *testing.T) {
 	}
 }
 
+func TestJSONPresetEscapesInvalidInput(t *testing.T) {
+	f := testFields()
+	f.Path = "/\x01\xff\b\f"
+	f.ReqHeader.Set("User-Agent", "agent\x80\v")
+	out := render(t, JSON, f)
+	if !json.Valid([]byte(out)) {
+		t.Fatalf("json preset produced invalid JSON: %q", out)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["path"] != "/\x01�\b\f" {
+		t.Errorf("unexpected escaped path: %q", got["path"])
+	}
+	if got["user_agent"] != "agent�\v" {
+		t.Errorf("unexpected escaped user agent: %q", got["user_agent"])
+	}
+}
+
 func TestEscaping(t *testing.T) {
 	f := testFields()
 	f.User = `fr"ank\`
@@ -250,6 +270,26 @@ func TestRenderReusesBuffer(t *testing.T) {
 	b2 := fm.Render(b[:0], f)
 	if string(b2) != "GET 200\n" {
 		t.Errorf("unexpected render output: %q", string(b2))
+	}
+}
+
+func TestNeedsResultHeader(t *testing.T) {
+	for _, tc := range []struct {
+		format string
+		want   bool
+	}{
+		{format: "%m %s"},
+		{format: "%{engine}x", want: true},
+		{format: "%{cache-status}x", want: true},
+		{format: JSON, want: true},
+	} {
+		fm, err := ParseFormat(tc.format)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := fm.NeedsResultHeader(); got != tc.want {
+			t.Errorf("format %q needs result = %t, want %t", tc.format, got, tc.want)
+		}
 	}
 }
 

--- a/pkg/observability/logging/accesslog/format/format_test.go
+++ b/pkg/observability/logging/accesslog/format/format_test.go
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testFields() *Fields {
+	return &Fields{
+		StartTime:    time.Date(2026, 8, 26, 10, 30, 0, 0, time.UTC),
+		Duration:     1503 * time.Millisecond,
+		ClientIP:     "203.0.113.9",
+		User:         "frank",
+		Method:       http.MethodGet,
+		RequestURI:   "/api/query?q=up",
+		Path:         "/api/query",
+		Query:        "q=up",
+		Proto:        "HTTP/1.1",
+		Host:         "example.com",
+		LocalIP:      "10.0.0.1",
+		LocalPort:    "8480",
+		Status:       200,
+		BytesWritten: 2326,
+		ReqHeader: http.Header{
+			"Referer":    []string{"http://example.com/start.html"},
+			"User-Agent": []string{"test-agent/1.0"},
+			"Cookie":     []string{"session=abc123; theme=dark"},
+		},
+		RespHeader: http.Header{
+			"Content-Type": []string{"application/json"},
+		},
+		Backend:     "example1",
+		Provider:    "rp",
+		PathConfig:  "/api",
+		CacheStatus: "phit",
+		Engine:      "DeltaProxyCache",
+	}
+}
+
+func render(t *testing.T, formatStr string, f *Fields) string {
+	t.Helper()
+	fm, err := ParseFormat(formatStr)
+	if err != nil {
+		t.Fatalf("format %q: %v", formatStr, err)
+	}
+	return string(fm.Render(nil, f))
+}
+
+func TestTokens(t *testing.T) {
+	f := testFields()
+	tests := []struct {
+		format   string
+		expected string
+	}{
+		{"%h", "203.0.113.9"},
+		{"%a", "203.0.113.9"},
+		{"%l", "-"},
+		{"%u", "frank"},
+		{"%t", "[26/Aug/2026:10:30:00 +0000]"},
+		{"%r", "GET /api/query?q=up HTTP/1.1"},
+		{"%m", "GET"},
+		{"%U", "/api/query"},
+		{"%q", "?q=up"},
+		{"%H", "HTTP/1.1"},
+		{"%s", "200"},
+		{"%>s", "200"},
+		{"%b", "2326"},
+		{"%B", "2326"},
+		{"%D", "1503000"},
+		{"%T", "1"},
+		{"%{us}T", "1503000"},
+		{"%{ms}T", "1503"},
+		{"%{s}T", "1"},
+		{"%{sec}t", "1787740200"},
+		{"%{msec}t", "1787740200000"},
+		{"%{usec}t", "1787740200000000"},
+		{"%{2006-01-02}t", "2026-08-26"},
+		{"%{Referer}i", "http://example.com/start.html"},
+		{"%{user-agent}i", "test-agent/1.0"},
+		{"%{Missing}i", "-"},
+		{"%{Content-Type}o", "application/json"},
+		{"%{Missing}o", "-"},
+		{"%{session}c", "abc123"},
+		{"%{theme}c", "dark"},
+		{"%{missing}c", "-"},
+		{"%v", "example.com"},
+		{"%p", "8480"},
+		{"%A", "10.0.0.1"},
+		{"%%", "%"},
+		{"%{backend}x", "example1"},
+		{"%{provider}x", "rp"},
+		{"%{cache-status}x", "phit"},
+		{"%{engine}x", "DeltaProxyCache"},
+		{"%{path-config}x", "/api"},
+		{"literal only", "literal only"},
+		{"a %m b", "a GET b"},
+	}
+	for _, test := range tests {
+		if out := render(t, test.format, f); out != test.expected+"\n" {
+			t.Errorf("format %q: expected %q, got %q",
+				test.format, test.expected+"\n", out)
+		}
+	}
+}
+
+func TestEmptyFieldTokens(t *testing.T) {
+	f := &Fields{}
+	tests := []struct {
+		format   string
+		expected string
+	}{
+		{"%h", "-"},
+		{"%u", "-"},
+		{"%b", "-"},
+		{"%B", "0"},
+		{"%q", ""},
+		{"%{User-Agent}i", "-"},
+		{"%{Set-Cookie}o", "-"},
+		{"%{session}c", "-"},
+		{"%{cache-status}x", "-"},
+		{"%{engine}x", "-"},
+	}
+	for _, test := range tests {
+		if out := render(t, test.format, f); out != test.expected+"\n" {
+			t.Errorf("format %q: expected %q, got %q",
+				test.format, test.expected+"\n", out)
+		}
+	}
+}
+
+var clfRegex = regexp.MustCompile(
+	`^(\S+) (\S+) (\S+) \[([^\]]+)\] "([^"]*)" (\d{3}) (\d+|-)`)
+
+func TestCommonPresetCLFConformance(t *testing.T) {
+	out := strings.TrimSuffix(render(t, Common, testFields()), "\n")
+	m := clfRegex.FindStringSubmatch(out)
+	if m == nil {
+		t.Fatalf("common preset line does not parse as CLF: %q", out)
+	}
+	if m[1] != "203.0.113.9" || m[3] != "frank" || m[6] != "200" || m[7] != "2326" {
+		t.Errorf("unexpected CLF values: %v", m[1:])
+	}
+}
+
+func TestCombinedPreset(t *testing.T) {
+	out := render(t, Combined, testFields())
+	expected := `203.0.113.9 - frank [26/Aug/2026:10:30:00 +0000] ` +
+		`"GET /api/query?q=up HTTP/1.1" 200 2326 ` +
+		`"http://example.com/start.html" "test-agent/1.0"` + "\n"
+	if out != expected {
+		t.Errorf("expected %q, got %q", expected, out)
+	}
+}
+
+func TestExtendedPreset(t *testing.T) {
+	out := render(t, Extended, testFields())
+	if !strings.Contains(out, " 1503 phit example1\n") {
+		t.Errorf("unexpected extended preset output: %q", out)
+	}
+}
+
+func TestDefaultFormatIsCombined(t *testing.T) {
+	f := testFields()
+	if render(t, "", f) != render(t, Combined, f) {
+		t.Error("expected empty format to resolve to combined")
+	}
+}
+
+func TestJSONPreset(t *testing.T) {
+	out := render(t, JSON, testFields())
+	var m map[string]any
+	if err := json.Unmarshal([]byte(out), &m); err != nil {
+		t.Fatalf("json preset produced invalid JSON: %v: %q", err, out)
+	}
+	expected := map[string]any{
+		"client_ip":    "203.0.113.9",
+		"user":         "frank",
+		"method":       "GET",
+		"path":         "/api/query",
+		"query":        "q=up",
+		"status":       float64(200),
+		"bytes":        float64(2326),
+		"duration_ms":  float64(1503),
+		"host":         "example.com",
+		"user_agent":   "test-agent/1.0",
+		"backend":      "example1",
+		"cache_status": "phit",
+		"engine":       "DeltaProxyCache",
+	}
+	for k, v := range expected {
+		if m[k] != v {
+			t.Errorf("json field %s: expected %v, got %v", k, v, m[k])
+		}
+	}
+	if _, ok := m["time"]; !ok {
+		t.Error("expected time field in json output")
+	}
+}
+
+func TestEscaping(t *testing.T) {
+	f := testFields()
+	f.User = `fr"ank\`
+	f.RequestURI = "/x\ny\r\tz\x01"
+	out := render(t, `%u "%r"`, f)
+	expected := `fr\"ank\\ "GET /x\ny\r\tz\x01 HTTP/1.1"` + "\n"
+	if out != expected {
+		t.Errorf("expected %q, got %q", expected, out)
+	}
+}
+
+func TestParseFormatErrors(t *testing.T) {
+	for _, s := range []string{
+		"%", "%Z", "%{Referer", "%{Referer}", "%{Referer}Z", "%>x", "%>",
+		"%{}t", "%{nope}T", "%{nope}x", "trailing %",
+	} {
+		if _, err := ParseFormat(s); !errors.Is(err, ErrInvalidFormatToken) {
+			t.Errorf("format %q: expected ErrInvalidFormatToken, got %v", s, err)
+		}
+	}
+}
+
+func TestRenderReusesBuffer(t *testing.T) {
+	fm, err := ParseFormat("%m %s")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f := testFields()
+	b := fm.Render(make([]byte, 0, 64), f)
+	b2 := fm.Render(b[:0], f)
+	if string(b2) != "GET 200\n" {
+		t.Errorf("unexpected render output: %q", string(b2))
+	}
+}
+
+func FuzzParseFormat(f *testing.F) {
+	for _, seed := range []string{
+		presets[Common], presets[Combined], presets[Extended],
+		"%{Referer}i %% %{sec}t", "%", "%{", "plain",
+	} {
+		f.Add(seed)
+	}
+	fields := testFieldsForFuzz()
+	f.Fuzz(func(t *testing.T, input string) {
+		fm, err := ParseFormat(input)
+		if err != nil {
+			return
+		}
+		// a successfully parsed format must render without panicking
+		fm.Render(nil, fields)
+	})
+}
+
+func testFieldsForFuzz() *Fields {
+	return &Fields{
+		StartTime: time.Unix(1700000000, 0),
+		ReqHeader: http.Header{"Cookie": []string{"a=b"}},
+	}
+}

--- a/pkg/observability/logging/accesslog/generation.go
+++ b/pkg/observability/logging/accesslog/generation.go
@@ -21,23 +21,19 @@ import (
 	"time"
 )
 
-// generations tracks the Loggers created during the current config
-// (re)load so that a reload can retire the previous config's Loggers
 var generations = struct {
 	sync.Mutex
 	current  []*Logger
 	previous []*Logger
 }{}
 
-// track is called by NewLogger to register l in the current generation
 func track(l *Logger) {
 	generations.Lock()
 	generations.current = append(generations.current, l)
 	generations.Unlock()
 }
 
-// BeginGeneration moves the current generation of Loggers to the previous
-// set; call before registering routes for a new or reloaded config
+// BeginGeneration starts tracking loggers for a new configuration.
 func BeginGeneration() {
 	generations.Lock()
 	generations.previous = append(generations.previous, generations.current...)
@@ -45,8 +41,7 @@ func BeginGeneration() {
 	generations.Unlock()
 }
 
-// CommitGeneration closes the previous generation of Loggers after the
-// provided drain delay; call after a successful config (re)load
+// CommitGeneration closes the previous logger generation after delay.
 func CommitGeneration(delay time.Duration) {
 	generations.Lock()
 	toClose := generations.previous
@@ -63,8 +58,7 @@ func CommitGeneration(delay time.Duration) {
 	}()
 }
 
-// AbortGeneration closes any Loggers created during a failed config
-// (re)load and restores the previous generation as current
+// AbortGeneration closes new loggers and restores the previous generation.
 func AbortGeneration() {
 	generations.Lock()
 	toClose := generations.current

--- a/pkg/observability/logging/accesslog/generation.go
+++ b/pkg/observability/logging/accesslog/generation.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accesslog
+
+import (
+	"sync"
+	"time"
+)
+
+// generations tracks the Loggers created during the current config
+// (re)load so that a reload can retire the previous config's Loggers
+var generations = struct {
+	sync.Mutex
+	current  []*Logger
+	previous []*Logger
+}{}
+
+// track is called by NewLogger to register l in the current generation
+func track(l *Logger) {
+	generations.Lock()
+	generations.current = append(generations.current, l)
+	generations.Unlock()
+}
+
+// BeginGeneration moves the current generation of Loggers to the previous
+// set; call before registering routes for a new or reloaded config
+func BeginGeneration() {
+	generations.Lock()
+	generations.previous = append(generations.previous, generations.current...)
+	generations.current = nil
+	generations.Unlock()
+}
+
+// CommitGeneration closes the previous generation of Loggers after the
+// provided drain delay; call after a successful config (re)load
+func CommitGeneration(delay time.Duration) {
+	generations.Lock()
+	toClose := generations.previous
+	generations.previous = nil
+	generations.Unlock()
+	if len(toClose) == 0 {
+		return
+	}
+	go func() {
+		time.Sleep(delay)
+		for _, l := range toClose {
+			l.Close()
+		}
+	}()
+}
+
+// AbortGeneration closes any Loggers created during a failed config
+// (re)load and restores the previous generation as current
+func AbortGeneration() {
+	generations.Lock()
+	toClose := generations.current
+	generations.current = generations.previous
+	generations.previous = nil
+	generations.Unlock()
+	for _, l := range toClose {
+		l.Close()
+	}
+}

--- a/pkg/observability/logging/accesslog/middleware.go
+++ b/pkg/observability/logging/accesslog/middleware.go
@@ -19,24 +19,29 @@ package accesslog
 import (
 	"net"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/format"
 	authtypes "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
+	utilmiddleware "github.com/trickstercache/trickster/v2/pkg/util/middleware"
 )
 
 // Middleware wraps next with a recorder that writes an access log line to
 // the Logger after each request completes
-func Middleware(l *Logger, pathConfig string, next http.Handler) http.Handler {
+func Middleware(l *Logger, pathConfig string, captureAuth bool,
+	next http.Handler,
+) http.Handler {
 	if l == nil {
 		return next
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		rsc := request.GetResources(r)
-		if rsc == nil {
+		var rsc *request.Resources
+		if captureAuth {
+			rsc = request.GetResources(r)
+		}
+		if captureAuth && rsc == nil {
 			rsc = &request.Resources{}
 			r = request.SetResources(r, rsc)
 		}
@@ -55,47 +60,22 @@ func Middleware(l *Logger, pathConfig string, next http.Handler) http.Handler {
 		if la, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
 			f.LocalIP, f.LocalPort = splitAddr(la.String())
 		}
-		rec := &recorder{ResponseWriter: w, status: http.StatusOK}
+		rec := utilmiddleware.NewResponseObserver(w)
 		next.ServeHTTP(rec, r)
 		f.Duration = time.Since(f.StartTime)
-		f.Status = rec.status
-		f.BytesWritten = rec.bytes
-		if rsc.AuthResult != nil && rsc.AuthResult.Status == authtypes.AuthSuccess {
+		f.Status = rec.StatusCode()
+		f.BytesWritten = rec.BytesWritten()
+		if rsc != nil && rsc.AuthResult != nil &&
+			rsc.AuthResult.Status == authtypes.AuthSuccess {
 			f.User = rsc.AuthResult.Username
 		}
 		f.RespHeader = w.Header()
-		f.Engine, f.CacheStatus = parseResultHeader(
-			w.Header().Get(headers.NameTricksterResult))
+		if l.NeedsResultHeader() {
+			f.Engine, f.CacheStatus = headers.ParseResultEngineStatus(
+				w.Header().Get(headers.NameTricksterResult))
+		}
 		l.Log(f)
 	})
-}
-
-type recorder struct {
-	http.ResponseWriter
-	status      int
-	bytes       int64
-	wroteHeader bool
-}
-
-func (r *recorder) WriteHeader(statusCode int) {
-	if r.wroteHeader {
-		return
-	}
-	r.wroteHeader = true
-	r.ResponseWriter.WriteHeader(statusCode)
-	r.status = statusCode
-}
-
-func (r *recorder) Write(b []byte) (int, error) {
-	r.wroteHeader = true
-	n, err := r.ResponseWriter.Write(b)
-	r.bytes += int64(n)
-	return n, err
-}
-
-// Unwrap exposes the underlying writer to http.ResponseController.
-func (r *recorder) Unwrap() http.ResponseWriter {
-	return r.ResponseWriter
 }
 
 func clientIP(remoteAddr string) string {
@@ -110,24 +90,4 @@ func splitAddr(addr string) (string, string) {
 		return host, port
 	}
 	return addr, ""
-}
-
-// parseResultHeader extracts the engine and cache status from an
-// X-Trickster-Result header value (e.g., "engine=DeltaProxyCache; status=hit")
-func parseResultHeader(value string) (engine, status string) {
-	for value != "" {
-		var part string
-		part, value, _ = strings.Cut(value, ";")
-		k, v, ok := strings.Cut(strings.TrimSpace(part), "=")
-		if !ok {
-			continue
-		}
-		switch k {
-		case "engine":
-			engine = v
-		case "status":
-			status = v
-		}
-	}
-	return
 }

--- a/pkg/observability/logging/accesslog/middleware.go
+++ b/pkg/observability/logging/accesslog/middleware.go
@@ -23,7 +23,9 @@ import (
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/format"
+	authtypes "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/request"
 )
 
 // Middleware wraps next with a recorder that writes an access log line to
@@ -33,6 +35,11 @@ func Middleware(l *Logger, pathConfig string, next http.Handler) http.Handler {
 		return next
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rsc := request.GetResources(r)
+		if rsc == nil {
+			rsc = &request.Resources{}
+			r = request.SetResources(r, rsc)
+		}
 		f := &format.Fields{
 			StartTime:  time.Now(),
 			Method:     r.Method,
@@ -45,9 +52,6 @@ func Middleware(l *Logger, pathConfig string, next http.Handler) http.Handler {
 			ReqHeader:  r.Header,
 		}
 		f.ClientIP = clientIP(r.RemoteAddr)
-		if u, _, ok := r.BasicAuth(); ok {
-			f.User = u
-		}
 		if la, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
 			f.LocalIP, f.LocalPort = splitAddr(la.String())
 		}
@@ -56,6 +60,9 @@ func Middleware(l *Logger, pathConfig string, next http.Handler) http.Handler {
 		f.Duration = time.Since(f.StartTime)
 		f.Status = rec.status
 		f.BytesWritten = rec.bytes
+		if rsc.AuthResult != nil && rsc.AuthResult.Status == authtypes.AuthSuccess {
+			f.User = rsc.AuthResult.Username
+		}
 		f.RespHeader = w.Header()
 		f.Engine, f.CacheStatus = parseResultHeader(
 			w.Header().Get(headers.NameTricksterResult))
@@ -65,19 +72,30 @@ func Middleware(l *Logger, pathConfig string, next http.Handler) http.Handler {
 
 type recorder struct {
 	http.ResponseWriter
-	status int
-	bytes  int64
+	status      int
+	bytes       int64
+	wroteHeader bool
 }
 
 func (r *recorder) WriteHeader(statusCode int) {
+	if r.wroteHeader {
+		return
+	}
+	r.wroteHeader = true
 	r.ResponseWriter.WriteHeader(statusCode)
 	r.status = statusCode
 }
 
 func (r *recorder) Write(b []byte) (int, error) {
+	r.wroteHeader = true
 	n, err := r.ResponseWriter.Write(b)
 	r.bytes += int64(n)
 	return n, err
+}
+
+// Unwrap exposes the underlying writer to http.ResponseController.
+func (r *recorder) Unwrap() http.ResponseWriter {
+	return r.ResponseWriter
 }
 
 func clientIP(remoteAddr string) string {

--- a/pkg/observability/logging/accesslog/middleware.go
+++ b/pkg/observability/logging/accesslog/middleware.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accesslog
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/format"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+)
+
+// Middleware wraps next with a recorder that writes an access log line to
+// the Logger after each request completes
+func Middleware(l *Logger, pathConfig string, next http.Handler) http.Handler {
+	if l == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f := &format.Fields{
+			StartTime:  time.Now(),
+			Method:     r.Method,
+			RequestURI: r.RequestURI,
+			Path:       r.URL.Path,
+			Query:      r.URL.RawQuery,
+			Proto:      r.Proto,
+			Host:       r.Host,
+			PathConfig: pathConfig,
+			ReqHeader:  r.Header,
+		}
+		f.ClientIP = clientIP(r.RemoteAddr)
+		if u, _, ok := r.BasicAuth(); ok {
+			f.User = u
+		}
+		if la, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr); ok {
+			f.LocalIP, f.LocalPort = splitAddr(la.String())
+		}
+		rec := &recorder{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(rec, r)
+		f.Duration = time.Since(f.StartTime)
+		f.Status = rec.status
+		f.BytesWritten = rec.bytes
+		f.RespHeader = w.Header()
+		f.Engine, f.CacheStatus = parseResultHeader(
+			w.Header().Get(headers.NameTricksterResult))
+		l.Log(f)
+	})
+}
+
+type recorder struct {
+	http.ResponseWriter
+	status int
+	bytes  int64
+}
+
+func (r *recorder) WriteHeader(statusCode int) {
+	r.ResponseWriter.WriteHeader(statusCode)
+	r.status = statusCode
+}
+
+func (r *recorder) Write(b []byte) (int, error) {
+	n, err := r.ResponseWriter.Write(b)
+	r.bytes += int64(n)
+	return n, err
+}
+
+func clientIP(remoteAddr string) string {
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
+	}
+	return remoteAddr
+}
+
+func splitAddr(addr string) (string, string) {
+	if host, port, err := net.SplitHostPort(addr); err == nil {
+		return host, port
+	}
+	return addr, ""
+}
+
+// parseResultHeader extracts the engine and cache status from an
+// X-Trickster-Result header value (e.g., "engine=DeltaProxyCache; status=hit")
+func parseResultHeader(value string) (engine, status string) {
+	for value != "" {
+		var part string
+		part, value, _ = strings.Cut(value, ";")
+		k, v, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "engine":
+			engine = v
+		case "status":
+			status = v
+		}
+	}
+	return
+}

--- a/pkg/observability/logging/accesslog/options/options.go
+++ b/pkg/observability/logging/accesslog/options/options.go
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package options provides the per-backend access_log configuration
+package options
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/format"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
+)
+
+// DefaultErrorThreshold is the minimum response status code written to the
+// error log when error_threshold is not configured
+const DefaultErrorThreshold = http.StatusBadRequest
+
+var ErrInvalidErrorThreshold = errors.New(
+	"error_threshold must be a valid http status code (100-599)")
+
+// Options is a collection of per-backend access and error logging options.
+// The access log is written only when Filename is set; the error log is
+// written only when ErrorFilename is set. Error* fields inherit from their
+// access log counterparts when unset.
+type Options struct {
+	// Filename is the path to the access log; empty disables access logging
+	Filename string `yaml:"filename,omitempty"`
+	// Format is a named preset (common, combined, extended, json) or a
+	// custom %-token format string; default is combined
+	Format string `yaml:"format,omitempty"`
+	// Rotation controls when the access log is rotated
+	Rotation *manager.RotationOptions `yaml:"rotation,omitempty"`
+	// Retention controls how many rotated access log archives are kept
+	Retention *manager.RetentionOptions `yaml:"retention,omitempty"`
+	// Compress indicates whether rotated archives are gzipped (default true)
+	Compress *bool `yaml:"compress,omitempty"`
+	// ErrorFilename is the path to the error log; empty disables error logging
+	ErrorFilename string `yaml:"error_filename,omitempty"`
+	// ErrorFormat overrides Format for the error log
+	ErrorFormat string `yaml:"error_format,omitempty"`
+	// ErrorThreshold is the minimum response status code written to the
+	// error log (default 400)
+	ErrorThreshold int `yaml:"error_threshold,omitempty"`
+	// ErrorRotation overrides Rotation for the error log
+	ErrorRotation *manager.RotationOptions `yaml:"error_rotation,omitempty"`
+	// ErrorRetention overrides Retention for the error log
+	ErrorRetention *manager.RetentionOptions `yaml:"error_retention,omitempty"`
+	// ErrorCompress overrides Compress for the error log
+	ErrorCompress *bool `yaml:"error_compress,omitempty"`
+}
+
+// New returns a new Options with default values
+func New() *Options {
+	return &Options{}
+}
+
+// Clone returns a copy of the Options
+func (o *Options) Clone() *Options {
+	if o == nil {
+		return nil
+	}
+	out := *o
+	out.Rotation = o.Rotation.Clone()
+	out.Retention = o.Retention.Clone()
+	out.Compress = pointers.Clone(o.Compress)
+	out.ErrorRotation = o.ErrorRotation.Clone()
+	out.ErrorRetention = o.ErrorRetention.Clone()
+	out.ErrorCompress = pointers.Clone(o.ErrorCompress)
+	return &out
+}
+
+func (o *Options) Initialize(_ string) error {
+	return nil
+}
+
+// IsEnabled returns true if access or error logging is configured
+func (o *Options) IsEnabled() bool {
+	return o != nil && (o.Filename != "" || o.ErrorFilename != "")
+}
+
+// Validate validates the Options, including compiling the format strings
+func (o *Options) Validate() (bool, error) {
+	if _, err := format.ParseFormat(o.ResolvedFormat()); err != nil {
+		return false, err
+	}
+	if _, err := format.ParseFormat(o.ResolvedErrorFormat()); err != nil {
+		return false, err
+	}
+	if o.ErrorThreshold != 0 &&
+		(o.ErrorThreshold < 100 || o.ErrorThreshold > 599) {
+		return false, ErrInvalidErrorThreshold
+	}
+	return true, nil
+}
+
+// ResolvedFormat returns the access log format, defaulted when unset
+func (o *Options) ResolvedFormat() string {
+	if o.Format == "" {
+		return format.DefaultFormatName
+	}
+	return o.Format
+}
+
+// ResolvedErrorFormat returns the error log format, inheriting the access
+// log format when unset
+func (o *Options) ResolvedErrorFormat() string {
+	if o.ErrorFormat == "" {
+		return o.ResolvedFormat()
+	}
+	return o.ErrorFormat
+}
+
+// ResolvedErrorThreshold returns the error log status threshold,
+// defaulted when unset
+func (o *Options) ResolvedErrorThreshold() int {
+	if o.ErrorThreshold == 0 {
+		return DefaultErrorThreshold
+	}
+	return o.ErrorThreshold
+}
+
+// AccessManagerOptions returns the rotation manager Options for the access
+// log file
+func (o *Options) AccessManagerOptions() *manager.Options {
+	return manager.ResolveOptions(o.Filename, o.Rotation, o.Retention, o.Compress)
+}
+
+// ErrorManagerOptions returns the rotation manager Options for the error
+// log file, inheriting access log settings for unset error_* fields
+func (o *Options) ErrorManagerOptions() *manager.Options {
+	rot := o.ErrorRotation
+	if rot == nil {
+		rot = o.Rotation
+	}
+	ret := o.ErrorRetention
+	if ret == nil {
+		ret = o.Retention
+	}
+	compress := o.ErrorCompress
+	if compress == nil {
+		compress = o.Compress
+	}
+	return manager.ResolveOptions(o.ErrorFilename, rot, ret, compress)
+}

--- a/pkg/observability/logging/accesslog/options/options.go
+++ b/pkg/observability/logging/accesslog/options/options.go
@@ -33,10 +33,8 @@ const DefaultErrorThreshold = http.StatusBadRequest
 var ErrInvalidErrorThreshold = errors.New(
 	"error_threshold must be a valid http status code (100-599)")
 
-// Options is a collection of per-backend access and error logging options.
-// The access log is written only when Filename is set; the error log is
-// written only when ErrorFilename is set. Error* fields inherit from their
-// access log counterparts when unset.
+// Options configures per-backend access and error logging. Error settings
+// inherit their access-log counterparts when unset.
 type Options struct {
 	// Filename is the path to the access log; empty disables access logging
 	Filename string `yaml:"filename,omitempty"`

--- a/pkg/observability/logging/accesslog/options/options_test.go
+++ b/pkg/observability/logging/accesslog/options/options_test.go
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/format"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
+	"github.com/trickstercache/trickster/v2/pkg/parsing/sizeconv"
+	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func TestIsEnabled(t *testing.T) {
+	var nilOpts *Options
+	if nilOpts.IsEnabled() {
+		t.Error("expected nil options to be disabled")
+	}
+	if New().IsEnabled() {
+		t.Error("expected empty options to be disabled")
+	}
+	if !(&Options{Filename: "/tmp/a.log"}).IsEnabled() {
+		t.Error("expected access-only options to be enabled")
+	}
+	if !(&Options{ErrorFilename: "/tmp/e.log"}).IsEnabled() {
+		t.Error("expected error-only options to be enabled")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	o := New()
+	if err := o.Initialize(""); err != nil {
+		t.Fatal(err)
+	}
+	if ok, err := o.Validate(); !ok || err != nil {
+		t.Errorf("expected default options to validate: %v", err)
+	}
+	o.Format = "%h %Z"
+	if _, err := o.Validate(); !errors.Is(err, format.ErrInvalidFormatToken) {
+		t.Errorf("expected format error, got %v", err)
+	}
+	o.Format = format.Common
+	o.ErrorFormat = "%Z"
+	if _, err := o.Validate(); !errors.Is(err, format.ErrInvalidFormatToken) {
+		t.Errorf("expected error format error, got %v", err)
+	}
+	o.ErrorFormat = ""
+	o.ErrorThreshold = 42
+	if _, err := o.Validate(); !errors.Is(err, ErrInvalidErrorThreshold) {
+		t.Errorf("expected threshold error, got %v", err)
+	}
+	o.ErrorThreshold = 500
+	if ok, err := o.Validate(); !ok || err != nil {
+		t.Errorf("expected options to validate: %v", err)
+	}
+}
+
+func TestResolvedInheritance(t *testing.T) {
+	o := New()
+	if o.ResolvedFormat() != format.DefaultFormatName {
+		t.Errorf("unexpected default format: %s", o.ResolvedFormat())
+	}
+	if o.ResolvedErrorFormat() != format.DefaultFormatName {
+		t.Errorf("unexpected default error format: %s", o.ResolvedErrorFormat())
+	}
+	if o.ResolvedErrorThreshold() != DefaultErrorThreshold {
+		t.Errorf("unexpected default threshold: %d", o.ResolvedErrorThreshold())
+	}
+	o.Format = format.JSON
+	if o.ResolvedErrorFormat() != format.JSON {
+		t.Error("expected error format to inherit format")
+	}
+	o.ErrorFormat = format.Common
+	o.ErrorThreshold = 500
+	if o.ResolvedErrorFormat() != format.Common ||
+		o.ResolvedErrorThreshold() != 500 {
+		t.Error("expected explicit error format and threshold")
+	}
+}
+
+func TestManagerOptionsInheritance(t *testing.T) {
+	size := sizeconv.Size(64)
+	count := 3
+	compress := false
+	o := &Options{
+		Filename:      "/tmp/a.log",
+		ErrorFilename: "/tmp/e.log",
+		Rotation:      &manager.RotationOptions{Size: &size},
+		Retention:     &manager.RetentionOptions{Count: &count},
+		Compress:      &compress,
+	}
+	am := o.AccessManagerOptions()
+	if am.Filename != "/tmp/a.log" || am.MaxSizeBytes != 64 ||
+		am.RetentionCount != 3 || am.Compress {
+		t.Errorf("unexpected access manager options: %+v", am)
+	}
+	// error log inherits the access log's rotation/retention/compression
+	em := o.ErrorManagerOptions()
+	if em.Filename != "/tmp/e.log" || em.MaxSizeBytes != 64 ||
+		em.RetentionCount != 3 || em.Compress {
+		t.Errorf("unexpected inherited error manager options: %+v", em)
+	}
+	// explicit error_* fields override
+	errSize := sizeconv.Size(128)
+	errCount := 7
+	errCompress := true
+	o.ErrorRotation = &manager.RotationOptions{Size: &errSize}
+	o.ErrorRetention = &manager.RetentionOptions{Count: &errCount}
+	o.ErrorCompress = &errCompress
+	em = o.ErrorManagerOptions()
+	if em.MaxSizeBytes != 128 || em.RetentionCount != 7 || !em.Compress {
+		t.Errorf("unexpected explicit error manager options: %+v", em)
+	}
+}
+
+func TestClone(t *testing.T) {
+	var nilOpts *Options
+	if nilOpts.Clone() != nil {
+		t.Error("expected nil clone")
+	}
+	size := sizeconv.Size(64)
+	age := timeconv.Duration(time.Hour)
+	compress := false
+	o := &Options{
+		Filename:  "/tmp/a.log",
+		Rotation:  &manager.RotationOptions{Size: &size},
+		Retention: &manager.RetentionOptions{Age: &age},
+		Compress:  &compress,
+	}
+	c := o.Clone()
+	if c == o || c.Rotation == o.Rotation || c.Retention == o.Retention ||
+		c.Compress == o.Compress {
+		t.Error("expected deep clone")
+	}
+	if c.Filename != o.Filename || *c.Rotation.Size != 64 ||
+		*c.Retention.Age != age || *c.Compress {
+		t.Errorf("unexpected clone values: %+v", c)
+	}
+}
+
+func TestYAMLRoundTrip(t *testing.T) {
+	doc := `
+filename: /var/log/trickster/example1.access.log
+format: combined
+rotation:
+  size: 256MB
+  interval: 1d
+retention:
+  count: 3
+  age: 7d
+compress: true
+error_filename: /var/log/trickster/example1.error.log
+error_threshold: 500
+error_retention:
+  count: 7
+`
+	o := New()
+	if err := yaml.Unmarshal([]byte(doc), o); err != nil {
+		t.Fatal(err)
+	}
+	if o.Filename != "/var/log/trickster/example1.access.log" ||
+		o.Format != "combined" ||
+		*o.Rotation.Size != 256*1024*1024 ||
+		time.Duration(*o.Rotation.Interval) != 24*time.Hour ||
+		*o.Retention.Count != 3 ||
+		time.Duration(*o.Retention.Age) != 7*24*time.Hour ||
+		!*o.Compress ||
+		o.ErrorFilename != "/var/log/trickster/example1.error.log" ||
+		o.ErrorThreshold != 500 ||
+		*o.ErrorRetention.Count != 7 {
+		t.Errorf("unexpected unmarshaled options: %+v", o)
+	}
+	if ok, err := o.Validate(); !ok || err != nil {
+		t.Errorf("expected round-tripped options to validate: %v", err)
+	}
+	b, err := yaml.Marshal(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o2 := New()
+	if err = yaml.Unmarshal(b, o2); err != nil {
+		t.Fatal(err)
+	}
+	if *o2.Rotation.Size != *o.Rotation.Size ||
+		*o2.Retention.Count != *o.Retention.Count {
+		t.Error("expected marshal/unmarshal round trip to preserve values")
+	}
+}

--- a/pkg/observability/logging/logger/logger.go
+++ b/pkg/observability/logging/logger/logger.go
@@ -120,6 +120,14 @@ func ErrorSynchronous(event string, detail logging.Pairs) {
 	logger.ErrorSynchronous(event, detail)
 }
 
+// Flush writes buffered output from the package-level logger when supported.
+func Flush() error {
+	if flusher, ok := logger.(interface{ Flush() error }); ok {
+		return flusher.Flush()
+	}
+	return nil
+}
+
 // LogOnce logs an event to the package-level logger
 // only once based on unique key
 func LogOnce(logLevel level.Level, key, event string, detail logging.Pairs) bool {

--- a/pkg/observability/logging/logger/logger_race.go
+++ b/pkg/observability/logging/logger/logger_race.go
@@ -135,6 +135,16 @@ func ErrorSynchronous(event string, detail logging.Pairs) {
 	logger.ErrorSynchronous(event, detail)
 }
 
+// Flush writes buffered output from the package-level logger when supported.
+func Flush() error {
+	mtx.Lock()
+	defer mtx.Unlock()
+	if flusher, ok := logger.(interface{ Flush() error }); ok {
+		return flusher.Flush()
+	}
+	return nil
+}
+
 func LogOnce(logLevel level.Level, key, event string, detail logging.Pairs) bool {
 	mtx.Lock()
 	defer mtx.Unlock()

--- a/pkg/observability/logging/logger/logger_test.go
+++ b/pkg/observability/logging/logger/logger_test.go
@@ -19,6 +19,7 @@ package logger
 import (
 	"bytes"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -100,7 +101,7 @@ func TestPackageLoggerWrappers(t *testing.T) {
 }
 
 func TestPackageLoggerAsync(t *testing.T) {
-	buf := &bytes.Buffer{}
+	buf := &syncBuffer{}
 	l := logging.StreamLogger(buf, level.Info)
 	SetLogger(l)
 	t.Cleanup(func() {
@@ -115,4 +116,27 @@ func TestPackageLoggerAsync(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	require.Contains(t, buf.String(), "async package log")
+}
+
+type syncBuffer struct {
+	mtx sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) Len() int {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	return b.buf.Len()
+}
+
+func (b *syncBuffer) String() string {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	return b.buf.String()
 }

--- a/pkg/observability/logging/logging.go
+++ b/pkg/observability/logging/logging.go
@@ -97,6 +97,9 @@ func New(conf *config.Config) Logger {
 			l.writer = w
 			l.closer = w
 		} else {
+			_, _ = fmt.Fprintf(os.Stderr,
+				"trickster: unable to open log file %q; using stdout: %v\n",
+				mo.Filename, err)
 			l.writer = os.Stdout
 		}
 	}
@@ -144,6 +147,9 @@ type logger struct {
 	writer         io.Writer
 	closer         io.Closer
 	mtx            sync.Mutex
+	asyncMtx       sync.Mutex
+	asyncWG        sync.WaitGroup
+	asyncClosed    bool
 	onceRanEntries sync.Map
 	logFunc        logFunc
 	now            func() time.Time
@@ -240,7 +246,9 @@ func (l *logger) ErrorSynchronous(event string, detail Pairs) {
 }
 
 func (l *logger) Fatal(code int, event string, detail Pairs) {
+	l.drainAsync()
 	l.log(level.Fatal, event, detail)
+	_ = l.Flush()
 	if code < 0 {
 		// tests will send a -1 code to avoid a panic during the test
 		return
@@ -314,7 +322,18 @@ func (l *logger) HasLoggedOnce(logLevel level.Level, key string) bool {
 }
 
 func (l *logger) logAsyncronous(logLevel level.Level, event string, detail Pairs) {
-	go l.logWithCaller(logLevel, event, detail, getCaller(1))
+	caller := getCaller(1)
+	l.asyncMtx.Lock()
+	if l.asyncClosed {
+		l.asyncMtx.Unlock()
+		return
+	}
+	l.asyncWG.Add(1)
+	l.asyncMtx.Unlock()
+	go func() {
+		defer l.asyncWG.Done()
+		l.logWithCaller(logLevel, event, detail, caller)
+	}()
 }
 
 type item struct {
@@ -427,8 +446,26 @@ func (l *logger) Level() level.Level {
 	return l.level
 }
 
+// Flush writes buffered log output to its destination when supported.
+func (l *logger) Flush() error {
+	l.mtx.Lock()
+	defer l.mtx.Unlock()
+	if flusher, ok := l.writer.(interface{ Flush() error }); ok {
+		return flusher.Flush()
+	}
+	return nil
+}
+
 func (l *logger) Close() {
+	l.drainAsync()
 	if l.closer != nil {
 		l.closer.Close()
 	}
+}
+
+func (l *logger) drainAsync() {
+	l.asyncMtx.Lock()
+	l.asyncClosed = true
+	l.asyncMtx.Unlock()
+	l.asyncWG.Wait()
 }

--- a/pkg/observability/logging/logging.go
+++ b/pkg/observability/logging/logging.go
@@ -90,8 +90,8 @@ func New(conf *config.Config) Logger {
 	if conf.Logging.LogFile == "" {
 		l.writer = os.Stdout
 	} else {
-		mo := manager.NewOptions()
-		mo.Filename = manager.InstanceFilename(conf.Logging.LogFile,
+		mo := conf.Logging.ManagerOptions()
+		mo.Filename = manager.InstanceFilename(mo.Filename,
 			conf.Main.InstanceID)
 		if w, err := manager.GetWriter(mo); err == nil {
 			l.writer = w

--- a/pkg/observability/logging/logging.go
+++ b/pkg/observability/logging/logging.go
@@ -95,12 +95,10 @@ func New(conf *config.Config) Logger {
 			conf.Main.InstanceID)
 		if w, err := manager.GetWriter(mo); err == nil {
 			l.writer = w
+			l.closer = w
 		} else {
 			l.writer = os.Stdout
 		}
-	}
-	if c, ok := l.writer.(io.Closer); ok && c != nil {
-		l.closer = c
 	}
 	l.SetLogLevel(level.Level(conf.Logging.LogLevel))
 	return l

--- a/pkg/observability/logging/logging.go
+++ b/pkg/observability/logging/logging.go
@@ -30,9 +30,8 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
 	tstr "github.com/trickstercache/trickster/v2/pkg/util/strings"
-
-	lumberjack "gopkg.in/natefinch/lumberjack.v2"
 )
 
 var (
@@ -91,17 +90,13 @@ func New(conf *config.Config) Logger {
 	if conf.Logging.LogFile == "" {
 		l.writer = os.Stdout
 	} else {
-		logFile := conf.Logging.LogFile
-		if conf.Main.InstanceID > 0 {
-			logFile = strings.Replace(logFile, ".log",
-				"."+strconv.Itoa(conf.Main.InstanceID)+".log", 1)
-		}
-		l.writer = &lumberjack.Logger{
-			Filename:   logFile,
-			MaxSize:    256,  // megabytes
-			MaxBackups: 80,   // 256 megs @ 80 backups is 20GB of Logs
-			MaxAge:     7,    // days
-			Compress:   true, // Compress Rolled Backups
+		mo := manager.NewOptions()
+		mo.Filename = manager.InstanceFilename(conf.Logging.LogFile,
+			conf.Main.InstanceID)
+		if w, err := manager.GetWriter(mo); err == nil {
+			l.writer = w
+		} else {
+			l.writer = os.Stdout
 		}
 	}
 	if c, ok := l.writer.(io.Closer); ok && c != nil {

--- a/pkg/observability/logging/logging_extended_test.go
+++ b/pkg/observability/logging/logging_extended_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -103,7 +104,7 @@ func TestLoggerOnceAndSynchronousHelpers(t *testing.T) {
 func TestLoggerAsyncMode(t *testing.T) {
 	t.Parallel()
 
-	buf := &bytes.Buffer{}
+	buf := &syncBuffer{}
 	l := StreamLogger(buf, level.Info)
 	l.SetLogAsynchronous(true)
 	l.Info("async entry", nil)
@@ -114,6 +115,23 @@ func TestLoggerAsyncMode(t *testing.T) {
 	if buf.Len() == 0 {
 		t.Fatal("expected async log output")
 	}
+}
+
+type syncBuffer struct {
+	mtx sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) Len() int {
+	b.mtx.Lock()
+	defer b.mtx.Unlock()
+	return b.buf.Len()
 }
 
 func TestQuoteAsNeeded(t *testing.T) {

--- a/pkg/observability/logging/logging_test.go
+++ b/pkg/observability/logging/logging_test.go
@@ -24,7 +24,9 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/options"
+	"github.com/trickstercache/trickster/v2/pkg/parsing/sizeconv"
 
 	"github.com/stretchr/testify/require"
 )
@@ -85,6 +87,31 @@ func TestNewLogger_LogFile(t *testing.T) {
 	b, err := os.ReadFile(instanceFileName)
 	require.NoError(t, err)
 	require.Equal(t, `time=0001-01-01T00:00:00Z app=trickster level=info event=testEntry testKey="test Val" testKey2=testValue2 testKey3=testValue3`+"\n", string(b))
+}
+
+func TestNewLogger_RotationOptions(t *testing.T) {
+	fileName := t.TempDir() + "/out.log"
+	size := sizeconv.Size(16)
+	count := 2
+	compress := false
+	conf := config.NewConfig()
+	conf.Main = &config.MainConfig{InstanceID: 0}
+	conf.Logging = &options.Options{
+		LogFile:   fileName,
+		LogLevel:  "info",
+		Rotation:  &manager.RotationOptions{Size: &size},
+		Retention: &manager.RetentionOptions{Count: &count},
+		Compress:  &compress,
+	}
+	log := New(conf)
+	log.SetLogAsynchronous(false)
+	// each line exceeds 16 bytes, so the second write must rotate the file
+	log.Info("first entry", nil)
+	log.Info("second entry", nil)
+	log.Close()
+	if _, err := os.Stat(fileName + ".1"); err != nil {
+		t.Errorf("expected a rotated archive per configured rotation: %v", err)
+	}
 }
 
 func TestNewLoggerDebug_LogFile(t *testing.T) {

--- a/pkg/observability/logging/logging_test.go
+++ b/pkg/observability/logging/logging_test.go
@@ -19,6 +19,7 @@ package logging
 import (
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -292,10 +293,17 @@ func TestNewLoggerFatal_LogFile(t *testing.T) {
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &options.Options{LogFile: fileName, LogLevel: "debug"}
 	logger := New(conf)
-	logger.SetLogAsynchronous(false)
+	logger.Info("before fatal", nil)
 	logger.Fatal(-1, "test entry", Pairs{"testKey": "testVal"})
-	if _, err := os.Stat(fileName); err != nil {
-		t.Error(err)
+	b, err := os.ReadFile(fileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "test entry") {
+		t.Errorf("fatal line was not flushed: %q", string(b))
+	}
+	if !strings.Contains(string(b), "before fatal") {
+		t.Errorf("preceding asynchronous line was not flushed: %q", string(b))
 	}
 	logger.Close()
 }

--- a/pkg/observability/logging/logging_test.go
+++ b/pkg/observability/logging/logging_test.go
@@ -54,10 +54,32 @@ func TestNew(t *testing.T) {
 	conf := config.NewConfig()
 	conf.Main = &config.MainConfig{InstanceID: 0}
 	conf.Logging = &options.Options{LogLevel: "info"}
-	logger := New(conf)
-	if logger.Level() != level.Info {
-		t.Errorf("expected %s got %s", "info", logger.Level())
+	log := New(conf)
+	if log.Level() != level.Info {
+		t.Errorf("expected %s got %s", "info", log.Level())
 	}
+	if log.(*logger).closer != nil {
+		t.Error("console logger must not own stdout")
+	}
+}
+
+func TestNewConflictFallbackDoesNotOwnStdout(t *testing.T) {
+	conf := config.NewConfig()
+	conf.Logging.LogFile = t.TempDir() + "/shared.log"
+	first := New(conf)
+	defer first.Close()
+
+	conflict := conf.Clone()
+	count := manager.DefaultRetentionCount - 1
+	conflict.Logging.Retention = &manager.RetentionOptions{Count: &count}
+	second := New(conflict).(*logger)
+	if second.writer != os.Stdout {
+		t.Fatal("expected conflicting writer to fall back to stdout")
+	}
+	if second.closer != nil {
+		t.Error("stdout fallback must not be owned by the logger")
+	}
+	second.Close()
 }
 
 func TestNewLogger_LogFile(t *testing.T) {

--- a/pkg/observability/logging/manager/options.go
+++ b/pkg/observability/logging/manager/options.go
@@ -19,7 +19,9 @@ package manager
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -42,6 +44,9 @@ const (
 
 // ErrNoFilename is returned when a Writer is requested without a Filename
 var ErrNoFilename = errors.New("log filename is required")
+
+// ErrConflictingOptions is returned when one file has incompatible managers
+var ErrConflictingOptions = errors.New("conflicting log manager options")
 
 // Options configures a managed log file
 type Options struct {
@@ -76,6 +81,47 @@ func NewOptions() *Options {
 func (o *Options) Clone() *Options {
 	out := *o
 	return &out
+}
+
+func normalizeOptions(o *Options) (Options, error) {
+	if o == nil || o.Filename == "" {
+		return Options{}, ErrNoFilename
+	}
+	out := *o
+	name, err := filepath.Abs(out.Filename)
+	if err != nil {
+		return Options{}, err
+	}
+	out.Filename = name
+	if out.FileMode == 0 {
+		out.FileMode = DefaultFileMode
+	}
+	return out, nil
+}
+
+func optionsEqual(a, b Options) bool {
+	return a == b
+}
+
+// ValidateOptions rejects incompatible manager settings for the same file.
+func ValidateOptions(options ...*Options) error {
+	seen := make(map[string]Options, len(options))
+	for _, o := range options {
+		if o == nil || o.Filename == "" {
+			continue
+		}
+		resolved, err := normalizeOptions(o)
+		if err != nil {
+			return err
+		}
+		if prior, ok := seen[resolved.Filename]; ok &&
+			!optionsEqual(prior, resolved) {
+			return fmt.Errorf("%w for %s", ErrConflictingOptions,
+				resolved.Filename)
+		}
+		seen[resolved.Filename] = resolved
+	}
+	return nil
 }
 
 // InstanceFilename returns the filename adjusted to include the provided

--- a/pkg/observability/logging/manager/options.go
+++ b/pkg/observability/logging/manager/options.go
@@ -23,7 +23,6 @@ import (
 	"io/fs"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -48,6 +47,9 @@ var ErrNoFilename = errors.New("log filename is required")
 // ErrConflictingOptions is returned when one file has incompatible managers
 var ErrConflictingOptions = errors.New("conflicting log manager options")
 
+// ErrBufferFull is returned when a log line exceeds the bounded write buffer.
+var ErrBufferFull = errors.New("log write buffer is full")
+
 // Options configures a managed log file
 type Options struct {
 	// Filename is the path to the live log file
@@ -56,7 +58,7 @@ type Options struct {
 	MaxSizeBytes int64
 	// Interval rotates the file when it has been open at least this long (0 disables)
 	Interval time.Duration
-	// RetentionCount is the max number of archived files kept (0 = delete on rotate)
+	// RetentionCount is the max archived files kept (0 disables count pruning)
 	RetentionCount int
 	// RetentionAge prunes archived files older than this (0 disables age pruning)
 	RetentionAge time.Duration
@@ -130,5 +132,7 @@ func InstanceFilename(name string, id int) string {
 	if id <= 0 {
 		return name
 	}
-	return strings.Replace(name, ".log", "."+strconv.Itoa(id)+".log", 1)
+	ext := filepath.Ext(filepath.Base(name))
+	stem := name[:len(name)-len(ext)]
+	return stem + "." + strconv.Itoa(id) + ext
 }

--- a/pkg/observability/logging/manager/options.go
+++ b/pkg/observability/logging/manager/options.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package manager provides rotating, retention-managed log file writers.
+package manager
+
+import (
+	"errors"
+	"io/fs"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// DefaultMaxSizeBytes is the default rotation size threshold (256 MB)
+	DefaultMaxSizeBytes = int64(256 * 1024 * 1024)
+	// DefaultRetentionCount is the default maximum number of archived files
+	DefaultRetentionCount = 80
+	// DefaultRetentionAge is the default maximum age of archived files
+	DefaultRetentionAge = 7 * 24 * time.Hour
+	// DefaultCompress indicates whether archived files are gzipped by default
+	DefaultCompress = true
+	// DefaultFileMode is the default mode for created log files
+	DefaultFileMode = fs.FileMode(0o644)
+	// DefaultDirMode is the default mode for created log directories
+	DefaultDirMode = fs.FileMode(0o755)
+)
+
+// ErrNoFilename is returned when a Writer is requested without a Filename
+var ErrNoFilename = errors.New("log filename is required")
+
+// Options configures a managed log file
+type Options struct {
+	// Filename is the path to the live log file
+	Filename string
+	// MaxSizeBytes rotates the file when a write would exceed this size (0 disables)
+	MaxSizeBytes int64
+	// Interval rotates the file when it has been open at least this long (0 disables)
+	Interval time.Duration
+	// RetentionCount is the max number of archived files kept (0 = delete on rotate)
+	RetentionCount int
+	// RetentionAge prunes archived files older than this (0 disables age pruning)
+	RetentionAge time.Duration
+	// Compress indicates whether archived files are gzipped
+	Compress bool
+	// FileMode is the mode used when creating log files
+	FileMode fs.FileMode
+}
+
+// NewOptions returns Options with default rotation and retention values
+func NewOptions() *Options {
+	return &Options{
+		MaxSizeBytes:   DefaultMaxSizeBytes,
+		RetentionCount: DefaultRetentionCount,
+		RetentionAge:   DefaultRetentionAge,
+		Compress:       DefaultCompress,
+		FileMode:       DefaultFileMode,
+	}
+}
+
+// Clone returns a copy of the Options
+func (o *Options) Clone() *Options {
+	out := *o
+	return &out
+}
+
+// InstanceFilename returns the filename adjusted to include the provided
+// instance ID (e.g., trickster.log -> trickster.1.log) when id is positive
+func InstanceFilename(name string, id int) string {
+	if id <= 0 {
+		return name
+	}
+	return strings.Replace(name, ".log", "."+strconv.Itoa(id)+".log", 1)
+}

--- a/pkg/observability/logging/manager/options_test.go
+++ b/pkg/observability/logging/manager/options_test.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manager
+
+import "testing"
+
+func TestNewOptions(t *testing.T) {
+	o := NewOptions()
+	if o.MaxSizeBytes != DefaultMaxSizeBytes ||
+		o.RetentionCount != DefaultRetentionCount ||
+		o.RetentionAge != DefaultRetentionAge ||
+		o.Compress != DefaultCompress ||
+		o.FileMode != DefaultFileMode {
+		t.Errorf("unexpected defaults: %+v", o)
+	}
+}
+
+func TestOptionsClone(t *testing.T) {
+	o := NewOptions()
+	o.Filename = "/tmp/x.log"
+	c := o.Clone()
+	if c == o || *c != *o {
+		t.Errorf("unexpected clone: %+v", c)
+	}
+}
+
+func TestInstanceFilename(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       int
+		expected string
+	}{
+		{"/var/log/trickster.log", 0, "/var/log/trickster.log"},
+		{"/var/log/trickster.log", -1, "/var/log/trickster.log"},
+		{"/var/log/trickster.log", 2, "/var/log/trickster.2.log"},
+		{"/var/log/trickster.txt", 2, "/var/log/trickster.txt"},
+		{"/var/log/a.log.d/trickster.log", 3, "/var/log/a.3.log.d/trickster.log"},
+	}
+	for _, test := range tests {
+		if s := InstanceFilename(test.name, test.id); s != test.expected {
+			t.Errorf("expected %s, got %s", test.expected, s)
+		}
+	}
+}

--- a/pkg/observability/logging/manager/options_test.go
+++ b/pkg/observability/logging/manager/options_test.go
@@ -51,8 +51,9 @@ func TestInstanceFilename(t *testing.T) {
 		{"/var/log/trickster.log", 0, "/var/log/trickster.log"},
 		{"/var/log/trickster.log", -1, "/var/log/trickster.log"},
 		{"/var/log/trickster.log", 2, "/var/log/trickster.2.log"},
-		{"/var/log/trickster.txt", 2, "/var/log/trickster.txt"},
-		{"/var/log/a.log.d/trickster.log", 3, "/var/log/a.3.log.d/trickster.log"},
+		{"/var/log/trickster.txt", 2, "/var/log/trickster.2.txt"},
+		{"/var/log/trickster", 2, "/var/log/trickster.2"},
+		{"/var/log/a.log.d/trickster.log", 3, "/var/log/a.log.d/trickster.3.log"},
 	}
 	for _, test := range tests {
 		if s := InstanceFilename(test.name, test.id); s != test.expected {

--- a/pkg/observability/logging/manager/options_test.go
+++ b/pkg/observability/logging/manager/options_test.go
@@ -16,7 +16,11 @@
 
 package manager
 
-import "testing"
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
 
 func TestNewOptions(t *testing.T) {
 	o := NewOptions()
@@ -54,5 +58,19 @@ func TestInstanceFilename(t *testing.T) {
 		if s := InstanceFilename(test.name, test.id); s != test.expected {
 			t.Errorf("expected %s, got %s", test.expected, s)
 		}
+	}
+}
+
+func TestValidateOptionsConflicts(t *testing.T) {
+	name := filepath.Join(t.TempDir(), "test.log")
+	a := NewOptions()
+	a.Filename = name
+	b := a.Clone()
+	if err := ValidateOptions(a, b); err != nil {
+		t.Fatalf("matching options failed validation: %v", err)
+	}
+	b.RetentionCount++
+	if err := ValidateOptions(a, b); !errors.Is(err, ErrConflictingOptions) {
+		t.Fatalf("expected conflicting options error, got %v", err)
 	}
 }

--- a/pkg/observability/logging/manager/registry.go
+++ b/pkg/observability/logging/manager/registry.go
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manager
+
+import (
+	"io"
+	"path/filepath"
+	"sync"
+)
+
+// registry deduplicates Writers by absolute filename so that multiple
+// consumers of the same log file share one rotation manager
+var registry = struct {
+	sync.Mutex
+	writers map[string]*regEntry
+}{writers: make(map[string]*regEntry)}
+
+type regEntry struct {
+	w    *Writer
+	refs int
+}
+
+// Handle is a reference-counted handle to a shared Writer; Close releases
+// the reference, closing the underlying Writer on last release
+type Handle struct {
+	w    *Writer
+	key  string
+	once sync.Once
+}
+
+func (h *Handle) Write(p []byte) (int, error) {
+	return h.w.Write(p)
+}
+
+// Rotate forces an immediate rotation of the underlying Writer
+func (h *Handle) Rotate() error {
+	return h.w.Rotate()
+}
+
+// Filename returns the path to the underlying live log file
+func (h *Handle) Filename() string {
+	return h.w.Filename()
+}
+
+// Close releases this handle's reference to the shared Writer. The Writer
+// is closed when the last handle is released. Close is idempotent.
+func (h *Handle) Close() error {
+	var err error
+	h.once.Do(func() {
+		registry.Lock()
+		e, ok := registry.writers[h.key]
+		if ok && e.w == h.w {
+			e.refs--
+			if e.refs < 1 {
+				delete(registry.writers, h.key)
+			} else {
+				ok = false
+			}
+		}
+		registry.Unlock()
+		if ok {
+			err = h.w.Close()
+		}
+	})
+	return err
+}
+
+var _ io.WriteCloser = &Handle{}
+
+// GetWriter returns a Handle to the shared Writer for the filename in the
+// provided Options, creating the Writer if one does not exist
+func GetWriter(o *Options) (*Handle, error) {
+	if o == nil || o.Filename == "" {
+		return nil, ErrNoFilename
+	}
+	key, err := filepath.Abs(o.Filename)
+	if err != nil {
+		return nil, err
+	}
+	registry.Lock()
+	defer registry.Unlock()
+	e, ok := registry.writers[key]
+	if !ok {
+		w, err := NewWriter(o)
+		if err != nil {
+			return nil, err
+		}
+		e = &regEntry{w: w}
+		registry.writers[key] = e
+	}
+	e.refs++
+	return &Handle{w: e.w, key: key}, nil
+}

--- a/pkg/observability/logging/manager/registry.go
+++ b/pkg/observability/logging/manager/registry.go
@@ -29,9 +29,11 @@ var registry = struct {
 }{writers: make(map[string]*regEntry)}
 
 type regEntry struct {
-	w    *Writer
-	opts Options
-	refs int
+	w       *Writer
+	opts    Options
+	refs    int
+	closing bool
+	cond    *sync.Cond
 }
 
 // Handle is a reference-counted handle to a shared Writer; Close releases
@@ -45,6 +47,12 @@ type Handle struct {
 func (h *Handle) Write(p []byte) (int, error) {
 	return h.w.Write(p)
 }
+
+// Flush writes buffered data to the underlying log file.
+func (h *Handle) Flush() error { return h.w.Flush() }
+
+// DroppedLines returns writes rejected because the shared buffer was full.
+func (h *Handle) DroppedLines() uint64 { return h.w.DroppedLines() }
 
 // Rotate forces an immediate rotation of the underlying Writer
 func (h *Handle) Rotate() error {
@@ -66,7 +74,7 @@ func (h *Handle) Close() error {
 		if ok && e.w == h.w {
 			e.refs--
 			if e.refs < 1 {
-				delete(registry.writers, h.key)
+				e.closing = true
 			} else {
 				ok = false
 			}
@@ -74,6 +82,12 @@ func (h *Handle) Close() error {
 		registry.Unlock()
 		if ok {
 			err = h.w.Close()
+			registry.Lock()
+			if registry.writers[h.key] == e {
+				delete(registry.writers, h.key)
+			}
+			e.cond.Broadcast()
+			registry.Unlock()
 		}
 	})
 	return err
@@ -92,12 +106,17 @@ func GetWriter(o *Options) (*Handle, error) {
 	registry.Lock()
 	defer registry.Unlock()
 	e, ok := registry.writers[key]
+	for ok && e.closing {
+		e.cond.Wait()
+		e, ok = registry.writers[key]
+	}
 	if !ok {
 		w, err := NewWriter(&opts)
 		if err != nil {
 			return nil, err
 		}
 		e = &regEntry{w: w, opts: opts}
+		e.cond = sync.NewCond(&registry.Mutex)
 		registry.writers[key] = e
 	} else if !optionsEqual(e.opts, opts) {
 		return nil, ErrConflictingOptions
@@ -116,6 +135,10 @@ func Reconfigure(o *Options) error {
 	registry.Lock()
 	defer registry.Unlock()
 	e, ok := registry.writers[opts.Filename]
+	for ok && e.closing {
+		e.cond.Wait()
+		e, ok = registry.writers[opts.Filename]
+	}
 	if !ok {
 		return nil
 	}

--- a/pkg/observability/logging/manager/registry.go
+++ b/pkg/observability/logging/manager/registry.go
@@ -18,7 +18,6 @@ package manager
 
 import (
 	"io"
-	"path/filepath"
 	"sync"
 )
 
@@ -31,6 +30,7 @@ var registry = struct {
 
 type regEntry struct {
 	w    *Writer
+	opts Options
 	refs int
 }
 
@@ -84,28 +84,42 @@ var _ io.WriteCloser = &Handle{}
 // GetWriter returns a Handle to the shared Writer for the filename in the
 // provided Options, creating the Writer if one does not exist
 func GetWriter(o *Options) (*Handle, error) {
-	if o == nil || o.Filename == "" {
-		return nil, ErrNoFilename
-	}
-	key, err := filepath.Abs(o.Filename)
+	opts, err := normalizeOptions(o)
 	if err != nil {
 		return nil, err
 	}
+	key := opts.Filename
 	registry.Lock()
 	defer registry.Unlock()
 	e, ok := registry.writers[key]
 	if !ok {
-		w, err := NewWriter(o)
+		w, err := NewWriter(&opts)
 		if err != nil {
 			return nil, err
 		}
-		e = &regEntry{w: w}
+		e = &regEntry{w: w, opts: opts}
 		registry.writers[key] = e
-	} else {
-		// an existing writer adopts the most recently provided settings
-		// (e.g., rotation changes applied by a config reload)
-		e.w.SetOptions(o)
+	} else if !optionsEqual(e.opts, opts) {
+		return nil, ErrConflictingOptions
 	}
 	e.refs++
 	return &Handle{w: e.w, key: key}, nil
+}
+
+// Reconfigure updates an existing shared Writer during a validated reload.
+// It is a no-op when the filename does not currently have a Writer.
+func Reconfigure(o *Options) error {
+	opts, err := normalizeOptions(o)
+	if err != nil {
+		return err
+	}
+	registry.Lock()
+	defer registry.Unlock()
+	e, ok := registry.writers[opts.Filename]
+	if !ok {
+		return nil
+	}
+	e.w.SetOptions(&opts)
+	e.opts = opts
+	return nil
 }

--- a/pkg/observability/logging/manager/registry.go
+++ b/pkg/observability/logging/manager/registry.go
@@ -101,6 +101,10 @@ func GetWriter(o *Options) (*Handle, error) {
 		}
 		e = &regEntry{w: w}
 		registry.writers[key] = e
+	} else {
+		// an existing writer adopts the most recently provided settings
+		// (e.g., rotation changes applied by a config reload)
+		e.w.SetOptions(o)
 	}
 	e.refs++
 	return &Handle{w: e.w, key: key}, nil

--- a/pkg/observability/logging/manager/registry_test.go
+++ b/pkg/observability/logging/manager/registry_test.go
@@ -148,6 +148,21 @@ func TestGetWriterWaitsForPriorClose(t *testing.T) {
 	<-started
 	closed := make(chan error, 1)
 	go func() { closed <- h.Close() }()
+	// ensure Close has marked the entry closing before racing GetWriter against it
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		registry.Lock()
+		e, ok := registry.writers[h.key]
+		closing := ok && e.closing
+		registry.Unlock()
+		if closing {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("close never marked the registry entry as closing")
+		}
+		time.Sleep(time.Millisecond)
+	}
 	acquired := make(chan *Handle, 1)
 	go func() {
 		next, getErr := GetWriter(o)

--- a/pkg/observability/logging/manager/registry_test.go
+++ b/pkg/observability/logging/manager/registry_test.go
@@ -20,7 +20,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestGetWriterErrors(t *testing.T) {
@@ -119,6 +121,58 @@ func TestGetWriterAfterRelease(t *testing.T) {
 	if s := readFile(t, o.Filename); s != "first\nsecond\n" {
 		t.Errorf("unexpected content: %q", s)
 	}
+}
+
+func TestGetWriterWaitsForPriorClose(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 4
+	o.Compress = true
+	h, err := GetWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	h.w.compress = func(path string) {
+		once.Do(func() { close(started) })
+		<-release
+		compressArchive(path)
+	}
+	if _, err = h.Write([]byte("aaaa")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = h.Write([]byte("bbbb")); err != nil {
+		t.Fatal(err)
+	}
+	<-started
+	closed := make(chan error, 1)
+	go func() { closed <- h.Close() }()
+	acquired := make(chan *Handle, 1)
+	go func() {
+		next, getErr := GetWriter(o)
+		if getErr != nil {
+			t.Error(getErr)
+		}
+		acquired <- next
+	}()
+	select {
+	case next := <-acquired:
+		if next != nil {
+			next.Close()
+		}
+		t.Fatal("writer was reacquired before the prior close completed")
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	if err = <-closed; err != nil {
+		t.Fatal(err)
+	}
+	next := <-acquired
+	if next == nil || next.w == h.w {
+		t.Fatal("expected a fresh writer after the prior close")
+	}
+	next.Close()
 }
 
 func TestGetWriterRejectsConflictingOptions(t *testing.T) {

--- a/pkg/observability/logging/manager/registry_test.go
+++ b/pkg/observability/logging/manager/registry_test.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manager
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetWriterErrors(t *testing.T) {
+	if _, err := GetWriter(nil); err != ErrNoFilename {
+		t.Errorf("expected ErrNoFilename, got %v", err)
+	}
+	if _, err := GetWriter(&Options{}); err != ErrNoFilename {
+		t.Errorf("expected ErrNoFilename, got %v", err)
+	}
+}
+
+func TestGetWriterSharing(t *testing.T) {
+	o := testOptions(t)
+	h1, err := GetWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := GetWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1.w != h2.w {
+		t.Error("expected handles to share one writer")
+	}
+	if h1.Filename() != o.Filename {
+		t.Errorf("unexpected filename: %s", h1.Filename())
+	}
+	if _, err = h1.Write([]byte("one\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err = h1.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// writer must remain open while another handle holds a reference
+	if _, err = h2.Write([]byte("two\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err = h2.Rotate(); err != nil {
+		t.Fatal(err)
+	}
+	if err = h2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if s := readFile(t, o.Filename+".1"); s != "one\ntwo\n" {
+		t.Errorf("unexpected content: %q", s)
+	}
+	// last release must close the underlying writer
+	if _, err = h2.w.Write([]byte("x")); err != os.ErrClosed {
+		t.Errorf("expected ErrClosed, got %v", err)
+	}
+	registry.Lock()
+	_, ok := registry.writers[mustAbs(t, o.Filename)]
+	registry.Unlock()
+	if ok {
+		t.Error("expected registry entry to be removed")
+	}
+}
+
+func TestHandleCloseIdempotent(t *testing.T) {
+	o := testOptions(t)
+	h1, err := GetWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h2, err := GetWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// double-close of one handle must not release the other's reference
+	h1.Close()
+	h1.Close()
+	if _, err = h2.Write([]byte("still open\n")); err != nil {
+		t.Fatalf("writer closed prematurely: %v", err)
+	}
+	h2.Close()
+}
+
+func TestGetWriterAfterRelease(t *testing.T) {
+	o := testOptions(t)
+	h1, err := GetWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h1.Write([]byte("first\n"))
+	h1.Close()
+	// a new handle after full release gets a fresh writer on the same file
+	h2, err := GetWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h2.w == h1.w {
+		t.Error("expected a new writer after full release")
+	}
+	h2.Write([]byte("second\n"))
+	h2.Close()
+	if s := readFile(t, o.Filename); s != "first\nsecond\n" {
+		t.Errorf("unexpected content: %q", s)
+	}
+}
+
+func mustAbs(t *testing.T, path string) string {
+	t.Helper()
+	s, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}

--- a/pkg/observability/logging/manager/registry_test.go
+++ b/pkg/observability/logging/manager/registry_test.go
@@ -17,6 +17,7 @@
 package manager
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -118,6 +119,28 @@ func TestGetWriterAfterRelease(t *testing.T) {
 	if s := readFile(t, o.Filename); s != "first\nsecond\n" {
 		t.Errorf("unexpected content: %q", s)
 	}
+}
+
+func TestGetWriterRejectsConflictingOptions(t *testing.T) {
+	o := testOptions(t)
+	h, err := GetWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer h.Close()
+	conflict := o.Clone()
+	conflict.RetentionCount++
+	if _, err = GetWriter(conflict); !errors.Is(err, ErrConflictingOptions) {
+		t.Fatalf("expected conflicting options error, got %v", err)
+	}
+	if err = Reconfigure(conflict); err != nil {
+		t.Fatal(err)
+	}
+	h2, err := GetWriter(conflict)
+	if err != nil {
+		t.Fatalf("get after reconfiguration failed: %v", err)
+	}
+	h2.Close()
 }
 
 func mustAbs(t *testing.T, path string) string {

--- a/pkg/observability/logging/manager/writer.go
+++ b/pkg/observability/logging/manager/writer.go
@@ -59,6 +59,24 @@ func (w *Writer) Filename() string {
 	return w.opts.Filename
 }
 
+// SetOptions updates the Writer's rotation, retention and compression
+// settings in place; the filename cannot be changed
+func (w *Writer) SetOptions(o *Options) {
+	if o == nil {
+		return
+	}
+	w.mtx.Lock()
+	w.opts.MaxSizeBytes = o.MaxSizeBytes
+	w.opts.Interval = o.Interval
+	w.opts.RetentionCount = o.RetentionCount
+	w.opts.RetentionAge = o.RetentionAge
+	w.opts.Compress = o.Compress
+	if o.FileMode != 0 {
+		w.opts.FileMode = o.FileMode
+	}
+	w.mtx.Unlock()
+}
+
 func (w *Writer) Write(p []byte) (int, error) {
 	w.mtx.Lock()
 	defer w.mtx.Unlock()
@@ -214,8 +232,11 @@ func (w *Writer) millRun() {
 // retention count or age. Errors are ignored: the writer cannot usefully
 // report failures of its own log maintenance.
 func (w *Writer) mill() {
-	archives := listArchives(w.opts.Filename)
-	if w.opts.Compress {
+	w.mtx.Lock()
+	opts := w.opts
+	w.mtx.Unlock()
+	archives := listArchives(opts.Filename)
+	if opts.Compress {
 		for _, a := range archives {
 			if !a.compressed {
 				compressArchive(a.path)
@@ -224,13 +245,13 @@ func (w *Writer) mill() {
 	}
 	now := w.now()
 	for _, a := range archives {
-		if a.n > w.opts.RetentionCount {
+		if a.n > opts.RetentionCount {
 			os.Remove(a.path)
 			continue
 		}
-		if w.opts.RetentionAge > 0 {
+		if opts.RetentionAge > 0 {
 			if fi, err := os.Stat(a.path); err == nil &&
-				now.Sub(fi.ModTime()) > w.opts.RetentionAge {
+				now.Sub(fi.ModTime()) > opts.RetentionAge {
 				os.Remove(a.path)
 			}
 		}

--- a/pkg/observability/logging/manager/writer.go
+++ b/pkg/observability/logging/manager/writer.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -35,18 +36,33 @@ type Writer struct {
 	archiveMtx    sync.Mutex
 	f             *os.File
 	fileInfo      os.FileInfo
+	buf           []byte
 	size          int64
 	openedAt      time.Time
 	nextPathCheck time.Time
+	flushTimer    *time.Timer
+	flushActive   bool
+	pendingSeq    uint64
+	droppedLines  uint64
 	wg            sync.WaitGroup
 	millPending   bool
 	millAgain     bool
+	epochPending  bool
+	epochAgain    bool
 	closed        bool
 	now           func() time.Time
 	compress      func(string)
+	write         func(*os.File, []byte) (int, error)
 }
 
-const pathCheckInterval = time.Second
+const (
+	pathCheckInterval   = time.Second
+	bufferFlushInterval = time.Second
+	writeBufferSize     = 64 * 1024
+	maxWriteBufferSize  = 4 * writeBufferSize
+	rotationEpochSuffix = ".rotation"
+	pendingMarker       = ".pending."
+)
 
 // NewWriter returns a Writer for the provided Options
 func NewWriter(o *Options) (*Writer, error) {
@@ -57,7 +73,17 @@ func NewWriter(o *Options) (*Writer, error) {
 	if opts.FileMode == 0 {
 		opts.FileMode = DefaultFileMode
 	}
-	return &Writer{opts: opts, now: time.Now, compress: compressArchive}, nil
+	w := &Writer{
+		opts: opts, now: time.Now, compress: compressArchive,
+		buf: make([]byte, 0, writeBufferSize),
+		write: func(f *os.File, p []byte) (int, error) {
+			return f.Write(p)
+		},
+	}
+	if len(listPending(opts.Filename)) > 0 {
+		w.requestMill()
+	}
+	return w, nil
 }
 
 // Filename returns the path to the live log file
@@ -98,24 +124,46 @@ func (w *Writer) Write(p []byte) (int, error) {
 		return 0, err
 	}
 	if w.shouldRotate(int64(len(p))) {
+		if err := w.flushLocked(); err != nil {
+			return 0, err
+		}
 		if err := w.rotate(); err != nil {
 			return 0, err
 		}
 	}
-	n, err := w.f.Write(p)
-	if err != nil {
-		// the live file may have been removed or invalidated externally
-		// (e.g., by logrotate); reopen and retry the write once
-		w.f.Close()
-		w.f = nil
-		w.fileInfo = nil
-		if err = w.open(); err != nil {
-			return n, err
-		}
-		n, err = w.f.Write(p)
+	if len(p) > maxWriteBufferSize-len(w.buf) {
+		w.droppedLines++
+		w.scheduleFlush(0)
+		return 0, ErrBufferFull
 	}
-	w.size += int64(n)
-	return n, err
+	wasEmpty := len(w.buf) == 0
+	w.buf = append(w.buf, p...)
+	w.size += int64(len(p))
+	if len(w.buf) >= writeBufferSize {
+		w.scheduleFlush(0)
+		return len(p), nil
+	}
+	if wasEmpty {
+		w.scheduleFlush(bufferFlushInterval)
+	}
+	return len(p), nil
+}
+
+// DroppedLines returns writes rejected because the bounded buffer was full.
+func (w *Writer) DroppedLines() uint64 {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	return w.droppedLines
+}
+
+// Flush writes buffered log data to the live file.
+func (w *Writer) Flush() error {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	if w.closed {
+		return os.ErrClosed
+	}
+	return w.flushLocked()
 }
 
 // Rotate forces an immediate rotation of the live log file
@@ -130,6 +178,9 @@ func (w *Writer) Rotate() error {
 			return err
 		}
 	}
+	if err := w.flushLocked(); err != nil {
+		return err
+	}
 	return w.rotate()
 }
 
@@ -142,9 +193,12 @@ func (w *Writer) Close() error {
 		return nil
 	}
 	w.closed = true
-	var err error
+	w.stopFlushTimer()
+	err := w.flushLocked()
 	if w.f != nil {
-		err = w.f.Close()
+		if closeErr := w.f.Close(); err == nil {
+			err = closeErr
+		}
 		w.f = nil
 		w.fileInfo = nil
 	}
@@ -153,7 +207,85 @@ func (w *Writer) Close() error {
 	return err
 }
 
-// shouldRotate is called with the mutex held
+func (w *Writer) scheduleFlush(delay time.Duration) {
+	if w.closed || len(w.buf) == 0 {
+		return
+	}
+	if w.flushActive {
+		if delay == 0 {
+			w.flushTimer.Reset(0)
+		}
+		return
+	}
+	w.flushActive = true
+	if w.flushTimer != nil {
+		w.flushTimer.Reset(delay)
+		return
+	}
+	w.flushTimer = time.AfterFunc(delay, func() {
+		w.mtx.Lock()
+		if !w.flushActive {
+			w.mtx.Unlock()
+			return
+		}
+		w.flushActive = false
+		if !w.closed {
+			_ = w.flushLocked()
+		}
+		w.mtx.Unlock()
+	})
+}
+
+func (w *Writer) stopFlushTimer() {
+	if w.flushTimer != nil {
+		w.flushTimer.Stop()
+	}
+	w.flushActive = false
+}
+
+func (w *Writer) flushLocked() error {
+	w.stopFlushTimer()
+	if len(w.buf) == 0 {
+		return nil
+	}
+	if w.f == nil {
+		if err := w.open(); err != nil {
+			w.scheduleFlush(bufferFlushInterval)
+			return err
+		}
+	}
+	err := w.writeBufferOnce()
+	if err != nil && len(w.buf) > 0 {
+		_ = w.f.Close()
+		w.f = nil
+		w.fileInfo = nil
+		if openErr := w.open(); openErr != nil {
+			w.scheduleFlush(bufferFlushInterval)
+			return openErr
+		}
+		err = w.writeBufferOnce()
+	}
+	if len(w.buf) > 0 {
+		w.scheduleFlush(bufferFlushInterval)
+	}
+	return err
+}
+
+func (w *Writer) writeBufferOnce() error {
+	n, err := w.write(w.f, w.buf)
+	if n > len(w.buf) {
+		n = len(w.buf)
+	}
+	if n > 0 {
+		copy(w.buf, w.buf[n:])
+		w.buf = w.buf[:len(w.buf)-n]
+	}
+	if err == nil && len(w.buf) > 0 {
+		return io.ErrShortWrite
+	}
+	return err
+}
+
 func (w *Writer) shouldRotate(incoming int64) bool {
 	if w.opts.MaxSizeBytes > 0 && w.size+incoming > w.opts.MaxSizeBytes {
 		return w.size > 0
@@ -164,8 +296,11 @@ func (w *Writer) shouldRotate(incoming int64) bool {
 	return false
 }
 
-// open is called with the mutex held
 func (w *Writer) open() error {
+	return w.openAt(time.Time{})
+}
+
+func (w *Writer) openAt(epoch time.Time) error {
 	if err := os.MkdirAll(filepath.Dir(w.opts.Filename), DefaultDirMode); err != nil {
 		return err
 	}
@@ -182,17 +317,50 @@ func (w *Writer) open() error {
 	now := w.now()
 	w.f = f
 	w.fileInfo = fi
-	w.size = fi.Size()
-	w.openedAt = now
-	w.nextPathCheck = now.Add(pathCheckInterval)
-	if fi.Size() > 0 {
-		w.openedAt = fi.ModTime()
+	w.size = fi.Size() + int64(len(w.buf))
+	if epoch.IsZero() {
+		epoch = readRotationEpoch(w.opts.Filename)
 	}
+	if epoch.IsZero() {
+		epoch = now
+		if fi.Size() > 0 {
+			epoch = fi.ModTime()
+		}
+	}
+	w.openedAt = epoch
+	w.nextPathCheck = now.Add(pathCheckInterval)
+	w.requestEpochWrite()
 	return nil
 }
 
-// ensureCurrentFile periodically detects external removal or replacement.
-// It is called with the mutex held.
+func (w *Writer) requestEpochWrite() {
+	if w.epochPending {
+		w.epochAgain = true
+		return
+	}
+	w.epochPending = true
+	w.wg.Add(1)
+	go w.epochWriteRun()
+}
+
+func (w *Writer) epochWriteRun() {
+	defer w.wg.Done()
+	for {
+		w.mtx.Lock()
+		filename, epoch, mode := w.opts.Filename, w.openedAt, w.opts.FileMode
+		w.mtx.Unlock()
+		writeRotationEpoch(filename, epoch, mode)
+		w.mtx.Lock()
+		if !w.epochAgain {
+			w.epochPending = false
+			w.mtx.Unlock()
+			return
+		}
+		w.epochAgain = false
+		w.mtx.Unlock()
+	}
+}
+
 func (w *Writer) ensureCurrentFile() error {
 	now := w.now()
 	if now.Before(w.nextPathCheck) {
@@ -201,7 +369,7 @@ func (w *Writer) ensureCurrentFile() error {
 	w.nextPathCheck = now.Add(pathCheckInterval)
 	fi, err := os.Stat(w.opts.Filename)
 	if err == nil && w.fileInfo != nil && os.SameFile(w.fileInfo, fi) {
-		w.size = fi.Size()
+		w.size = fi.Size() + int64(len(w.buf))
 		return nil
 	}
 	if err != nil && !os.IsNotExist(err) {
@@ -212,40 +380,33 @@ func (w *Writer) ensureCurrentFile() error {
 		w.f = nil
 	}
 	w.fileInfo = nil
-	return w.open()
+	_ = os.Remove(rotationEpochName(w.opts.Filename))
+	return w.openAt(now)
 }
 
-// rotate is called with the mutex held. It closes the live file, shifts the
-// numbered archives, reopens a fresh live file, and requests background
-// compression/pruning.
 func (w *Writer) rotate() error {
+	now := w.now()
 	if w.f != nil {
-		w.f.Close()
+		if err := w.f.Close(); err != nil {
+			return err
+		}
 		w.f = nil
 		w.fileInfo = nil
 	}
-	w.archiveMtx.Lock()
-	defer w.archiveMtx.Unlock()
-	if w.opts.RetentionCount < 1 {
-		os.Remove(w.opts.Filename)
-	} else {
-		removeArchive(w.opts.Filename, w.opts.RetentionCount)
-		for n := w.opts.RetentionCount - 1; n >= 1; n-- {
-			shiftArchive(w.opts.Filename, n)
-		}
-		err := os.Rename(w.opts.Filename, archiveName(w.opts.Filename, 1, false))
-		if err != nil && !os.IsNotExist(err) {
-			return err
-		}
+	w.pendingSeq++
+	pending := pendingName(w.opts.Filename, now, w.pendingSeq)
+	err := os.Rename(w.opts.Filename, pending)
+	if err != nil && !os.IsNotExist(err) {
+		_ = w.open()
+		return err
 	}
-	if err := w.open(); err != nil {
+	if err := w.openAt(now); err != nil {
 		return err
 	}
 	w.requestMill()
 	return nil
 }
 
-// requestMill is called with the mutex held
 func (w *Writer) requestMill() {
 	if w.millPending {
 		w.millAgain = true
@@ -271,15 +432,16 @@ func (w *Writer) millRun() {
 	}
 }
 
-// mill compresses uncompressed archives and prunes archives beyond the
-// retention count or age. Errors are ignored: the writer cannot usefully
-// report failures of its own log maintenance.
 func (w *Writer) mill() {
 	w.mtx.Lock()
 	opts := w.opts
 	w.mtx.Unlock()
 	w.archiveMtx.Lock()
 	defer w.archiveMtx.Unlock()
+	for _, pending := range listPending(opts.Filename) {
+		shiftArchives(opts.Filename, opts.RetentionCount)
+		_ = os.Rename(pending.path, archiveName(opts.Filename, 1, false))
+	}
 	archives := listArchives(opts.Filename)
 	if opts.Compress {
 		for _, a := range archives {
@@ -291,7 +453,7 @@ func (w *Writer) mill() {
 	}
 	now := w.now()
 	for _, a := range archives {
-		if a.n > opts.RetentionCount {
+		if opts.RetentionCount > 0 && a.n > opts.RetentionCount {
 			os.Remove(a.path)
 			continue
 		}
@@ -323,16 +485,73 @@ func removeArchive(filename string, n int) {
 	os.Remove(archiveName(filename, n, true))
 }
 
-// shiftArchive best-effort renames archive n to n+1, preferring the
-// compressed form
+func shiftArchives(filename string, retentionCount int) {
+	if retentionCount > 0 {
+		removeArchive(filename, retentionCount)
+		for n := retentionCount - 1; n >= 1; n-- {
+			shiftArchive(filename, n)
+		}
+		return
+	}
+	maxArchive := 0
+	for _, a := range listArchives(filename) {
+		if a.n > maxArchive {
+			maxArchive = a.n
+		}
+	}
+	for n := maxArchive; n >= 1; n-- {
+		shiftArchive(filename, n)
+	}
+}
+
 func shiftArchive(filename string, n int) {
 	if p := archiveName(filename, n, true); fileExists(p) {
 		_ = os.Rename(p, archiveName(filename, n+1, true))
-		return
 	}
 	if p := archiveName(filename, n, false); fileExists(p) {
 		_ = os.Rename(p, archiveName(filename, n+1, false))
 	}
+}
+
+type pendingArchive struct {
+	path    string
+	name    string
+	modTime time.Time
+}
+
+func pendingName(filename string, now time.Time, seq uint64) string {
+	return filename + pendingMarker + strconv.FormatInt(now.UnixNano(), 10) + "." +
+		strconv.FormatUint(seq, 10)
+}
+
+func listPending(filename string) []pendingArchive {
+	dir := filepath.Dir(filename)
+	prefix := filepath.Base(filename) + pendingMarker
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	out := make([]pendingArchive, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		out = append(out, pendingArchive{
+			path: filepath.Join(dir, entry.Name()), name: entry.Name(),
+			modTime: info.ModTime(),
+		})
+	}
+	slices.SortFunc(out, func(a, b pendingArchive) int {
+		if order := a.modTime.Compare(b.modTime); order != 0 {
+			return order
+		}
+		return strings.Compare(a.name, b.name)
+	})
+	return out
 }
 
 func fileExists(path string) bool {
@@ -340,7 +559,6 @@ func fileExists(path string) bool {
 	return err == nil
 }
 
-// listArchives returns the numbered archives for the provided live filename
 func listArchives(filename string) []archive {
 	dir := filepath.Dir(filename)
 	base := filepath.Base(filename) + "."
@@ -367,8 +585,6 @@ func listArchives(filename string) []archive {
 	return out
 }
 
-// compressArchive gzips the file at path to path.gz, preserving its
-// modification time, and removes the original on success
 func compressArchive(path string) {
 	src, err := os.Open(path)
 	if err != nil {
@@ -400,4 +616,25 @@ func compressArchive(path string) {
 	}
 	_ = os.Chtimes(dstPath, fi.ModTime(), fi.ModTime())
 	os.Remove(path)
+}
+
+func rotationEpochName(filename string) string {
+	return filename + rotationEpochSuffix
+}
+
+func readRotationEpoch(filename string) time.Time {
+	b, err := os.ReadFile(rotationEpochName(filename))
+	if err != nil {
+		return time.Time{}
+	}
+	nanos, err := strconv.ParseInt(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(0, nanos)
+}
+
+func writeRotationEpoch(filename string, epoch time.Time, mode os.FileMode) {
+	b := strconv.AppendInt(nil, epoch.UnixNano(), 10)
+	_ = os.WriteFile(rotationEpochName(filename), b, mode)
 }

--- a/pkg/observability/logging/manager/writer.go
+++ b/pkg/observability/logging/manager/writer.go
@@ -30,17 +30,23 @@ import (
 // Writer is a rotating, retention-managed log file writer. The live file is
 // opened lazily on first Write. Implements io.WriteCloser.
 type Writer struct {
-	opts        Options
-	mtx         sync.Mutex
-	f           *os.File
-	size        int64
-	openedAt    time.Time
-	wg          sync.WaitGroup
-	millPending bool
-	millAgain   bool
-	closed      bool
-	now         func() time.Time
+	opts          Options
+	mtx           sync.Mutex
+	archiveMtx    sync.Mutex
+	f             *os.File
+	fileInfo      os.FileInfo
+	size          int64
+	openedAt      time.Time
+	nextPathCheck time.Time
+	wg            sync.WaitGroup
+	millPending   bool
+	millAgain     bool
+	closed        bool
+	now           func() time.Time
+	compress      func(string)
 }
+
+const pathCheckInterval = time.Second
 
 // NewWriter returns a Writer for the provided Options
 func NewWriter(o *Options) (*Writer, error) {
@@ -51,7 +57,7 @@ func NewWriter(o *Options) (*Writer, error) {
 	if opts.FileMode == 0 {
 		opts.FileMode = DefaultFileMode
 	}
-	return &Writer{opts: opts, now: time.Now}, nil
+	return &Writer{opts: opts, now: time.Now, compress: compressArchive}, nil
 }
 
 // Filename returns the path to the live log file
@@ -88,6 +94,9 @@ func (w *Writer) Write(p []byte) (int, error) {
 			return 0, err
 		}
 	}
+	if err := w.ensureCurrentFile(); err != nil {
+		return 0, err
+	}
 	if w.shouldRotate(int64(len(p))) {
 		if err := w.rotate(); err != nil {
 			return 0, err
@@ -99,6 +108,7 @@ func (w *Writer) Write(p []byte) (int, error) {
 		// (e.g., by logrotate); reopen and retry the write once
 		w.f.Close()
 		w.f = nil
+		w.fileInfo = nil
 		if err = w.open(); err != nil {
 			return n, err
 		}
@@ -136,6 +146,7 @@ func (w *Writer) Close() error {
 	if w.f != nil {
 		err = w.f.Close()
 		w.f = nil
+		w.fileInfo = nil
 	}
 	w.mtx.Unlock()
 	w.wg.Wait()
@@ -163,16 +174,45 @@ func (w *Writer) open() error {
 	if err != nil {
 		return err
 	}
+	fi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return err
+	}
+	now := w.now()
 	w.f = f
-	w.size = 0
-	w.openedAt = w.now()
-	if fi, err2 := f.Stat(); err2 == nil {
-		w.size = fi.Size()
-		if fi.Size() > 0 {
-			w.openedAt = fi.ModTime()
-		}
+	w.fileInfo = fi
+	w.size = fi.Size()
+	w.openedAt = now
+	w.nextPathCheck = now.Add(pathCheckInterval)
+	if fi.Size() > 0 {
+		w.openedAt = fi.ModTime()
 	}
 	return nil
+}
+
+// ensureCurrentFile periodically detects external removal or replacement.
+// It is called with the mutex held.
+func (w *Writer) ensureCurrentFile() error {
+	now := w.now()
+	if now.Before(w.nextPathCheck) {
+		return nil
+	}
+	w.nextPathCheck = now.Add(pathCheckInterval)
+	fi, err := os.Stat(w.opts.Filename)
+	if err == nil && w.fileInfo != nil && os.SameFile(w.fileInfo, fi) {
+		w.size = fi.Size()
+		return nil
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	if w.f != nil {
+		_ = w.f.Close()
+		w.f = nil
+	}
+	w.fileInfo = nil
+	return w.open()
 }
 
 // rotate is called with the mutex held. It closes the live file, shifts the
@@ -182,7 +222,10 @@ func (w *Writer) rotate() error {
 	if w.f != nil {
 		w.f.Close()
 		w.f = nil
+		w.fileInfo = nil
 	}
+	w.archiveMtx.Lock()
+	defer w.archiveMtx.Unlock()
 	if w.opts.RetentionCount < 1 {
 		os.Remove(w.opts.Filename)
 	} else {
@@ -235,13 +278,16 @@ func (w *Writer) mill() {
 	w.mtx.Lock()
 	opts := w.opts
 	w.mtx.Unlock()
+	w.archiveMtx.Lock()
+	defer w.archiveMtx.Unlock()
 	archives := listArchives(opts.Filename)
 	if opts.Compress {
 		for _, a := range archives {
 			if !a.compressed {
-				compressArchive(a.path)
+				w.compress(a.path)
 			}
 		}
+		archives = listArchives(opts.Filename)
 	}
 	now := w.now()
 	for _, a := range archives {

--- a/pkg/observability/logging/manager/writer.go
+++ b/pkg/observability/logging/manager/writer.go
@@ -1,0 +1,336 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manager
+
+import (
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Writer is a rotating, retention-managed log file writer. The live file is
+// opened lazily on first Write. Implements io.WriteCloser.
+type Writer struct {
+	opts        Options
+	mtx         sync.Mutex
+	f           *os.File
+	size        int64
+	openedAt    time.Time
+	wg          sync.WaitGroup
+	millPending bool
+	millAgain   bool
+	closed      bool
+	now         func() time.Time
+}
+
+// NewWriter returns a Writer for the provided Options
+func NewWriter(o *Options) (*Writer, error) {
+	if o == nil || o.Filename == "" {
+		return nil, ErrNoFilename
+	}
+	opts := *o
+	if opts.FileMode == 0 {
+		opts.FileMode = DefaultFileMode
+	}
+	return &Writer{opts: opts, now: time.Now}, nil
+}
+
+// Filename returns the path to the live log file
+func (w *Writer) Filename() string {
+	return w.opts.Filename
+}
+
+func (w *Writer) Write(p []byte) (int, error) {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	if w.closed {
+		return 0, os.ErrClosed
+	}
+	if w.f == nil {
+		if err := w.open(); err != nil {
+			return 0, err
+		}
+	}
+	if w.shouldRotate(int64(len(p))) {
+		if err := w.rotate(); err != nil {
+			return 0, err
+		}
+	}
+	n, err := w.f.Write(p)
+	if err != nil {
+		// the live file may have been removed or invalidated externally
+		// (e.g., by logrotate); reopen and retry the write once
+		w.f.Close()
+		w.f = nil
+		if err = w.open(); err != nil {
+			return n, err
+		}
+		n, err = w.f.Write(p)
+	}
+	w.size += int64(n)
+	return n, err
+}
+
+// Rotate forces an immediate rotation of the live log file
+func (w *Writer) Rotate() error {
+	w.mtx.Lock()
+	defer w.mtx.Unlock()
+	if w.closed {
+		return os.ErrClosed
+	}
+	if w.f == nil {
+		if err := w.open(); err != nil {
+			return err
+		}
+	}
+	return w.rotate()
+}
+
+// Close closes the live file and waits for any background archive
+// maintenance to complete. Close is idempotent.
+func (w *Writer) Close() error {
+	w.mtx.Lock()
+	if w.closed {
+		w.mtx.Unlock()
+		return nil
+	}
+	w.closed = true
+	var err error
+	if w.f != nil {
+		err = w.f.Close()
+		w.f = nil
+	}
+	w.mtx.Unlock()
+	w.wg.Wait()
+	return err
+}
+
+// shouldRotate is called with the mutex held
+func (w *Writer) shouldRotate(incoming int64) bool {
+	if w.opts.MaxSizeBytes > 0 && w.size+incoming > w.opts.MaxSizeBytes {
+		return w.size > 0
+	}
+	if w.opts.Interval > 0 && w.now().Sub(w.openedAt) >= w.opts.Interval {
+		return w.size > 0
+	}
+	return false
+}
+
+// open is called with the mutex held
+func (w *Writer) open() error {
+	if err := os.MkdirAll(filepath.Dir(w.opts.Filename), DefaultDirMode); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(w.opts.Filename,
+		os.O_APPEND|os.O_CREATE|os.O_WRONLY, w.opts.FileMode)
+	if err != nil {
+		return err
+	}
+	w.f = f
+	w.size = 0
+	w.openedAt = w.now()
+	if fi, err2 := f.Stat(); err2 == nil {
+		w.size = fi.Size()
+		if fi.Size() > 0 {
+			w.openedAt = fi.ModTime()
+		}
+	}
+	return nil
+}
+
+// rotate is called with the mutex held. It closes the live file, shifts the
+// numbered archives, reopens a fresh live file, and requests background
+// compression/pruning.
+func (w *Writer) rotate() error {
+	if w.f != nil {
+		w.f.Close()
+		w.f = nil
+	}
+	if w.opts.RetentionCount < 1 {
+		os.Remove(w.opts.Filename)
+	} else {
+		removeArchive(w.opts.Filename, w.opts.RetentionCount)
+		for n := w.opts.RetentionCount - 1; n >= 1; n-- {
+			shiftArchive(w.opts.Filename, n)
+		}
+		err := os.Rename(w.opts.Filename, archiveName(w.opts.Filename, 1, false))
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if err := w.open(); err != nil {
+		return err
+	}
+	w.requestMill()
+	return nil
+}
+
+// requestMill is called with the mutex held
+func (w *Writer) requestMill() {
+	if w.millPending {
+		w.millAgain = true
+		return
+	}
+	w.millPending = true
+	w.wg.Add(1)
+	go w.millRun()
+}
+
+func (w *Writer) millRun() {
+	defer w.wg.Done()
+	for {
+		w.mill()
+		w.mtx.Lock()
+		if !w.millAgain {
+			w.millPending = false
+			w.mtx.Unlock()
+			return
+		}
+		w.millAgain = false
+		w.mtx.Unlock()
+	}
+}
+
+// mill compresses uncompressed archives and prunes archives beyond the
+// retention count or age. Errors are ignored: the writer cannot usefully
+// report failures of its own log maintenance.
+func (w *Writer) mill() {
+	archives := listArchives(w.opts.Filename)
+	if w.opts.Compress {
+		for _, a := range archives {
+			if !a.compressed {
+				compressArchive(a.path)
+			}
+		}
+	}
+	now := w.now()
+	for _, a := range archives {
+		if a.n > w.opts.RetentionCount {
+			os.Remove(a.path)
+			continue
+		}
+		if w.opts.RetentionAge > 0 {
+			if fi, err := os.Stat(a.path); err == nil &&
+				now.Sub(fi.ModTime()) > w.opts.RetentionAge {
+				os.Remove(a.path)
+			}
+		}
+	}
+}
+
+type archive struct {
+	path       string
+	n          int
+	compressed bool
+}
+
+func archiveName(filename string, n int, compressed bool) string {
+	s := filename + "." + strconv.Itoa(n)
+	if compressed {
+		s += ".gz"
+	}
+	return s
+}
+
+func removeArchive(filename string, n int) {
+	os.Remove(archiveName(filename, n, false))
+	os.Remove(archiveName(filename, n, true))
+}
+
+// shiftArchive best-effort renames archive n to n+1, preferring the
+// compressed form
+func shiftArchive(filename string, n int) {
+	if p := archiveName(filename, n, true); fileExists(p) {
+		_ = os.Rename(p, archiveName(filename, n+1, true))
+		return
+	}
+	if p := archiveName(filename, n, false); fileExists(p) {
+		_ = os.Rename(p, archiveName(filename, n+1, false))
+	}
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// listArchives returns the numbered archives for the provided live filename
+func listArchives(filename string) []archive {
+	dir := filepath.Dir(filename)
+	base := filepath.Base(filename) + "."
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	out := make([]archive, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasPrefix(e.Name(), base) {
+			continue
+		}
+		suffix, compressed := strings.CutSuffix(e.Name()[len(base):], ".gz")
+		n, err := strconv.Atoi(suffix)
+		if err != nil || n < 1 {
+			continue
+		}
+		out = append(out, archive{
+			path:       filepath.Join(dir, e.Name()),
+			n:          n,
+			compressed: compressed,
+		})
+	}
+	return out
+}
+
+// compressArchive gzips the file at path to path.gz, preserving its
+// modification time, and removes the original on success
+func compressArchive(path string) {
+	src, err := os.Open(path)
+	if err != nil {
+		return
+	}
+	defer src.Close()
+	fi, err := src.Stat()
+	if err != nil {
+		return
+	}
+	dstPath := path + ".gz"
+	dst, err := os.OpenFile(dstPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, fi.Mode())
+	if err != nil {
+		return
+	}
+	gz := gzip.NewWriter(dst)
+	_, err = io.Copy(gz, src)
+	if err == nil {
+		err = gz.Close()
+	} else {
+		_ = gz.Close()
+	}
+	if err2 := dst.Close(); err == nil {
+		err = err2
+	}
+	if err != nil {
+		os.Remove(dstPath)
+		return
+	}
+	_ = os.Chtimes(dstPath, fi.ModTime(), fi.ModTime())
+	os.Remove(path)
+}

--- a/pkg/observability/logging/manager/writer_test.go
+++ b/pkg/observability/logging/manager/writer_test.go
@@ -19,6 +19,7 @@ package manager
 import (
 	"bytes"
 	"compress/gzip"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -130,7 +131,7 @@ func TestRetentionCountPruning(t *testing.T) {
 	}
 }
 
-func TestRetentionCountZeroDeletesOnRotate(t *testing.T) {
+func TestRetentionCountZeroKeepsAllArchives(t *testing.T) {
 	o := testOptions(t)
 	o.MaxSizeBytes = 4
 	o.RetentionCount = 0
@@ -140,12 +141,16 @@ func TestRetentionCountZeroDeletesOnRotate(t *testing.T) {
 	}
 	mustWrite(t, w, "aaaa")
 	mustWrite(t, w, "bbbb")
+	mustWrite(t, w, "cccc")
 	w.Close()
-	if s := readFile(t, o.Filename); s != "bbbb" {
+	if s := readFile(t, o.Filename); s != "cccc" {
 		t.Errorf("unexpected live content: %q", s)
 	}
-	if fileExists(o.Filename + ".1") {
-		t.Error("expected no archives with zero retention count")
+	if s := readFile(t, o.Filename+".1"); s != "bbbb" {
+		t.Errorf("unexpected .1 content: %q", s)
+	}
+	if s := readFile(t, o.Filename+".2"); s != "aaaa" {
+		t.Errorf("unexpected .2 content: %q", s)
 	}
 }
 
@@ -314,6 +319,9 @@ func TestReopenAfterExternalRemoval(t *testing.T) {
 		t.Fatal(err)
 	}
 	mustWrite(t, w, "aaaa")
+	if err = w.Flush(); err != nil {
+		t.Fatal(err)
+	}
 	if err = os.Remove(o.Filename); err != nil {
 		t.Fatal(err)
 	}
@@ -325,7 +333,7 @@ func TestReopenAfterExternalRemoval(t *testing.T) {
 	}
 }
 
-func TestRotationWaitsForCompression(t *testing.T) {
+func TestRotationDoesNotWaitForCompression(t *testing.T) {
 	o := testOptions(t)
 	o.MaxSizeBytes = 4
 	o.RetentionCount = 3
@@ -352,13 +360,13 @@ func TestRotationWaitsForCompression(t *testing.T) {
 	}()
 	select {
 	case err := <-done:
-		t.Fatalf("rotation completed during compression: %v", err)
+		if err != nil {
+			t.Fatal(err)
+		}
 	case <-time.After(20 * time.Millisecond):
+		t.Fatal("rotation blocked on background compression")
 	}
 	close(release)
-	if err = <-done; err != nil {
-		t.Fatal(err)
-	}
 	if err = w.Close(); err != nil {
 		t.Fatal(err)
 	}
@@ -370,6 +378,184 @@ func TestRotationWaitsForCompression(t *testing.T) {
 	}
 	if s := readGzipFile(t, o.Filename+".2.gz"); s != "aaaa" {
 		t.Errorf("unexpected .2 content: %q", s)
+	}
+}
+
+func TestBufferedWriteFlush(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "buffered")
+	if s := readFile(t, o.Filename); s != "" {
+		t.Fatalf("write bypassed buffer: %q", s)
+	}
+	if err = w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if s := readFile(t, o.Filename); s != "buffered" {
+		t.Errorf("unexpected flushed content: %q", s)
+	}
+	w.Close()
+}
+
+func TestBufferedWriteThresholdAndTimer(t *testing.T) {
+	t.Run("threshold", func(t *testing.T) {
+		o := testOptions(t)
+		w, err := NewWriter(o)
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := strings.Repeat("x", writeBufferSize)
+		mustWrite(t, w, payload)
+		deadline := time.Now().Add(bufferFlushInterval)
+		for time.Now().Before(deadline) {
+			if b, readErr := os.ReadFile(o.Filename); readErr == nil && string(b) == payload {
+				w.Close()
+				return
+			}
+			time.Sleep(time.Millisecond)
+		}
+		w.Close()
+		t.Error("threshold buffer was not flushed promptly")
+	})
+
+	t.Run("timer", func(t *testing.T) {
+		o := testOptions(t)
+		w, err := NewWriter(o)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mustWrite(t, w, "timer")
+		deadline := time.Now().Add(2 * bufferFlushInterval)
+		for time.Now().Before(deadline) {
+			if b, readErr := os.ReadFile(o.Filename); readErr == nil && string(b) == "timer" {
+				w.Close()
+				return
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+		w.Close()
+		t.Error("buffer was not flushed by the timer")
+	})
+}
+
+func TestBufferLimitDropsWholeWrite(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.mtx.Lock()
+	w.buf = append(w.buf, make([]byte, maxWriteBufferSize-1)...)
+	w.mtx.Unlock()
+	if n, writeErr := w.Write([]byte("line")); n != 0 || !errors.Is(writeErr, ErrBufferFull) {
+		t.Fatalf("write = %d, %v; want 0, ErrBufferFull", n, writeErr)
+	}
+	if w.DroppedLines() != 1 {
+		t.Errorf("dropped lines = %d, want 1", w.DroppedLines())
+	}
+	if err = w.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPartialWriteRetryDoesNotDuplicate(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first := true
+	w.write = func(f *os.File, p []byte) (int, error) {
+		if first {
+			first = false
+			n, writeErr := f.Write(p[:2])
+			if writeErr != nil {
+				return n, writeErr
+			}
+			return n, errors.New("injected partial write")
+		}
+		return f.Write(p)
+	}
+	mustWrite(t, w, "abcdef")
+	if err = w.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if err = w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, o.Filename); got != "abcdef" {
+		t.Errorf("partial retry content = %q, want abcdef", got)
+	}
+}
+
+func TestFlushReopensRetainedBuffer(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "retained")
+	dir := filepath.Dir(o.Filename)
+	movedDir := dir + ".moved"
+	first := true
+	w.write = func(*os.File, []byte) (int, error) {
+		if first {
+			first = false
+			if renameErr := os.Rename(dir, movedDir); renameErr != nil {
+				t.Fatal(renameErr)
+			}
+			if writeErr := os.WriteFile(dir, []byte("blocker"), 0o600); writeErr != nil {
+				t.Fatal(writeErr)
+			}
+		}
+		return 0, errors.New("injected write failure")
+	}
+	if err = w.Flush(); err == nil {
+		t.Fatal("expected reopen failure")
+	}
+	if removeErr := os.Remove(dir); removeErr != nil {
+		t.Fatal(removeErr)
+	}
+	if renameErr := os.Rename(movedDir, dir); renameErr != nil {
+		t.Fatal(renameErr)
+	}
+	w.write = func(f *os.File, p []byte) (int, error) { return f.Write(p) }
+	if err = w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := readFile(t, o.Filename); got != "retained" {
+		t.Errorf("recovered content = %q, want retained", got)
+	}
+}
+
+func TestIntervalEpochSurvivesRestart(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 0
+	o.Interval = time.Hour
+	start := time.Now().Add(-2 * time.Hour)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.now = func() time.Time { return start }
+	mustWrite(t, w, "old")
+	w.Close()
+
+	w, err = NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.now = time.Now
+	mustWrite(t, w, "new")
+	w.Close()
+	if s := readFile(t, o.Filename); s != "new" {
+		t.Errorf("unexpected live content: %q", s)
+	}
+	if s := readFile(t, o.Filename+".1"); s != "old" {
+		t.Errorf("unexpected rotated content: %q", s)
 	}
 }
 

--- a/pkg/observability/logging/manager/writer_test.go
+++ b/pkg/observability/logging/manager/writer_test.go
@@ -227,6 +227,24 @@ func TestAgePruning(t *testing.T) {
 	}
 }
 
+func TestCompressedAgePruning(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 4
+	o.RetentionAge = time.Hour
+	o.Compress = true
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "aaaa")
+	w.now = func() time.Time { return time.Now().Add(2 * time.Hour) }
+	mustWrite(t, w, "bbbb")
+	w.Close()
+	if fileExists(o.Filename+".1") || fileExists(o.Filename+".1.gz") {
+		t.Error("expected compressed aged archive to be pruned")
+	}
+}
+
 func TestTimeRotation(t *testing.T) {
 	o := testOptions(t)
 	o.MaxSizeBytes = 0
@@ -296,14 +314,82 @@ func TestReopenAfterExternalRemoval(t *testing.T) {
 		t.Fatal(err)
 	}
 	mustWrite(t, w, "aaaa")
-	// close the handle out from under the writer to force a write error
-	w.f.Close()
-	os.Remove(o.Filename)
+	if err = os.Remove(o.Filename); err != nil {
+		t.Fatal(err)
+	}
+	w.now = func() time.Time { return time.Now().Add(2 * pathCheckInterval) }
 	mustWrite(t, w, "bbbb")
 	w.Close()
 	if s := readFile(t, o.Filename); s != "bbbb" {
 		t.Errorf("unexpected content after reopen: %q", s)
 	}
+}
+
+func TestRotationWaitsForCompression(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 4
+	o.RetentionCount = 3
+	o.Compress = true
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var startedOnce sync.Once
+	w.compress = func(path string) {
+		startedOnce.Do(func() { close(started) })
+		<-release
+		compressArchive(path)
+	}
+	mustWrite(t, w, "aaaa")
+	mustWrite(t, w, "bbbb")
+	<-started
+	done := make(chan error, 1)
+	go func() {
+		_, err := w.Write([]byte("cccc"))
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("rotation completed during compression: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	if err = <-done; err != nil {
+		t.Fatal(err)
+	}
+	if err = w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if s := readFile(t, o.Filename); s != "cccc" {
+		t.Errorf("unexpected live content: %q", s)
+	}
+	if s := readGzipFile(t, o.Filename+".1.gz"); s != "bbbb" {
+		t.Errorf("unexpected .1 content: %q", s)
+	}
+	if s := readGzipFile(t, o.Filename+".2.gz"); s != "aaaa" {
+		t.Errorf("unexpected .2 content: %q", s)
+	}
+}
+
+func readGzipFile(t *testing.T, path string) string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	zr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer zr.Close()
+	b, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
 }
 
 func TestOpenFailure(t *testing.T) {
@@ -476,7 +562,7 @@ func TestSetOptions(t *testing.T) {
 	}
 }
 
-func TestGetWriterUpdatesOptions(t *testing.T) {
+func TestReconfigureUpdatesSharedWriter(t *testing.T) {
 	o := testOptions(t)
 	h1, err := GetWriter(o)
 	if err != nil {
@@ -484,6 +570,9 @@ func TestGetWriterUpdatesOptions(t *testing.T) {
 	}
 	o2 := o.Clone()
 	o2.MaxSizeBytes = 42
+	if err = Reconfigure(o2); err != nil {
+		t.Fatal(err)
+	}
 	h2, err := GetWriter(o2)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/observability/logging/manager/writer_test.go
+++ b/pkg/observability/logging/manager/writer_test.go
@@ -452,3 +452,51 @@ func TestMillPrunesStrayArchives(t *testing.T) {
 		t.Error("expected .1 archive to be retained")
 	}
 }
+
+func TestSetOptions(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.SetOptions(nil) // no-op
+	mustWrite(t, w, "aaaa")
+	// lower the rotation threshold; the next write must rotate
+	o2 := o.Clone()
+	o2.MaxSizeBytes = 4
+	o2.RetentionCount = 2
+	w.SetOptions(o2)
+	mustWrite(t, w, "bbbb")
+	w.Close()
+	if s := readFile(t, o.Filename+".1"); s != "aaaa" {
+		t.Errorf("expected rotation under updated options, got %q", s)
+	}
+	if w.opts.FileMode != DefaultFileMode {
+		t.Errorf("unexpected file mode: %v", w.opts.FileMode)
+	}
+}
+
+func TestGetWriterUpdatesOptions(t *testing.T) {
+	o := testOptions(t)
+	h1, err := GetWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	o2 := o.Clone()
+	o2.MaxSizeBytes = 42
+	h2, err := GetWriter(o2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1.w != h2.w {
+		t.Fatal("expected shared writer")
+	}
+	h1.w.mtx.Lock()
+	size := h1.w.opts.MaxSizeBytes
+	h1.w.mtx.Unlock()
+	if size != 42 {
+		t.Errorf("expected updated max size, got %d", size)
+	}
+	h1.Close()
+	h2.Close()
+}

--- a/pkg/observability/logging/manager/writer_test.go
+++ b/pkg/observability/logging/manager/writer_test.go
@@ -1,0 +1,454 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manager
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func testOptions(t *testing.T) *Options {
+	t.Helper()
+	o := NewOptions()
+	o.Filename = filepath.Join(t.TempDir(), "test.log")
+	o.Compress = false
+	return o
+}
+
+func mustWrite(t *testing.T, w *Writer, s string) {
+	t.Helper()
+	n, err := w.Write([]byte(s))
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	if n != len(s) {
+		t.Fatalf("expected %d bytes written, got %d", len(s), n)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s failed: %v", path, err)
+	}
+	return string(b)
+}
+
+func TestNewWriterErrors(t *testing.T) {
+	if _, err := NewWriter(nil); err != ErrNoFilename {
+		t.Errorf("expected ErrNoFilename, got %v", err)
+	}
+	if _, err := NewWriter(&Options{}); err != ErrNoFilename {
+		t.Errorf("expected ErrNoFilename, got %v", err)
+	}
+}
+
+func TestWriteAndAppend(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "hello\n")
+	if err = w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// a new writer on the same file should append, not truncate
+	w2, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w2, "world\n")
+	w2.Close()
+	if s := readFile(t, o.Filename); s != "hello\nworld\n" {
+		t.Errorf("unexpected content: %q", s)
+	}
+}
+
+func TestSizeRotation(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 10
+	o.RetentionCount = 2
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "1111111111") // fills the file exactly
+	mustWrite(t, w, "2222222222") // triggers rotation to .1
+	mustWrite(t, w, "3333333333") // triggers rotation, shifting .1 -> .2
+	w.Close()
+	if s := readFile(t, o.Filename); s != "3333333333" {
+		t.Errorf("unexpected live content: %q", s)
+	}
+	if s := readFile(t, o.Filename+".1"); s != "2222222222" {
+		t.Errorf("unexpected .1 content: %q", s)
+	}
+	if s := readFile(t, o.Filename+".2"); s != "1111111111" {
+		t.Errorf("unexpected .2 content: %q", s)
+	}
+}
+
+func TestRetentionCountPruning(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 4
+	o.RetentionCount = 1
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range []string{"aaaa", "bbbb", "cccc"} {
+		mustWrite(t, w, s)
+	}
+	w.Close()
+	if s := readFile(t, o.Filename+".1"); s != "bbbb" {
+		t.Errorf("unexpected .1 content: %q", s)
+	}
+	if fileExists(o.Filename + ".2") {
+		t.Error("expected .2 to be pruned")
+	}
+}
+
+func TestRetentionCountZeroDeletesOnRotate(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 4
+	o.RetentionCount = 0
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "aaaa")
+	mustWrite(t, w, "bbbb")
+	w.Close()
+	if s := readFile(t, o.Filename); s != "bbbb" {
+		t.Errorf("unexpected live content: %q", s)
+	}
+	if fileExists(o.Filename + ".1") {
+		t.Error("expected no archives with zero retention count")
+	}
+}
+
+func TestCompression(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 4
+	o.Compress = true
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "aaaa")
+	mustWrite(t, w, "bbbb")
+	w.Close() // waits for background compression
+	gzPath := o.Filename + ".1.gz"
+	if fileExists(o.Filename + ".1") {
+		t.Error("expected uncompressed archive to be removed")
+	}
+	f, err := os.Open(gzPath)
+	if err != nil {
+		t.Fatalf("expected compressed archive: %v", err)
+	}
+	defer f.Close()
+	zr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "aaaa" {
+		t.Errorf("unexpected archive content: %q", string(b))
+	}
+}
+
+func TestCompressedArchiveShift(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 4
+	o.Compress = true
+	o.RetentionCount = 3
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "aaaa")
+	mustWrite(t, w, "bbbb")
+	w.Close()
+	// reopen and rotate again; the compressed .1.gz must shift to .2.gz
+	w2, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w2, "cccc")
+	w2.Close()
+	if !fileExists(o.Filename + ".1.gz") {
+		t.Error("expected .1.gz to exist")
+	}
+	if !fileExists(o.Filename + ".2.gz") {
+		t.Error("expected .2.gz to exist")
+	}
+}
+
+func TestAgePruning(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 4
+	o.RetentionAge = time.Hour
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "aaaa")
+	// force rotation and simulate the archive being older than the max age
+	w.now = func() time.Time { return time.Now().Add(2 * time.Hour) }
+	mustWrite(t, w, "bbbb")
+	w.Close()
+	if fileExists(o.Filename+".1") || fileExists(o.Filename+".1.gz") {
+		t.Error("expected aged archive to be pruned")
+	}
+}
+
+func TestTimeRotation(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 0
+	o.Interval = time.Hour
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "aaaa")
+	mustWrite(t, w, "bbbb") // same window; no rotation
+	w.now = func() time.Time { return time.Now().Add(2 * time.Hour) }
+	mustWrite(t, w, "cccc")
+	w.Close()
+	if s := readFile(t, o.Filename); s != "cccc" {
+		t.Errorf("unexpected live content: %q", s)
+	}
+	if s := readFile(t, o.Filename+".1"); s != "aaaabbbb" {
+		t.Errorf("unexpected .1 content: %q", s)
+	}
+}
+
+func TestForcedRotate(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "aaaa")
+	if err = w.Rotate(); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "bbbb")
+	w.Close()
+	if s := readFile(t, o.Filename); s != "bbbb" {
+		t.Errorf("unexpected live content: %q", s)
+	}
+	if s := readFile(t, o.Filename+".1"); s != "aaaa" {
+		t.Errorf("unexpected .1 content: %q", s)
+	}
+	if err = w.Rotate(); err != os.ErrClosed {
+		t.Errorf("expected ErrClosed, got %v", err)
+	}
+}
+
+func TestWriteAfterClose(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "aaaa")
+	if err = w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err = w.Close(); err != nil {
+		t.Errorf("expected idempotent close, got %v", err)
+	}
+	if _, err = w.Write([]byte("x")); err != os.ErrClosed {
+		t.Errorf("expected ErrClosed, got %v", err)
+	}
+}
+
+func TestReopenAfterExternalRemoval(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, w, "aaaa")
+	// close the handle out from under the writer to force a write error
+	w.f.Close()
+	os.Remove(o.Filename)
+	mustWrite(t, w, "bbbb")
+	w.Close()
+	if s := readFile(t, o.Filename); s != "bbbb" {
+		t.Errorf("unexpected content after reopen: %q", s)
+	}
+}
+
+func TestOpenFailure(t *testing.T) {
+	o := NewOptions()
+	// a path whose parent is a file cannot be created
+	base := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(base, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	o.Filename = filepath.Join(base, "test.log")
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = w.Write([]byte("x")); err == nil {
+		t.Error("expected open error")
+	}
+	w.Close()
+}
+
+func TestConcurrentWrites(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 128
+	o.RetentionCount = 100
+	o.Compress = true
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	line := strings.Repeat("z", 31) + "\n"
+	for range 8 {
+		wg.Go(func() {
+			for range 50 {
+				w.Write([]byte(line))
+			}
+		})
+	}
+	wg.Wait()
+	if err = w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	// every written line must be present exactly once across live + archives
+	var total int
+	for _, a := range listArchives(o.Filename) {
+		b, err := os.ReadFile(a.path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a.compressed {
+			zr, err := gzip.NewReader(bytes.NewReader(b))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if b, err = io.ReadAll(zr); err != nil {
+				t.Fatal(err)
+			}
+		}
+		total += strings.Count(string(b), "\n")
+	}
+	total += strings.Count(readFile(t, o.Filename), "\n")
+	if total != 400 {
+		t.Errorf("expected 400 lines across all files, got %d", total)
+	}
+}
+
+func TestListArchivesIgnoresUnrelated(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "test.log")
+	for _, f := range []string{"test.log", "test.log.1", "test.log.2.gz",
+		"test.log.bak", "test.log.0", "other.log.1"} {
+		os.WriteFile(filepath.Join(dir, f), []byte("x"), 0644)
+	}
+	os.Mkdir(filepath.Join(dir, "test.log.3"), 0755)
+	archives := listArchives(name)
+	if len(archives) != 2 {
+		t.Fatalf("expected 2 archives, got %d", len(archives))
+	}
+}
+
+func TestListArchivesMissingDir(t *testing.T) {
+	if a := listArchives(filepath.Join(t.TempDir(), "nope", "x.log")); a != nil {
+		t.Errorf("expected nil, got %v", a)
+	}
+}
+
+func TestCompressArchiveErrors(t *testing.T) {
+	// missing source is a no-op
+	compressArchive(filepath.Join(t.TempDir(), "missing.log.1"))
+	// an unwritable destination is a no-op that leaves the source in place
+	dir := t.TempDir()
+	src := filepath.Join(dir, "test.log.1")
+	os.WriteFile(src, []byte("x"), 0644)
+	os.Mkdir(src+".gz", 0755)
+	compressArchive(src)
+	if !fileExists(src) {
+		t.Error("expected source to remain after failed compression")
+	}
+}
+
+func TestRotateUnopened(t *testing.T) {
+	o := testOptions(t)
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = w.Rotate(); err != nil {
+		t.Fatal(err)
+	}
+	w.Close()
+	if !fileExists(o.Filename) {
+		t.Error("expected live file to exist after rotating an unopened writer")
+	}
+}
+
+func TestDefaultFileModeApplied(t *testing.T) {
+	w, err := NewWriter(&Options{
+		Filename: filepath.Join(t.TempDir(), "test.log"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if w.opts.FileMode != DefaultFileMode {
+		t.Errorf("expected default file mode, got %v", w.opts.FileMode)
+	}
+	w.Close()
+}
+
+func TestMillPrunesStrayArchives(t *testing.T) {
+	o := testOptions(t)
+	o.MaxSizeBytes = 4
+	o.RetentionCount = 1
+	w, err := NewWriter(o)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// simulate an archive left over from a larger retention setting
+	os.WriteFile(o.Filename+".5", []byte("stale"), 0644)
+	mustWrite(t, w, "aaaa")
+	mustWrite(t, w, "bbbb")
+	w.Close()
+	if fileExists(o.Filename + ".5") {
+		t.Error("expected stray archive beyond retention count to be pruned")
+	}
+	if !fileExists(o.Filename + ".1") {
+		t.Error("expected .1 archive to be retained")
+	}
+}

--- a/pkg/observability/logging/manager/yaml_options.go
+++ b/pkg/observability/logging/manager/yaml_options.go
@@ -36,7 +36,7 @@ type RotationOptions struct {
 // RetentionOptions is the YAML-facing configuration for how many rotated
 // archives are kept; nil fields inherit defaults, explicit zeros disable
 type RetentionOptions struct {
-	// Count is the maximum number of archived files kept
+	// Count is the maximum archived files kept; zero disables count pruning
 	Count *int `yaml:"count,omitempty"`
 	// Age prunes archived files older than this
 	Age *timeconv.Duration `yaml:"age,omitempty"`

--- a/pkg/observability/logging/manager/yaml_options.go
+++ b/pkg/observability/logging/manager/yaml_options.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manager
+
+import (
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/parsing/sizeconv"
+	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
+	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
+)
+
+// RotationOptions is the YAML-facing configuration for when a managed log
+// file is rotated; nil fields inherit defaults, explicit zeros disable
+type RotationOptions struct {
+	// Size rotates the log when the live file would exceed this size
+	Size *sizeconv.Size `yaml:"size,omitempty"`
+	// Interval rotates the log when the live file has been open this long
+	Interval *timeconv.Duration `yaml:"interval,omitempty"`
+}
+
+// RetentionOptions is the YAML-facing configuration for how many rotated
+// archives are kept; nil fields inherit defaults, explicit zeros disable
+type RetentionOptions struct {
+	// Count is the maximum number of archived files kept
+	Count *int `yaml:"count,omitempty"`
+	// Age prunes archived files older than this
+	Age *timeconv.Duration `yaml:"age,omitempty"`
+}
+
+// Clone returns a copy of the RotationOptions
+func (o *RotationOptions) Clone() *RotationOptions {
+	if o == nil {
+		return nil
+	}
+	return &RotationOptions{
+		Size:     pointers.Clone(o.Size),
+		Interval: pointers.Clone(o.Interval),
+	}
+}
+
+// Clone returns a copy of the RetentionOptions
+func (o *RetentionOptions) Clone() *RetentionOptions {
+	if o == nil {
+		return nil
+	}
+	return &RetentionOptions{
+		Count: pointers.Clone(o.Count),
+		Age:   pointers.Clone(o.Age),
+	}
+}
+
+// ResolveOptions maps YAML-facing rotation/retention/compression settings
+// onto a manager Options for the provided filename, applying defaults for
+// any nil field
+func ResolveOptions(filename string, rot *RotationOptions,
+	ret *RetentionOptions, compress *bool,
+) *Options {
+	o := NewOptions()
+	o.Filename = filename
+	if rot != nil {
+		if rot.Size != nil {
+			o.MaxSizeBytes = int64(*rot.Size)
+		}
+		if rot.Interval != nil {
+			o.Interval = time.Duration(*rot.Interval)
+		}
+	}
+	if ret != nil {
+		if ret.Count != nil {
+			o.RetentionCount = *ret.Count
+		}
+		if ret.Age != nil {
+			o.RetentionAge = time.Duration(*ret.Age)
+		}
+	}
+	if compress != nil {
+		o.Compress = *compress
+	}
+	return o
+}

--- a/pkg/observability/logging/manager/yaml_options_test.go
+++ b/pkg/observability/logging/manager/yaml_options_test.go
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package manager
+
+import (
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/parsing/sizeconv"
+	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
+)
+
+func TestResolveOptionsDefaults(t *testing.T) {
+	o := ResolveOptions("/tmp/x.log", nil, nil, nil)
+	if o.Filename != "/tmp/x.log" ||
+		o.MaxSizeBytes != DefaultMaxSizeBytes ||
+		o.Interval != 0 ||
+		o.RetentionCount != DefaultRetentionCount ||
+		o.RetentionAge != DefaultRetentionAge ||
+		!o.Compress {
+		t.Errorf("unexpected resolved options: %+v", o)
+	}
+}
+
+func TestResolveOptionsExplicit(t *testing.T) {
+	size := sizeconv.Size(64)
+	interval := timeconv.Duration(time.Hour)
+	count := 0
+	age := timeconv.Duration(0)
+	compress := false
+	o := ResolveOptions("/tmp/x.log",
+		&RotationOptions{Size: &size, Interval: &interval},
+		&RetentionOptions{Count: &count, Age: &age}, &compress)
+	if o.MaxSizeBytes != 64 || o.Interval != time.Hour ||
+		o.RetentionCount != 0 || o.RetentionAge != 0 || o.Compress {
+		t.Errorf("unexpected resolved options: %+v", o)
+	}
+}
+
+func TestRotationRetentionClone(t *testing.T) {
+	var nilRot *RotationOptions
+	var nilRet *RetentionOptions
+	if nilRot.Clone() != nil || nilRet.Clone() != nil {
+		t.Error("expected nil clones")
+	}
+	size := sizeconv.Size(64)
+	count := 3
+	rot := &RotationOptions{Size: &size}
+	ret := &RetentionOptions{Count: &count}
+	rotC, retC := rot.Clone(), ret.Clone()
+	if rotC.Size == rot.Size || *rotC.Size != 64 {
+		t.Error("expected deep rotation clone")
+	}
+	if retC.Count == ret.Count || *retC.Count != 3 {
+		t.Error("expected deep retention clone")
+	}
+	if rotC.Interval != nil || retC.Age != nil {
+		t.Error("expected nil unset fields")
+	}
+}

--- a/pkg/observability/logging/options/options.go
+++ b/pkg/observability/logging/options/options.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/config/types"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
 	"github.com/trickstercache/trickster/v2/pkg/util/pointers"
 )
 
@@ -30,6 +31,12 @@ type Options struct {
 	LogFile string `yaml:"log_file,omitempty"`
 	// LogLevel provides the most granular level (e.g., DEBUG, INFO, ERROR) to log
 	LogLevel string `yaml:"log_level,omitempty"`
+	// Rotation controls when the log file is rotated
+	Rotation *manager.RotationOptions `yaml:"rotation,omitempty"`
+	// Retention controls how many rotated log archives are kept
+	Retention *manager.RetentionOptions `yaml:"retention,omitempty"`
+	// Compress indicates whether rotated archives are gzipped (default true)
+	Compress *bool `yaml:"compress,omitempty"`
 }
 
 var _ types.ConfigOptions[Options] = &Options{}
@@ -43,7 +50,30 @@ func New() *Options {
 
 // Clone returns a clone of the Options
 func (o *Options) Clone() *Options {
-	return pointers.Clone(o)
+	out := pointers.Clone(o)
+	if out == nil {
+		return nil
+	}
+	out.Rotation = o.Rotation.Clone()
+	out.Retention = o.Retention.Clone()
+	out.Compress = pointers.Clone(o.Compress)
+	return out
+}
+
+// ManagerOptions returns the rotation manager Options for the log file
+func (o *Options) ManagerOptions() *manager.Options {
+	return manager.ResolveOptions(o.LogFile, o.Rotation, o.Retention, o.Compress)
+}
+
+// RotationEqual returns true if both Options resolve to the same rotation,
+// retention and compression behaviors
+func (o *Options) RotationEqual(other *Options) bool {
+	if o == nil || other == nil {
+		return o == other
+	}
+	a := manager.ResolveOptions("", o.Rotation, o.Retention, o.Compress)
+	b := manager.ResolveOptions("", other.Rotation, other.Retention, other.Compress)
+	return *a == *b
 }
 
 func (o *Options) Initialize(_ string) error {

--- a/pkg/observability/logging/options/options_test.go
+++ b/pkg/observability/logging/options/options_test.go
@@ -19,8 +19,13 @@ package options
 import (
 	"errors"
 	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/manager"
+	"github.com/trickstercache/trickster/v2/pkg/parsing/sizeconv"
 
 	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestNew(t *testing.T) {
@@ -86,4 +91,92 @@ func TestValidate(t *testing.T) {
 			require.True(t, errors.Is(err, ErrInvalidLogLevel))
 		})
 	}
+}
+
+func TestRotationRetentionYAML(t *testing.T) {
+	t.Parallel()
+
+	doc := `
+log_file: /var/log/trickster/trickster.log
+log_level: info
+rotation:
+  size: 64MB
+  interval: 1d
+retention:
+  count: 5
+  age: 3d
+compress: false
+`
+	o := New()
+	require.NoError(t, yaml.Unmarshal([]byte(doc), o))
+	mo := o.ManagerOptions()
+	require.Equal(t, "/var/log/trickster/trickster.log", mo.Filename)
+	require.Equal(t, int64(64*1024*1024), mo.MaxSizeBytes)
+	require.Equal(t, 24*time.Hour, mo.Interval)
+	require.Equal(t, 5, mo.RetentionCount)
+	require.Equal(t, 3*24*time.Hour, mo.RetentionAge)
+	require.False(t, mo.Compress)
+}
+
+func TestManagerOptionsDefaults(t *testing.T) {
+	t.Parallel()
+
+	o := New()
+	o.LogFile = "/tmp/trickster.log"
+	mo := o.ManagerOptions()
+	require.Equal(t, manager.DefaultMaxSizeBytes, mo.MaxSizeBytes)
+	require.Equal(t, time.Duration(0), mo.Interval)
+	require.Equal(t, manager.DefaultRetentionCount, mo.RetentionCount)
+	require.Equal(t, manager.DefaultRetentionAge, mo.RetentionAge)
+	require.True(t, mo.Compress)
+}
+
+func TestCloneDeepCopiesRotation(t *testing.T) {
+	t.Parallel()
+
+	size := sizeconv.Size(64)
+	count := 5
+	compress := false
+	o := New()
+	o.Rotation = &manager.RotationOptions{Size: &size}
+	o.Retention = &manager.RetentionOptions{Count: &count}
+	o.Compress = &compress
+
+	c := o.Clone()
+	require.NotSame(t, o.Rotation, c.Rotation)
+	require.NotSame(t, o.Retention, c.Retention)
+	require.NotSame(t, o.Compress, c.Compress)
+	*c.Rotation.Size = 128
+	*c.Retention.Count = 9
+	require.Equal(t, sizeconv.Size(64), *o.Rotation.Size)
+	require.Equal(t, 5, *o.Retention.Count)
+}
+
+func TestRotationEqual(t *testing.T) {
+	t.Parallel()
+
+	var nilOpts *Options
+	require.True(t, nilOpts.RotationEqual(nil))
+	require.False(t, nilOpts.RotationEqual(New()))
+	require.False(t, New().RotationEqual(nil))
+
+	a, b := New(), New()
+	// different filenames and levels do not affect rotation equality
+	a.LogFile, b.LogFile = "/tmp/a.log", "/tmp/b.log"
+	a.LogLevel, b.LogLevel = "info", "debug"
+	require.True(t, a.RotationEqual(b))
+
+	// explicit values equal to the defaults still compare equal
+	size := sizeconv.Size(manager.DefaultMaxSizeBytes)
+	a.Rotation = &manager.RotationOptions{Size: &size}
+	require.True(t, a.RotationEqual(b))
+
+	size2 := sizeconv.Size(64)
+	b.Rotation = &manager.RotationOptions{Size: &size2}
+	require.False(t, a.RotationEqual(b))
+
+	b.Rotation = nil
+	compress := false
+	b.Compress = &compress
+	require.False(t, a.RotationEqual(b))
 }

--- a/pkg/parsing/sizeconv/sizeconv.go
+++ b/pkg/parsing/sizeconv/sizeconv.go
@@ -20,6 +20,7 @@ package sizeconv
 
 import (
 	"errors"
+	"math"
 	"strconv"
 	"strings"
 
@@ -71,7 +72,7 @@ func ParseSize(input string) (Size, error) {
 	}
 	if !strings.Contains(num, ".") {
 		v, err := strconv.ParseInt(num, 10, 64)
-		if err != nil || v < 0 {
+		if err != nil || v < 0 || v > math.MaxInt64/mult {
 			return 0, ErrInvalidSizeFormat
 		}
 		return Size(v * mult), nil
@@ -80,7 +81,11 @@ func ParseSize(input string) (Size, error) {
 	if err != nil || f < 0 {
 		return 0, ErrInvalidSizeFormat
 	}
-	return Size(f * float64(mult)), nil
+	result := f * float64(mult)
+	if math.IsInf(result, 0) || result >= float64(math.MaxInt64) {
+		return 0, ErrInvalidSizeFormat
+	}
+	return Size(result), nil
 }
 
 func (s Size) String() string {

--- a/pkg/parsing/sizeconv/sizeconv.go
+++ b/pkg/parsing/sizeconv/sizeconv.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package sizeconv provides parsing of human-readable byte sizes
+// (e.g., "256MB", "1.5GiB", "1024") into byte counts.
+package sizeconv
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// Size is a byte count that supports YAML (un)marshaling from
+// human-readable strings; units are binary (1KB = 1024 bytes)
+type Size int64
+
+var ErrInvalidSizeFormat = errors.New("invalid size format")
+
+const (
+	kb = 1 << 10
+	mb = 1 << 20
+	gb = 1 << 30
+	tb = 1 << 40
+)
+
+var units = map[string]int64{
+	"":    1,
+	"b":   1,
+	"k":   kb,
+	"kb":  kb,
+	"kib": kb,
+	"m":   mb,
+	"mb":  mb,
+	"mib": mb,
+	"g":   gb,
+	"gb":  gb,
+	"gib": gb,
+	"t":   tb,
+	"tb":  tb,
+	"tib": tb,
+}
+
+// ParseSize returns the byte count represented by the provided string,
+// which is a number with an optional unit suffix (B, KB, MB, GB, TB)
+func ParseSize(input string) (Size, error) {
+	s := strings.TrimSpace(strings.ToLower(input))
+	i := len(s)
+	for i > 0 && (s[i-1] < '0' || s[i-1] > '9') && s[i-1] != '.' {
+		i--
+	}
+	num, unit := s[:i], strings.TrimSpace(s[i:])
+	mult, ok := units[unit]
+	if !ok || num == "" {
+		return 0, ErrInvalidSizeFormat
+	}
+	if !strings.Contains(num, ".") {
+		v, err := strconv.ParseInt(num, 10, 64)
+		if err != nil || v < 0 {
+			return 0, ErrInvalidSizeFormat
+		}
+		return Size(v * mult), nil
+	}
+	f, err := strconv.ParseFloat(num, 64)
+	if err != nil || f < 0 {
+		return 0, ErrInvalidSizeFormat
+	}
+	return Size(f * float64(mult)), nil
+}
+
+func (s Size) String() string {
+	v := int64(s)
+	for _, u := range []struct {
+		mult int64
+		name string
+	}{{tb, "TB"}, {gb, "GB"}, {mb, "MB"}, {kb, "KB"}} {
+		if v != 0 && v%u.mult == 0 {
+			return strconv.FormatInt(v/u.mult, 10) + u.name
+		}
+	}
+	return strconv.FormatInt(v, 10)
+}
+
+// UnmarshalYAML unmarshals a number or size string into a Size
+func (s *Size) UnmarshalYAML(value *yaml.Node) error {
+	var raw string
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	parsed, err := ParseSize(raw)
+	if err != nil {
+		return err
+	}
+	*s = parsed
+	return nil
+}
+
+// MarshalYAML marshals a Size to its most compact string format
+func (s Size) MarshalYAML() (any, error) {
+	return s.String(), nil
+}

--- a/pkg/parsing/sizeconv/sizeconv_test.go
+++ b/pkg/parsing/sizeconv/sizeconv_test.go
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sizeconv
+
+import (
+	"testing"
+
+	"go.yaml.in/yaml/v3"
+)
+
+func TestParseSize(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected Size
+		err      bool
+	}{
+		{"1024", 1024, false},
+		{"64b", 64, false},
+		{"1KB", 1024, false},
+		{"1k", 1024, false},
+		{"1KiB", 1024, false},
+		{"256MB", 256 * 1024 * 1024, false},
+		{"256 MB", 256 * 1024 * 1024, false},
+		{"1.5GB", 1610612736, false},
+		{"2TB", 2 << 40, false},
+		{"0", 0, false},
+		{"", 0, true},
+		{"MB", 0, true},
+		{"12XB", 0, true},
+		{"1.2.3MB", 0, true},
+		{"-5MB", 0, true},
+	}
+	for _, test := range tests {
+		v, err := ParseSize(test.input)
+		if test.err != (err != nil) {
+			t.Errorf("input %q: unexpected error state: %v", test.input, err)
+			continue
+		}
+		if v != test.expected {
+			t.Errorf("input %q: expected %d, got %d", test.input, test.expected, v)
+		}
+	}
+}
+
+func TestSizeString(t *testing.T) {
+	tests := []struct {
+		input    Size
+		expected string
+	}{
+		{0, "0"},
+		{512, "512"},
+		{1024, "1KB"},
+		{256 * 1024 * 1024, "256MB"},
+		{3 << 30, "3GB"},
+		{2 << 40, "2TB"},
+		{1536, "1536"},
+	}
+	for _, test := range tests {
+		if s := test.input.String(); s != test.expected {
+			t.Errorf("expected %q, got %q", test.expected, s)
+		}
+	}
+}
+
+func TestSizeYAMLRoundTrip(t *testing.T) {
+	type doc struct {
+		Max Size `yaml:"max"`
+	}
+	var d doc
+	if err := yaml.Unmarshal([]byte("max: 256MB"), &d); err != nil {
+		t.Fatal(err)
+	}
+	if d.Max != 256*1024*1024 {
+		t.Errorf("unexpected value: %d", d.Max)
+	}
+	b, err := yaml.Marshal(&d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "max: 256MB\n" {
+		t.Errorf("unexpected marshal output: %q", string(b))
+	}
+	if err = yaml.Unmarshal([]byte("max: 1048576"), &d); err != nil {
+		t.Fatal(err)
+	}
+	if d.Max != 1<<20 {
+		t.Errorf("unexpected value: %d", d.Max)
+	}
+	if err = yaml.Unmarshal([]byte("max: nope"), &d); err == nil {
+		t.Error("expected unmarshal error")
+	}
+	if err = yaml.Unmarshal([]byte("max: [1]"), &d); err == nil {
+		t.Error("expected unmarshal error for non-scalar")
+	}
+}

--- a/pkg/parsing/sizeconv/sizeconv_test.go
+++ b/pkg/parsing/sizeconv/sizeconv_test.go
@@ -43,6 +43,8 @@ func TestParseSize(t *testing.T) {
 		{"12XB", 0, true},
 		{"1.2.3MB", 0, true},
 		{"-5MB", 0, true},
+		{"9000000000GB", 0, true},
+		{"9000000000.5GB", 0, true},
 	}
 	for _, test := range tests {
 		v, err := ParseSize(test.input)

--- a/pkg/proxy/authenticator/handler/handler.go
+++ b/pkg/proxy/authenticator/handler/handler.go
@@ -28,6 +28,11 @@ import (
 // Middleware returns a handler that authenticates the request and passes to
 // the next handler on success, else responds with unauthorized and aborts
 func Middleware(a types.Authenticator, next http.Handler) http.Handler {
+	return NamedMiddleware("", a, next)
+}
+
+// NamedMiddleware authenticates requests and scopes cached results by name.
+func NamedMiddleware(name string, a types.Authenticator, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if a == nil {
 			logger.WarnOnce("auth.middleware.nil.handle",
@@ -37,6 +42,7 @@ func Middleware(a types.Authenticator, next http.Handler) http.Handler {
 		}
 		// if the request has already been authorized, use the existing result
 		if rsc := request.GetResources(r); rsc != nil && rsc.AuthResult != nil &&
+			rsc.AuthResult.AuthenticatorName == name &&
 			rsc.AuthResult.Status != types.AuthObserved {
 			if rsc.AuthResult.Status != types.AuthSuccess {
 				failures.HandleUnauthorized(w, nil)
@@ -59,7 +65,9 @@ func Middleware(a types.Authenticator, next http.Handler) http.Handler {
 		}
 		// and cache the auth result to the request context
 		rsc := request.GetResources(r)
-		rsc.AuthResult = res
+		cached := *res
+		cached.AuthenticatorName = name
+		rsc.AuthResult = &cached
 		if res.Status == types.AuthSuccess {
 			a.Sanitize(r)
 		}

--- a/pkg/proxy/authenticator/handler/handler_test.go
+++ b/pkg/proxy/authenticator/handler/handler_test.go
@@ -123,3 +123,21 @@ func TestMiddleware(t *testing.T) {
 		})
 	}
 }
+
+func TestNamedMiddlewareScopesCachedResult(t *testing.T) {
+	a := &testAuthenticator{result: &types.AuthResult{Status: types.AuthSuccess}}
+	rsc := &request.Resources{AuthResult: &types.AuthResult{
+		AuthenticatorName: "outer", Status: types.AuthSuccess,
+	}}
+	req := request.SetResources(httptest.NewRequest(http.MethodGet, "/", nil), rsc)
+	recorder := httptest.NewRecorder()
+	NamedMiddleware("inner", a, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})).ServeHTTP(recorder, req)
+	if a.authCalls != 1 {
+		t.Fatalf("inner authenticator calls = %d, want 1", a.authCalls)
+	}
+	if rsc.AuthResult.AuthenticatorName != "inner" {
+		t.Errorf("cached authenticator = %q, want inner", rsc.AuthResult.AuthenticatorName)
+	}
+}

--- a/pkg/proxy/authenticator/types/auth_result.go
+++ b/pkg/proxy/authenticator/types/auth_result.go
@@ -17,10 +17,11 @@
 package types
 
 type AuthResult struct {
-	Status          AuthResultStatus
-	StatusDetail    string
-	Username        string
-	ResponseHeaders map[string]string
+	AuthenticatorName string
+	Status            AuthResultStatus
+	StatusDetail      string
+	Username          string
+	ResponseHeaders   map[string]string
 	// Claims, etc. would go here in the future as needed
 }
 

--- a/pkg/proxy/engines/main_test.go
+++ b/pkg/proxy/engines/main_test.go
@@ -29,6 +29,5 @@ func TestMain(m *testing.M) {
 		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
 		goleak.IgnoreTopFunction("github.com/dgraph-io/ristretto/v2.(*Cache[...]).processItems"),
 		goleak.IgnoreTopFunction("github.com/dgraph-io/ristretto/v2.(*defaultPolicy[...]).processItems"),
-		goleak.IgnoreTopFunction("gopkg.in/natefinch/lumberjack%2ev2.(*Logger).millRun"),
 	)
 }

--- a/pkg/proxy/engines/tracing_test.go
+++ b/pkg/proxy/engines/tracing_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -289,9 +290,9 @@ func resourceAttributeStrings(rsc *request.Resources) map[string]string {
 func latestEndedSpan(t testing.TB, sr *tracetest.SpanRecorder, name string) sdktrace.ReadOnlySpan {
 	t.Helper()
 	spans := sr.Ended()
-	for i := len(spans) - 1; i >= 0; i-- {
-		if spans[i].Name() == name {
-			return spans[i]
+	for _, span := range slices.Backward(spans) {
+		if span.Name() == name {
+			return span
 		}
 	}
 	t.Fatalf("span %q not found in %d ended spans", name, len(spans))

--- a/pkg/proxy/headers/result_header.go
+++ b/pkg/proxy/headers/result_header.go
@@ -167,3 +167,28 @@ func parseResultHeaderVals(h string) ResultHeaderParts {
 	}
 	return r
 }
+
+// ParseResultHeader returns the structured values in X-Trickster-Result.
+func ParseResultHeader(h string) ResultHeaderParts {
+	return parseResultHeaderVals(h)
+}
+
+// ParseResultEngineStatus extracts only engine and status without extents.
+func ParseResultEngineStatus(h string) (engine, status string) {
+	for part := range strings.SplitSeq(h, ";") {
+		key, value, ok := strings.Cut(strings.TrimSpace(part), "=")
+		if !ok || value == "" {
+			continue
+		}
+		switch key {
+		case "engine":
+			engine = value
+		case "status":
+			status = value
+		}
+		if engine != "" && status != "" {
+			return engine, status
+		}
+	}
+	return engine, status
+}

--- a/pkg/proxy/headers/result_header_test.go
+++ b/pkg/proxy/headers/result_header_test.go
@@ -101,3 +101,11 @@ func TestParseResultHeaderVals(t *testing.T) {
 
 	// t.Error()
 }
+
+func TestParseResultEngineStatus(t *testing.T) {
+	engine, status := ParseResultEngineStatus(
+		"engine=DeltaProxyCache; status=phit; fetched=[1000-2000]; ffstatus=hit")
+	if engine != "DeltaProxyCache" || status != "phit" {
+		t.Errorf("engine/status = %q/%q", engine, status)
+	}
+}

--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -74,7 +74,7 @@ type Listener struct {
 	routeSwapper *switcher.SwitchHandler
 	server       server
 	exitOnError  atomic.Bool
-	state        int32
+	state        atomic.Int32
 	readyCh      chan struct{}
 	readyOnce    sync.Once
 }
@@ -144,12 +144,12 @@ func NewGroup() *Group {
 
 // State returns the current state of the listener
 func (l *Listener) State() ListenerState {
-	return ListenerState(atomic.LoadInt32(&l.state))
+	return ListenerState(l.state.Load())
 }
 
 // setState atomically sets the listener state
 func (l *Listener) setState(state ListenerState) {
-	atomic.StoreInt32(&l.state, int32(state))
+	l.state.Store(int32(state))
 }
 
 // markReady signals that the listener is ready to accept connections

--- a/pkg/proxy/request/resources.go
+++ b/pkg/proxy/request/resources.go
@@ -159,7 +159,9 @@ func (r *Resources) Merge(r2 *Resources) {
 	r.AlternateCacheTTL = r2.AlternateCacheTTL
 	r.TimeRangeQuery = r2.TimeRangeQuery
 	r.Tracer = r2.Tracer
-	r.AuthResult = r2.AuthResult
+	if r2.AuthResult != nil {
+		r.AuthResult = r2.AuthResult
+	}
 
 	r.RequestBody = slices.Clone(r2.RequestBody)
 	r.IsMergeMember = r.IsMergeMember || r2.IsMergeMember

--- a/pkg/proxy/request/resources_test.go
+++ b/pkg/proxy/request/resources_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	authtypes "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/types"
 	tc "github.com/trickstercache/trickster/v2/pkg/proxy/context"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/response/merge"
 )
@@ -233,6 +234,7 @@ func TestMergeResources(t *testing.T) {
 	logger.SetLogger(logging.ConsoleLogger(level.Error))
 	r1 := NewResources(nil, nil, nil, nil, nil, nil)
 	r1.AlternateCacheTTL = time.Minute
+	r1.AuthResult = &authtypes.AuthResult{Status: authtypes.AuthSuccess, Username: "outer"}
 	r1.Merge(nil)
 	if r1.AlternateCacheTTL != time.Minute {
 		t.Errorf("nil merge shouldn't set anything in subject resources")
@@ -247,5 +249,13 @@ func TestMergeResources(t *testing.T) {
 	}
 	if r1.BatchMergeFunc == nil {
 		t.Error("merge should propagate BatchMergeFunc")
+	}
+	if r1.AuthResult == nil || r1.AuthResult.Username != "outer" {
+		t.Error("nil inner auth result replaced the outer authentication")
+	}
+	r2.AuthResult = &authtypes.AuthResult{Status: authtypes.AuthSuccess, Username: "inner"}
+	r1.Merge(r2)
+	if r1.AuthResult.Username != "inner" {
+		t.Error("non-nil inner auth result did not replace the outer authentication")
 	}
 }

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -34,6 +34,7 @@ import (
 	encoding "github.com/trickstercache/trickster/v2/pkg/encoding/handler"
 	fopt "github.com/trickstercache/trickster/v2/pkg/frontend/options"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/handler"
@@ -267,6 +268,8 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 		}
 	}
 
+	al := newAccessLogger(conf, o)
+
 	applyMiddleware := func(po1 *po.Options) http.Handler {
 		// default base route is the path handler
 		maxBodySizeBytes, truncateOnly := getSizeLimits(frontendOptions(conf, o))
@@ -293,6 +296,8 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 		if !po1.NoMetrics {
 			h = middleware.Decorate(o.Name, o.Provider, po1.Path, h)
 		}
+		// attach access logging outermost so it observes the full request
+		h = accesslog.Middleware(al, po1.Path, h)
 		return h
 	}
 
@@ -360,7 +365,7 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 	bknds backends.Backends, tracers tracing.Tracers,
 ) {
 	applyMiddleware := func(o *bo.Options, po *po.Options, tr *tracing.Tracer,
-		c cache.Cache, client backends.Backend,
+		c cache.Cache, client backends.Backend, al *accesslog.Logger,
 	) http.Handler {
 		// default base route is the path handler
 		maxBodySizeBytes, truncateOnly := getSizeLimits(frontendOptions(conf, o))
@@ -385,6 +390,8 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 		if !po.NoMetrics {
 			h = middleware.Decorate(o.Name, o.Provider, po.Path, h)
 		}
+		// attach access logging outermost so it observes the full request
+		h = accesslog.Middleware(al, po.Path, h)
 		return h
 	}
 
@@ -402,6 +409,8 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 			logger.Info("registering default backend handler paths",
 				logging.Pairs{"backendName": o.Name})
 
+			al := newAccessLogger(conf, o)
+
 			for _, p := range o.Paths {
 				if p.Handler != nil && len(p.Methods) > 0 {
 					logger.Debug(
@@ -414,14 +423,33 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 
 					if p.MatchType == matching.PathMatchTypePrefix {
 						r.RegisterRoute(p.Path, nil, p.Methods,
-							true, applyMiddleware(o, p, tr, b.Cache(), b))
+							true, applyMiddleware(o, p, tr, b.Cache(), b, al))
 					}
 					r.RegisterRoute(p.Path, nil, p.Methods,
-						false, applyMiddleware(o, p, tr, b.Cache(), b))
+						false, applyMiddleware(o, p, tr, b.Cache(), b, al))
 				}
 			}
 		}
 	}
+}
+
+// newAccessLogger returns an access logger for the backend, or nil when
+// access logging is not configured or the logger cannot be created
+func newAccessLogger(conf *config.Config, o *bo.Options) *accesslog.Logger {
+	if o == nil || !o.AccessLog.IsEnabled() {
+		return nil
+	}
+	var instanceID int
+	if conf != nil && conf.Main != nil {
+		instanceID = conf.Main.InstanceID
+	}
+	al, err := accesslog.NewLogger(o.AccessLog, instanceID, o.Name, o.Provider)
+	if err != nil {
+		logger.Error("access logger creation failed; access logging disabled",
+			logging.Pairs{"backendName": o.Name, "error": err.Error()})
+		return nil
+	}
+	return al
 }
 
 func frontendOptions(conf *config.Config, o *bo.Options) *fopt.Options {

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -52,15 +52,26 @@ import (
 
 var noCacheBackends = providers.NonCacheBackends()
 
-// attachAuthenticator attaches authentication middleware to the handler based on path and backend options
 func attachAuthenticator(h http.Handler, pathOptions *po.Options, backendOptions *bo.Options) http.Handler {
 	if pathOptions.AuthOptions != nil && pathOptions.AuthOptions.Authenticator != nil {
-		h = handler.Middleware(pathOptions.AuthOptions.Authenticator, h)
+		h = handler.NamedMiddleware(pathOptions.AuthOptions.Name,
+			pathOptions.AuthOptions.Authenticator, h)
 	} else if pathOptions.AuthenticatorName != "none" && backendOptions.AuthOptions != nil &&
 		backendOptions.AuthOptions.Authenticator != nil {
-		h = handler.Middleware(backendOptions.AuthOptions.Authenticator, h)
+		h = handler.NamedMiddleware(backendOptions.AuthOptions.Name,
+			backendOptions.AuthOptions.Authenticator, h)
 	}
 	return h
+}
+
+func hasAuthenticator(pathOptions *po.Options, backendOptions *bo.Options) bool {
+	return pathOptions.AuthOptions != nil && pathOptions.AuthOptions.Authenticator != nil ||
+		pathOptions.AuthenticatorName != "none" && backendOptions.AuthOptions != nil &&
+			backendOptions.AuthOptions.Authenticator != nil
+}
+
+func shouldCaptureAuth(pathOptions *po.Options, backendOptions *bo.Options) bool {
+	return hasAuthenticator(pathOptions, backendOptions) || backends.IsVirtual(backendOptions.Provider)
 }
 
 // RegisterProxyRoutes iterates the Trickster Configuration and
@@ -280,6 +291,7 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 			h = middleware.Trace(tr, h)
 		}
 		// attach authenticator
+		captureAuth := shouldCaptureAuth(po1, o)
 		h = attachAuthenticator(h, po1, o)
 		// attach compression handler
 		h = encoding.HandleCompression(h, o.CompressibleTypes)
@@ -297,7 +309,7 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 			h = middleware.Decorate(o.Name, o.Provider, po1.Path, h)
 		}
 		// attach access logging outermost so it observes the full request
-		h = accesslog.Middleware(al, po1.Path, h)
+		h = accesslog.Middleware(al, po1.Path, captureAuth, h)
 		return h
 	}
 
@@ -376,6 +388,7 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 			h = middleware.Trace(tr, h)
 		}
 		// attach authenticator
+		captureAuth := shouldCaptureAuth(po, o)
 		h = attachAuthenticator(h, po, o)
 		// add Backend, Cache, and Path Configs to the HTTP Request's context (must wrap outer than LimitQueryRange)
 		h = middleware.WithResourcesContext(client, o, c, po, tr, h)
@@ -391,7 +404,7 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 			h = middleware.Decorate(o.Name, o.Provider, po.Path, h)
 		}
 		// attach access logging outermost so it observes the full request
-		h = accesslog.Middleware(al, po.Path, h)
+		h = accesslog.Middleware(al, po.Path, captureAuth, h)
 		return h
 	}
 
@@ -433,8 +446,6 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 	}
 }
 
-// newAccessLogger returns an access logger for the backend, or nil when
-// access logging is not configured or the logger cannot be created
 func newAccessLogger(conf *config.Config, o *bo.Options) *accesslog.Logger {
 	if o == nil || !o.AccessLog.IsEnabled() {
 		return nil

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -61,6 +61,18 @@ func newPromClient() backends.Backend {
 
 var promClient = newPromClient()
 
+func TestShouldCaptureAuthForVirtualBackend(t *testing.T) {
+	path := po.New()
+	backend := &bo.Options{Provider: providers.Rule}
+	if !shouldCaptureAuth(path, backend) {
+		t.Error("rule backend must capture downstream authentication")
+	}
+	backend.Provider = providers.ReverseProxyShort
+	if shouldCaptureAuth(path, backend) {
+		t.Error("ordinary unauthenticated backend should not seed resources")
+	}
+}
+
 func TestRegisterHealthHandler(t *testing.T) {
 	router := lm.NewRouter()
 	path := "/test"

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -19,6 +19,7 @@ package routing
 import (
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
@@ -38,6 +39,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	"github.com/trickstercache/trickster/v2/pkg/config/listener"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	alo "github.com/trickstercache/trickster/v2/pkg/observability/logging/accesslog/options"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/level"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
@@ -521,5 +523,28 @@ func TestRegisterDefaultBackendRoutesForListeners(t *testing.T) {
 	defaultRouter.ServeHTTP(defaultResponse, request)
 	if defaultResponse.Code == http.StatusOK {
 		t.Errorf("backend route was also registered on default")
+	}
+}
+
+func TestNewAccessLogger(t *testing.T) {
+	if newAccessLogger(nil, nil) != nil {
+		t.Error("expected nil logger for nil options")
+	}
+	o := bo.New()
+	o.Name = "test"
+	if newAccessLogger(nil, o) != nil {
+		t.Error("expected nil logger when access logging is unconfigured")
+	}
+	o.AccessLog = &alo.Options{Filename: filepath.Join(t.TempDir(), "a.log")}
+	al := newAccessLogger(nil, o)
+	if al == nil {
+		t.Fatal("expected an access logger")
+	}
+	al.Close()
+	// formats are validated at config load; an invalid one here exercises
+	// the construction failure branch
+	o.AccessLog.Format = "%Z"
+	if newAccessLogger(nil, o) != nil {
+		t.Error("expected nil logger on construction error")
 	}
 }

--- a/pkg/util/middleware/metrics.go
+++ b/pkg/util/middleware/metrics.go
@@ -17,7 +17,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -29,40 +28,75 @@ import (
 // perspective
 func Decorate(backendName, backendProvider, path string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		observer := &responseObserver{
-			w,
-			"2xx",
-			http.StatusOK,
+		observer, ok := w.(*ResponseObserver)
+		if !ok {
+			observer = NewResponseObserver(w)
 		}
+		startBytes := observer.BytesWritten()
 
 		n := time.Now()
 		next.ServeHTTP(observer, r)
+		statusClass := observer.StatusClass()
 
 		metrics.FrontendRequestDuration.WithLabelValues(backendName, backendProvider,
-			r.Method, path, observer.status).Observe(time.Since(n).Seconds())
+			r.Method, path, statusClass).Observe(time.Since(n).Seconds())
 		metrics.FrontendRequestStatus.WithLabelValues(backendName, backendProvider,
-			r.Method, path, observer.status).Inc()
+			r.Method, path, statusClass).Inc()
 		metrics.FrontendRequestWrittenBytes.WithLabelValues(backendName, backendProvider,
-			r.Method, path, observer.status).Add(observer.bytesWritten)
+			r.Method, path, statusClass).Add(float64(observer.BytesWritten() - startBytes))
 	})
 }
 
-type responseObserver struct {
+// ResponseObserver records the response status and number of bytes written.
+type ResponseObserver struct {
 	http.ResponseWriter
 
-	status       string
-	bytesWritten float64
+	statusCode   int
+	bytesWritten int64
+	wroteHeader  bool
 }
 
-func (w *responseObserver) WriteHeader(statusCode int) {
+// NewResponseObserver wraps w with a response observer.
+func NewResponseObserver(w http.ResponseWriter) *ResponseObserver {
+	return &ResponseObserver{ResponseWriter: w, statusCode: http.StatusOK}
+}
+
+func (w *ResponseObserver) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
+	if statusCode >= 100 && statusCode < 200 && statusCode != http.StatusSwitchingProtocols {
+		w.ResponseWriter.WriteHeader(statusCode)
+		return
+	}
+	w.wroteHeader = true
 	w.ResponseWriter.WriteHeader(statusCode)
-	w.status = fmt.Sprintf("%dxx", statusCode/100)
+	w.statusCode = statusCode
 }
 
-func (w *responseObserver) Write(b []byte) (int, error) {
+func (w *ResponseObserver) Write(b []byte) (int, error) {
+	w.wroteHeader = true
 	bytesWritten, err := w.ResponseWriter.Write(b)
-
-	w.bytesWritten += float64(bytesWritten)
-
+	w.bytesWritten += int64(bytesWritten)
 	return bytesWritten, err
 }
+
+// StatusCode returns the first HTTP status written, or 200 if none was written.
+func (w *ResponseObserver) StatusCode() int { return w.statusCode }
+
+// StatusClass returns the recorded HTTP status class, such as "2xx".
+func (w *ResponseObserver) StatusClass() string {
+	class := w.statusCode / 100
+	if class >= 0 && class < len(statusClasses) {
+		return statusClasses[class]
+	}
+	return statusClasses[0]
+}
+
+// BytesWritten returns the number of response body bytes written.
+func (w *ResponseObserver) BytesWritten() int64 { return w.bytesWritten }
+
+// Unwrap exposes the underlying writer to http.ResponseController.
+func (w *ResponseObserver) Unwrap() http.ResponseWriter { return w.ResponseWriter }
+
+var statusClasses = [6]string{"0xx", "1xx", "2xx", "3xx", "4xx", "5xx"}

--- a/pkg/util/middleware/metrics_test.go
+++ b/pkg/util/middleware/metrics_test.go
@@ -120,3 +120,29 @@ func TestDecorate(t *testing.T) {
 		})
 	}
 }
+
+func TestDecorateReusesResponseObserver(t *testing.T) {
+	base := NewResponseObserver(httptest.NewRecorder())
+	var got http.ResponseWriter
+	h := Decorate("backend", "provider", "/", http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			got = w
+			_, _ = w.Write([]byte("ok"))
+		}))
+	h.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/", nil))
+	if got != base {
+		t.Error("expected metrics middleware to reuse the existing response observer")
+	}
+	if base.BytesWritten() != 2 || base.StatusCode() != http.StatusOK {
+		t.Errorf("unexpected observation: status=%d bytes=%d",
+			base.StatusCode(), base.BytesWritten())
+	}
+}
+
+func TestResponseObserverStatusClassBounds(t *testing.T) {
+	observer := NewResponseObserver(httptest.NewRecorder())
+	observer.statusCode = 999
+	if got := observer.StatusClass(); got != "0xx" {
+		t.Errorf("invalid status class = %q, want 0xx", got)
+	}
+}

--- a/testdata/ignore_words.txt
+++ b/testdata/ignore_words.txt
@@ -2,3 +2,4 @@ te
 uint
 flate
 ro
+alo


### PR DESCRIPTION
## Description

* Replace lumberjack with internal log manager solution
* Add operator-customizable retentions for application log rolling (log size, # archives, compression on/off, etc.)
* Add Apache-style per-backend Access/Error Logging with customizable output format (that also contains the operator-customizable rolling/retentions)
  * Off by default. At minimum, user must configure the access log path and/or error log path to enable the feature

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [ ] Bug fix
- - [x] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [x] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
