### PR TITLE
feat: implement regex path matching

### DIFF
--- a/docs/paths.md
+++ b/docs/paths.md
@@ -12,11 +12,45 @@ Trickster supports, via configuration, customizing the upstream request and down
 
 ## Path Matching Scope
 
-Paths are matchable as `exact` or `prefix`
+Paths are matchable as `exact`, `prefix` or `regex`
 
 The default match is `exact`, meaning the client's requested URL Path must be an exact match to the configured path in order to match and be handled by a given Path Config. For example a request to `/foo/bar` will not match an `exact` Path Config for `/foo`.
 
 A `prefix` match will match any client-requested path to the Path Config with the longest prefix match. A `prefix` match Path Config to `/foo` will match `/foo/bar` as well as `/foobar` and `/food`. A basic string match is used to evaluate the incoming URL path, so it is recommended to consider finishing paths with a trailing `/`, like `/foo/` in Path Configurations, if needed to avoid any unintentional matches.
+
+### Regex Paths
+
+A path can also be a regular expression, evaluated against the client's requested URL Path. A path is treated as a regex when either:
+
+- the path value starts with `^/` (or the escaped form `^\/`) — this is auto-detected and applies regardless of any configured `match_type`; or
+- the Path Config explicitly sets `match_type: regex`, in which case the path need not start with `^/`; Trickster will prepend a `^` anchor if absent, so match semantics are consistent.
+
+Regex paths use Go's [RE2 syntax](https://github.com/google/re2/wiki/Syntax) (linear-time matching; no backtracking). Patterns are always anchored at the start with `^`. A `$` end anchor is honored when present but never required — an unanchored end behaves like a prefix-style match, so `^/api/[0-9]+` matches `/api/42` and `/api/42/details` alike, while `^/api/[0-9]+$` matches only `/api/42`.
+
+Evaluation order: regex paths are evaluated only after both `exact` and `prefix` matching have missed. Within the regex tier, patterns are evaluated longest-pattern-string first; equal-length patterns are evaluated in the order they appear in the configuration; the first pattern that matches wins.
+
+**Catch-all warning:** a classic catch-all path — `match_type: prefix` on `/`, or an effective catch-all like `/api` in front of regexes that all begin `^/api` — always prefix-matches first and prevents the regex tier from ever being evaluated for those requests. When using regex paths, define the catch-all as a regex too (e.g. `^/.*`), which sorts shortest and therefore evaluates last. Trickster logs a startup warning when a backend defines regex paths alongside a `/` prefix catch-all.
+
+```yaml
+backends:
+  default:
+    provider: rpc
+    origin_url: 'http://example.com'
+    paths:
+      # auto-detected as a regex path (starts with ^/)
+      - path: '^/api/[0-9]+/results'
+        methods: [ GET ]
+        handler: proxycache
+      # explicit opt-in; Trickster anchors this to ^/reports/(annual|monthly)/
+      - path: '/reports/(annual|monthly)/'
+        match_type: regex
+        methods: [ GET ]
+        handler: proxy
+      # regex catch-all: evaluates last, does not shadow the regexes above
+      - path: '^/.*'
+        methods: [ '*' ]
+        handler: proxy
+```
 
 ### Method Matching Scope
 

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -598,6 +598,13 @@ backends:
 #                                                               # while the - will remove the header
 #         request_params:
 #           +authToken: SomeTokenHere                 # manipulate request query parameters in the same way
+#       # regex path: a path starting with ^/ is auto-detected as a regular expression
+#       # (RE2 syntax); or set match_type: regex explicitly. Regex paths are evaluated
+#       # only after exact and prefix matching both miss, longest pattern first.
+#       # See the Regex Paths section of /docs/paths.md, including the catch-all caveat.
+#       - path: '^/api/[0-9]+/results'
+#         methods: [ GET ]
+#         handler: proxycache
 
 #         # the tls section configures the frontend and backend TLS operation for the backend
 #     tls:

--- a/pkg/backends/options/options.go
+++ b/pkg/backends/options/options.go
@@ -378,7 +378,7 @@ func (o *Options) Validate() (bool, error) {
 	}
 
 	if len(o.Paths) > 0 {
-		if err := o.Paths.Validate(); err != nil {
+		if err := o.Paths.Validate(o.Name); err != nil {
 			return false, err
 		}
 	}

--- a/pkg/daemon/setup/listeners.go
+++ b/pkg/daemon/setup/listeners.go
@@ -37,6 +37,7 @@ import (
 	ph "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/purge"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener/native"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 )
@@ -69,7 +70,8 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		return
 	}
 
-	metricsRouter.RegisterRoute("/metrics", nil, nil, false, metrics.Handler())
+	metricsRouter.RegisterRoute("/metrics", nil, nil,
+		matching.PathMatchTypeExact, metrics.Handler())
 	if listenerEnabledOn(conf.MgmtConfig.ConfigHandlerListener, mgmt.ListenerNameMetrics) {
 		registerConfigRoutes(conf, metricsRouter)
 	}
@@ -82,9 +84,10 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 		registerConfigRoutes(conf, managementRouter)
 	}
 	managementRouter.RegisterRoute(conf.MgmtConfig.ReloadHandlerPath, nil, nil,
-		false, reloadHandler)
+		matching.PathMatchTypeExact, reloadHandler)
 	managementRouter.RegisterRoute(conf.MgmtConfig.PurgeByPathHandlerPath, nil, nil,
-		true, http.HandlerFunc(ph.PathHandler(conf.MgmtConfig.PurgeByPathHandlerPath, &clients)))
+		matching.PathMatchTypePrefix,
+		http.HandlerFunc(ph.PathHandler(conf.MgmtConfig.PurgeByPathHandlerPath, &clients)))
 	if listenerEnabledOn(conf.MgmtConfig.PprofListener, mgmt.ListenerNameMgmt) {
 		pprof.RegisterRoutes(mgmt.ListenerNameMgmt, managementRouter)
 	}
@@ -273,9 +276,9 @@ func runtimeListenerNeedsRestart(lg *listener.Group, key string, old, current de
 
 func registerConfigRoutes(conf *config.Config, r router.Router) {
 	r.RegisterRoute(conf.MgmtConfig.ConfigHandlerPath, nil, nil,
-		false, http.HandlerFunc(ch.HandlerFunc(conf)))
+		matching.PathMatchTypeExact, http.HandlerFunc(ch.HandlerFunc(conf)))
 	r.RegisterRoute(ch.SanitizedHandlerPath(conf.MgmtConfig.ConfigHandlerPath), nil, nil,
-		false, http.HandlerFunc(ch.SanitizedHandlerFunc(conf)))
+		matching.PathMatchTypeExact, http.HandlerFunc(ch.SanitizedHandlerFunc(conf)))
 }
 
 func updateListenerCertificates(conf *config.Config, desired desiredListener, lg *listener.Group) {

--- a/pkg/daemon/setup/listeners_test.go
+++ b/pkg/daemon/setup/listeners_test.go
@@ -38,6 +38,7 @@ import (
 	configtypes "github.com/trickstercache/trickster/v2/pkg/config/types"
 	autho "github.com/trickstercache/trickster/v2/pkg/proxy/authenticator/options"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	to "github.com/trickstercache/trickster/v2/pkg/proxy/tls/options"
@@ -288,9 +289,10 @@ func TestApplyMySQLListenerRestartsWhenTLSFileContentsRotate(t *testing.T) {
 
 func markerRouter(marker string) router.Router {
 	r := lm.NewRouter()
-	r.RegisterRoute("/", nil, nil, true, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = w.Write([]byte(marker))
-	}))
+	r.RegisterRoute("/", nil, nil, matching.PathMatchTypePrefix,
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(marker))
+		}))
 	return r
 }
 

--- a/pkg/daemon/setup/setup.go
+++ b/pkg/daemon/setup/setup.go
@@ -50,6 +50,7 @@ import (
 	ph "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/purge"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/reload"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/lm"
 	"github.com/trickstercache/trickster/v2/pkg/routing"
@@ -181,7 +182,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 
 	for _, r := range listenerRouters {
 		r.RegisterRoute(newConf.MgmtConfig.PingHandlerPath, nil,
-			[]string{http.MethodGet, http.MethodHead}, false,
+			[]string{http.MethodGet, http.MethodHead}, matching.PathMatchTypeExact,
 			http.HandlerFunc((pnh.HandlerFunc(newConf))))
 	}
 
@@ -199,7 +200,7 @@ func ApplyConfig(si *instance.ServerInstance, newConf *config.Config,
 	}
 	for _, r := range listenerRouters {
 		r.RegisterRoute(newConf.MgmtConfig.PurgeByKeyHandlerPath, nil,
-			[]string{http.MethodDelete}, true,
+			[]string{http.MethodDelete}, matching.PathMatchTypePrefix,
 			http.HandlerFunc(ph.KeyHandler(newConf.MgmtConfig.PurgeByKeyHandlerPath, clients)))
 	}
 

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -43,6 +43,9 @@ var ErrInvalidPath = errors.New("invalid path value in config")
 // ErrInvalidMethod is an error for when a configuration's method is invalid
 var ErrInvalidMethod = errors.New("invalid method value in config")
 
+// ErrInvalidMatchType is an error for when a route's path match type is invalid
+var ErrInvalidMatchType = errors.New("invalid path match type")
+
 // ErrNoValidBackends is an error for when not valid backends have been configured
 var ErrNoValidBackends = errors.New("no valid backends configured")
 

--- a/pkg/observability/pprof/pprof.go
+++ b/pkg/observability/pprof/pprof.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 )
 
@@ -29,13 +30,13 @@ import (
 func RegisterRoutes(routerName string, r router.Router) {
 	logger.Info("registering pprof /debug routes", logging.Pairs{"routerName": routerName})
 	r.RegisterRoute("/debug/pprof/", nil, nil,
-		true, http.HandlerFunc(pprof.Index))
+		matching.PathMatchTypePrefix, http.HandlerFunc(pprof.Index))
 	r.RegisterRoute("/debug/pprof/cmdline", nil, nil,
-		false, http.HandlerFunc(pprof.Cmdline))
+		matching.PathMatchTypeExact, http.HandlerFunc(pprof.Cmdline))
 	r.RegisterRoute("/debug/pprof/profile", nil, nil,
-		false, http.HandlerFunc(pprof.Profile))
+		matching.PathMatchTypeExact, http.HandlerFunc(pprof.Profile))
 	r.RegisterRoute("/debug/pprof/symbol", nil, nil,
-		false, http.HandlerFunc(pprof.Symbol))
+		matching.PathMatchTypeExact, http.HandlerFunc(pprof.Symbol))
 	r.RegisterRoute("/debug/pprof/trace", nil, nil,
-		false, http.HandlerFunc(pprof.Trace))
+		matching.PathMatchTypeExact, http.HandlerFunc(pprof.Trace))
 }

--- a/pkg/proxy/paths/matching/matching.go
+++ b/pkg/proxy/paths/matching/matching.go
@@ -28,15 +28,19 @@ const (
 	PathMatchTypeExact = PathMatchType(iota)
 	// PathMatchTypePrefix indicates the router will map the Path by prefix against incoming requests
 	PathMatchTypePrefix
+	// PathMatchTypeRegex indicates the router will map the Path as a regular expression
+	PathMatchTypeRegex
 
 	PathMatchNameExact  PathMatchName = "exact"
 	PathMatchNamePrefix PathMatchName = "prefix"
+	PathMatchNameRegex  PathMatchName = "regex"
 )
 
 // Names is a map of PathMatchTypes keyed by string name
 var Names = map[PathMatchName]PathMatchType{
 	PathMatchNameExact:  PathMatchTypeExact,
 	PathMatchNamePrefix: PathMatchTypePrefix,
+	PathMatchNameRegex:  PathMatchTypeRegex,
 }
 
 // Values is a map of PathMatchTypes valued by string name

--- a/pkg/proxy/paths/matching/matching_test.go
+++ b/pkg/proxy/paths/matching/matching_test.go
@@ -21,8 +21,9 @@ import "testing"
 func TestPMTString(t *testing.T) {
 	t1 := PathMatchTypeExact
 	t2 := PathMatchTypePrefix
+	t4 := PathMatchTypeRegex
 
-	var t3 PathMatchType = 3
+	var t3 PathMatchType = 27
 
 	if t1.String() != string(PathMatchNameExact) {
 		t.Errorf("expected %s got %s", PathMatchNameExact, t1.String())
@@ -32,7 +33,11 @@ func TestPMTString(t *testing.T) {
 		t.Errorf("expected %s got %s", PathMatchNamePrefix, t2.String())
 	}
 
-	if t3.String() != "3" {
-		t.Errorf("expected %s got %s", "3", t3.String())
+	if t4.String() != string(PathMatchNameRegex) {
+		t.Errorf("expected %s got %s", PathMatchNameRegex, t4.String())
+	}
+
+	if t3.String() != "27" {
+		t.Errorf("expected %s got %s", "27", t3.String())
 	}
 }

--- a/pkg/proxy/paths/options/options.go
+++ b/pkg/proxy/paths/options/options.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -84,6 +85,10 @@ type Options struct {
 	ResponseBodyBytes []byte `yaml:"-"`
 	// MatchType is the PathMatchType representation of MatchTypeName
 	MatchType matching.PathMatchType `yaml:"-"`
+	// Regexp is the compiled representation of Path when MatchType is
+	// PathMatchTypeRegex, compiled once at config load; compiled regexps are
+	// immutable and safe for concurrent use, so Clone copies the pointer
+	Regexp *regexp.Regexp `yaml:"-"`
 	// CollapsedForwardingType is the typed representation of CollapsedForwardingName
 	CollapsedForwardingType forwarding.CollapsedForwardingType `yaml:"-"`
 	// KeyHasher points to an optional function that hashes the cacheKey with a custom algorithm
@@ -160,7 +165,12 @@ func (o *Options) Initialize(_ string) error {
 		o.Methods = methods.AllHTTPMethods()
 	}
 
-	if o.MatchTypeName == "" {
+	if isRegexPath(o.Path) {
+		// a path starting with ^/ (or the escaped ^\/ form) is always treated
+		// as a regex path, regardless of the configured match_type
+		o.MatchTypeName = matching.PathMatchNameRegex
+		o.MatchType = matching.PathMatchTypeRegex
+	} else if o.MatchTypeName == "" {
 		o.MatchTypeName = matching.PathMatchNameExact
 		o.MatchType = matching.PathMatchTypeExact
 	} else {
@@ -170,6 +180,17 @@ func (o *Options) Initialize(_ string) error {
 		} else {
 			o.MatchType = matching.PathMatchTypeExact
 			o.MatchTypeName = matching.PathMatchNameExact
+		}
+	}
+
+	if o.MatchType == matching.PathMatchTypeRegex {
+		if !strings.HasPrefix(o.Path, "^") {
+			o.Path = "^" + o.Path
+		}
+		// compile errors are surfaced by Validate, which reports them with
+		// full config context
+		if re, err := regexp.Compile(o.Path); err == nil {
+			o.Regexp = re
 		}
 	}
 
@@ -201,10 +222,27 @@ func (l Lookup) Initialize() error {
 	return nil
 }
 
+// isRegexPath returns true if the path pattern indicates a regex path via the
+// auto-detection rule: a leading ^/ or the escaped ^\/ form
+func isRegexPath(path string) bool {
+	return strings.HasPrefix(path, "^/") || strings.HasPrefix(path, `^\/`)
+}
+
 func (o *Options) Validate() (bool, error) {
 	normalized := matching.PathMatchName(strings.ToLower(string(o.MatchTypeName)))
-	if _, ok := matching.Names[normalized]; !ok && o.MatchTypeName != "" {
+	if _, ok := matching.Names[normalized]; !ok && o.MatchTypeName != "" &&
+		!isRegexPath(o.Path) {
 		return false, fmt.Errorf("invalid match_type: %s", o.MatchTypeName)
+	}
+	if o.MatchType == matching.PathMatchTypeRegex ||
+		normalized == matching.PathMatchNameRegex || isRegexPath(o.Path) {
+		if o.Regexp == nil {
+			re, err := regexp.Compile(o.Path)
+			if err != nil {
+				return false, fmt.Errorf("invalid regex path %q: %s", o.Path, err)
+			}
+			o.Regexp = re
+		}
 	}
 	for _, method := range o.Methods {
 		if !methods.IsValidMethod(method) {
@@ -227,14 +265,41 @@ func (o *Options) Validate() (bool, error) {
 	return true, nil
 }
 
-func (l List) Validate() error {
+// Validate validates each path Options in the List; name is the name of the
+// backend the List belongs to, used to provide context in errors
+func (l List) Validate(name string) error {
 	for _, o := range l {
+		if o == nil {
+			continue
+		}
 		_, err := o.Validate()
 		if err != nil {
-			return err
+			return fmt.Errorf("backend %q: %s", name, err)
 		}
 	}
 	return nil
+}
+
+// RegexShadowedByCatchAll returns true if the List contains one or more regex
+// paths alongside a catch-all classic prefix path ("/"), which prefix-matches
+// every request and therefore precludes the regex tier (evaluated only after
+// exact and prefix both miss) from ever being reached
+func (l List) RegexShadowedByCatchAll() bool {
+	var hasRegex, hasCatchAll bool
+	for _, o := range l {
+		if o == nil {
+			continue
+		}
+		switch o.MatchType {
+		case matching.PathMatchTypeRegex:
+			hasRegex = true
+		case matching.PathMatchTypePrefix:
+			if o.Path == "/" {
+				hasCatchAll = true
+			}
+		}
+	}
+	return hasRegex && hasCatchAll
 }
 
 func (l List) Clone() List {
@@ -321,6 +386,89 @@ func (l List) Overlay(l2 List) List {
 		}
 	}
 	return out
+}
+
+// Match returns the path Options that the lm router would select for the
+// provided request method and path, mirroring router precedence exactly:
+// exact match first, then longest prefix, then regex (longest pattern string
+// first, ties broken by config order, first match wins). Within a tier, a
+// matched path whose Options do not permit the method returns nil (where the
+// router would respond 405 Method Not Allowed) rather than falling through to
+// the next tier. HEAD implicitly matches a GET entry unless HEAD is
+// explicitly configured for the same path. Returns nil when no path matches.
+func (l List) Match(method, path string) *Options {
+	method = strings.ToUpper(method)
+	// exact tier
+	if candidates := l.withPath(matching.PathMatchTypeExact, path); len(candidates) > 0 {
+		return matchMethod(candidates, method)
+	}
+	// prefix tier: the longest matching prefix wins regardless of method
+	var longest string
+	var matched bool
+	for _, o := range l {
+		if o == nil || o.MatchType != matching.PathMatchTypePrefix {
+			continue
+		}
+		if strings.HasPrefix(path, o.Path) && (!matched || len(o.Path) > len(longest)) {
+			longest = o.Path
+			matched = true
+		}
+	}
+	if matched {
+		return matchMethod(l.withPath(matching.PathMatchTypePrefix, longest), method)
+	}
+	// regex tier: longest pattern first, config order breaks ties,
+	// first match wins
+	regexes := make(List, 0, len(l))
+	for _, o := range l {
+		if o != nil && o.MatchType == matching.PathMatchTypeRegex && o.Regexp != nil {
+			regexes = append(regexes, o)
+		}
+	}
+	slices.SortStableFunc(regexes, func(a, b *Options) int {
+		return len(b.Path) - len(a.Path)
+	})
+	for _, o := range regexes {
+		if o.Regexp.MatchString(path) {
+			return matchMethod(l.withPath(matching.PathMatchTypeRegex, o.Path), method)
+		}
+	}
+	return nil
+}
+
+// withPath returns the members of the List having the provided MatchType and
+// exact Path string, in config order
+func (l List) withPath(t matching.PathMatchType, path string) List {
+	out := make(List, 0, len(l))
+	for _, o := range l {
+		if o != nil && o.MatchType == t && o.Path == path {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+// matchMethod returns the first candidate permitting the method; a HEAD
+// request additionally matches a GET entry when no candidate explicitly
+// permits HEAD, mirroring the router's implicit HEAD-for-GET registration
+func matchMethod(candidates List, method string) *Options {
+	for _, o := range candidates {
+		if slices.ContainsFunc(o.Methods, func(m string) bool {
+			return strings.EqualFold(m, method)
+		}) {
+			return o
+		}
+	}
+	if method == http.MethodHead {
+		for _, o := range candidates {
+			if slices.ContainsFunc(o.Methods, func(m string) bool {
+				return strings.EqualFold(m, http.MethodGet)
+			}) {
+				return o
+			}
+		}
+	}
+	return nil
 }
 
 func (o *Options) UnmarshalYAML(value *yaml.Node) error {

--- a/pkg/proxy/paths/options/options_regex_test.go
+++ b/pkg/proxy/paths/options/options_regex_test.go
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package options
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
+
+	"github.com/stretchr/testify/require"
+)
+
+func newPathOptions(path string, matchTypeName matching.PathMatchName,
+	methods ...string,
+) *Options {
+	o := New()
+	o.Path = path
+	o.MatchTypeName = matchTypeName
+	if len(methods) > 0 {
+		o.Methods = methods
+	}
+	return o
+}
+
+func TestInitializeRegexAutoDetect(t *testing.T) {
+	tests := []struct {
+		name              string
+		path              string
+		matchTypeName     matching.PathMatchName
+		expectedMatchType matching.PathMatchType
+		expectedPath      string
+		expectCompiled    bool
+	}{
+		{
+			name:              "caret slash prefix",
+			path:              "^/api/[0-9]+/results",
+			expectedMatchType: matching.PathMatchTypeRegex,
+			expectedPath:      "^/api/[0-9]+/results",
+			expectCompiled:    true,
+		},
+		{
+			name:              "escaped caret slash prefix",
+			path:              `^\/api\/[0-9]+`,
+			expectedMatchType: matching.PathMatchTypeRegex,
+			expectedPath:      `^\/api\/[0-9]+`,
+			expectCompiled:    true,
+		},
+		{
+			name:              "auto-detection overrides explicit match_type",
+			path:              "^/api/.*",
+			matchTypeName:     matching.PathMatchNameExact,
+			expectedMatchType: matching.PathMatchTypeRegex,
+			expectedPath:      "^/api/.*",
+			expectCompiled:    true,
+		},
+		{
+			name:              "explicit regex is anchored when unanchored",
+			path:              "/api/.*",
+			matchTypeName:     matching.PathMatchNameRegex,
+			expectedMatchType: matching.PathMatchTypeRegex,
+			expectedPath:      "^/api/.*",
+			expectCompiled:    true,
+		},
+		{
+			name:              "explicit regex already anchored",
+			path:              "^/api/.*$",
+			matchTypeName:     matching.PathMatchNameRegex,
+			expectedMatchType: matching.PathMatchTypeRegex,
+			expectedPath:      "^/api/.*$",
+			expectCompiled:    true,
+		},
+		{
+			name:              "literal path remains exact",
+			path:              "/api/query",
+			expectedMatchType: matching.PathMatchTypeExact,
+			expectedPath:      "/api/query",
+			expectCompiled:    false,
+		},
+		{
+			name:              "literal path remains prefix",
+			path:              "/api",
+			matchTypeName:     matching.PathMatchNamePrefix,
+			expectedMatchType: matching.PathMatchTypePrefix,
+			expectedPath:      "/api",
+			expectCompiled:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			o := newPathOptions(test.path, test.matchTypeName)
+			require.NoError(t, o.Initialize(""))
+			if o.MatchType != test.expectedMatchType {
+				t.Errorf("expected match type %s, got %s",
+					test.expectedMatchType, o.MatchType)
+			}
+			if o.Path != test.expectedPath {
+				t.Errorf("expected path %s, got %s", test.expectedPath, o.Path)
+			}
+			if test.expectCompiled {
+				require.NotNil(t, o.Regexp)
+				if o.MatchTypeName != matching.PathMatchNameRegex {
+					t.Errorf("expected match type name %s, got %s",
+						matching.PathMatchNameRegex, o.MatchTypeName)
+				}
+			} else {
+				require.Nil(t, o.Regexp)
+			}
+		})
+	}
+}
+
+func TestValidateRegexCompileFailure(t *testing.T) {
+	o := newPathOptions("^/api/(unclosed", "")
+	require.NoError(t, o.Initialize(""))
+	require.Nil(t, o.Regexp)
+
+	_, err := o.Validate()
+	require.Error(t, err)
+	if !strings.Contains(err.Error(), "^/api/(unclosed") {
+		t.Errorf("expected error to contain the pattern, got %v", err)
+	}
+
+	err = List{o}.Validate("test-backend")
+	require.Error(t, err)
+	if !strings.Contains(err.Error(), "test-backend") {
+		t.Errorf("expected error to contain the backend name, got %v", err)
+	}
+
+	// a valid regex path passes and Validate compiles when Initialize was skipped
+	o2 := newPathOptions("^/api/.*", "")
+	o2.MatchType = matching.PathMatchTypeRegex
+	o2.MatchTypeName = matching.PathMatchNameRegex
+	ok, err := o2.Validate()
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.NotNil(t, o2.Regexp)
+}
+
+func TestRegexClone(t *testing.T) {
+	o := newPathOptions("^/api/.*", "")
+	require.NoError(t, o.Initialize(""))
+	require.NotNil(t, o.Regexp)
+	o2 := o.Clone()
+	if o2.Regexp != o.Regexp {
+		t.Error("expected Clone to copy the compiled regexp pointer")
+	}
+	if o2.MatchType != matching.PathMatchTypeRegex {
+		t.Errorf("expected match type %s, got %s",
+			matching.PathMatchTypeRegex, o2.MatchType)
+	}
+}
+
+func TestRegexOverlay(t *testing.T) {
+	// regex paths overlay by exact pattern-string equality
+	o1 := newPathOptions("^/api/.*", "", http.MethodGet)
+	o2 := newPathOptions("^/api/.*", "", http.MethodGet)
+	o3 := newPathOptions("^/other/.*", "", http.MethodGet)
+	l := List{o1, o2, o3}
+	require.NoError(t, l.Initialize())
+
+	out := List{o1}.Overlay(List{o2})
+	require.Equal(t, 1, len(out))
+	if out[0] != o2 {
+		t.Error("expected overlay with identical pattern and methods to replace")
+	}
+
+	out = List{o1}.Overlay(List{o3})
+	require.Equal(t, 2, len(out))
+	if out[0] != o1 || out[1] != o3 {
+		t.Error("expected overlay with a distinct pattern to append")
+	}
+}
+
+func TestListMatch(t *testing.T) {
+	exact := newPathOptions("/api/query", "", http.MethodGet, http.MethodPost)
+	prefixShort := newPathOptions("/api", matching.PathMatchNamePrefix, http.MethodGet)
+	prefixLong := newPathOptions("/api/admin", matching.PathMatchNamePrefix, http.MethodGet)
+	regexLong := newPathOptions("^/results/[0-9]+/detail", "", http.MethodGet)
+	regexShort := newPathOptions("^/results/[0-9]+", "", http.MethodGet)
+	regexCatchAll := newPathOptions("^/.*", "", http.MethodGet)
+	postOnly := newPathOptions("^/write/.*", "", http.MethodPost)
+
+	l := List{exact, prefixShort, prefixLong, regexShort, regexLong,
+		regexCatchAll, postOnly}
+	require.NoError(t, l.Initialize())
+
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		expected *Options
+	}{
+		{"exact match wins", http.MethodGet, "/api/query", exact},
+		{"longest prefix wins", http.MethodGet, "/api/admin/users", prefixLong},
+		{"shorter prefix", http.MethodGet, "/api/other", prefixShort},
+		{"regex only after classic misses", http.MethodGet,
+			"/results/42/detail", regexLong},
+		{"shorter regex when longer misses", http.MethodGet,
+			"/results/42/summary", regexShort},
+		{"regex catch-all evaluates last", http.MethodGet, "/misc", regexCatchAll},
+		{"regex method match", http.MethodPost, "/write/data", postOnly},
+		{"implicit HEAD for GET on exact", http.MethodHead, "/api/query", exact},
+		{"implicit HEAD for GET on regex", http.MethodHead,
+			"/results/42/detail", regexLong},
+		{"method not allowed on exact returns nil", http.MethodDelete,
+			"/api/query", nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := l.Match(test.method, test.path)
+			if out != test.expected {
+				t.Errorf("expected %v, got %v", test.expected, out)
+			}
+		})
+	}
+
+	// tie in pattern length is broken by config order
+	tieA := newPathOptions("^/tie/[ab]+", "", http.MethodGet)
+	tieB := newPathOptions("^/tie/[ba]+", "", http.MethodGet)
+	l2 := List{tieB, tieA}
+	require.NoError(t, l2.Initialize())
+	if out := l2.Match(http.MethodGet, "/tie/ab"); out != tieB {
+		t.Error("expected pattern-length tie to be broken by config order")
+	}
+
+	// no match at all
+	if out := (List{exact}).Match(http.MethodGet, "/nope"); out != nil {
+		t.Errorf("expected nil, got %v", out)
+	}
+}
+
+func TestListValidate(t *testing.T) {
+	o := newPathOptions("^/api/.*", "")
+	require.NoError(t, o.Initialize(""))
+	require.NoError(t, List{nil, o}.Validate("test-backend"))
+
+	bad := newPathOptions("/api/query", "bogus")
+	err := List{bad}.Validate("test-backend")
+	require.Error(t, err)
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("expected error to contain the invalid match_type, got %v", err)
+	}
+}
+
+func TestListClone(t *testing.T) {
+	o := newPathOptions("^/api/.*", "")
+	require.NoError(t, o.Initialize(""))
+	l := List{o}
+	l2 := l.Clone()
+	require.Equal(t, 1, len(l2))
+	if l2[0] == o || l2[0].Regexp != o.Regexp {
+		t.Error("expected a cloned Options sharing the compiled regexp pointer")
+	}
+}
+
+func TestRegexShadowedByCatchAll(t *testing.T) {
+	regex := newPathOptions("^/api/.*", "")
+	catchAll := newPathOptions("/", matching.PathMatchNamePrefix)
+	exact := newPathOptions("/api/query", "")
+
+	l := List{regex, catchAll}
+	require.NoError(t, l.Initialize())
+	l = append(l, nil)
+	if !l.RegexShadowedByCatchAll() {
+		t.Error("expected regex + catch-all prefix to report shadowing")
+	}
+
+	l = List{regex, exact}
+	require.NoError(t, l.Initialize())
+	if l.RegexShadowedByCatchAll() {
+		t.Error("expected no shadowing without a catch-all prefix")
+	}
+
+	l = List{catchAll, exact}
+	require.NoError(t, l.Initialize())
+	if l.RegexShadowedByCatchAll() {
+		t.Error("expected no shadowing without a regex path")
+	}
+}

--- a/pkg/proxy/router/lm/lm.go
+++ b/pkg/proxy/router/lm/lm.go
@@ -19,13 +19,16 @@ package lm
 
 import (
 	"cmp"
+	"fmt"
 	"net/http"
+	"regexp"
 	"slices"
 	"strings"
 
 	"github.com/trickstercache/trickster/v2/pkg/errors"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
 	meth "github.com/trickstercache/trickster/v2/pkg/proxy/methods"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/route"
 )
@@ -61,7 +64,7 @@ func (rt *lmRouter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (rt *lmRouter) RegisterRoute(path string, hosts, methods []string,
-	matchPrefix bool, handler http.Handler,
+	matchType matching.PathMatchType, handler http.Handler,
 ) error {
 	pl := len(path)
 	if pl == 0 {
@@ -77,6 +80,17 @@ func (rt *lmRouter) RegisterRoute(path string, hosts, methods []string,
 			methods[i] = strings.ToUpper(m)
 		}
 	}
+	var re *regexp.Regexp
+	switch matchType {
+	case matching.PathMatchTypeExact, matching.PathMatchTypePrefix:
+	case matching.PathMatchTypeRegex:
+		var err error
+		if re, err = regexp.Compile(path); err != nil {
+			return fmt.Errorf("%w: %s", errors.ErrInvalidPath, err)
+		}
+	default:
+		return errors.ErrInvalidMatchType
+	}
 	if hosts == nil {
 		hosts = emptyHost
 	}
@@ -87,89 +101,106 @@ func (rt *lmRouter) RegisterRoute(path string, hosts, methods []string,
 				ExactMatchRoutes:     make(route.LookupLookup),
 				PrefixMatchRoutes:    make(route.PrefixRouteSets, 0, 16),
 				PrefixMatchRoutesLkp: make(route.PrefixRouteSetLookup),
+				RegexMatchRoutesLkp:  make(route.RegexRouteSetLookup),
 			}
 			rt.routes[h] = hrc
 		}
-		if !matchPrefix {
+		switch matchType {
+		case matching.PathMatchTypeExact:
 			rl, ok := hrc.ExactMatchRoutes[path]
 			if rl == nil || !ok {
 				rl = make(route.Lookup)
 				hrc.ExactMatchRoutes[path] = rl
 			}
-			for _, m := range methods {
-				rl[m] = &route.Route{
-					ExactMatch: true,
-					Method:     m,
-					Host:       h,
-					Path:       path,
-					Handler:    handler,
+			registerMethods(rl, path, h, methods, handler, true)
+		case matching.PathMatchTypePrefix:
+			prc, ok := hrc.PrefixMatchRoutesLkp[path]
+			if prc == nil || !ok {
+				prc = &route.PrefixRouteSet{
+					Path:           path,
+					PathLen:        pl,
+					RoutesByMethod: make(route.Lookup),
 				}
-				if m == http.MethodGet {
-					if _, ok := rl[http.MethodHead]; !ok {
-						rl[http.MethodHead] = &route.Route{
-							ExactMatch: true,
-							Method:     http.MethodHead,
-							Host:       h,
-							Path:       path,
-							Handler:    handler,
-						}
-					}
+				hrc.PrefixMatchRoutesLkp[path] = prc
+				if len(hrc.PrefixMatchRoutes) == 0 {
+					hrc.PrefixMatchRoutes = make(route.PrefixRouteSets, 0, 16)
 				}
+				hrc.PrefixMatchRoutes = append(hrc.PrefixMatchRoutes, prc)
 			}
-			continue
-		}
-		prc, ok := hrc.PrefixMatchRoutesLkp[path]
-		if prc == nil || !ok {
-			prc = &route.PrefixRouteSet{
-				Path:           path,
-				PathLen:        pl,
-				RoutesByMethod: make(route.Lookup),
-			}
-			hrc.PrefixMatchRoutesLkp[path] = prc
-			if len(hrc.PrefixMatchRoutes) == 0 {
-				hrc.PrefixMatchRoutes = make(route.PrefixRouteSets, 0, 16)
-			}
-			hrc.PrefixMatchRoutes = append(hrc.PrefixMatchRoutes, prc)
-		}
-		for _, m := range methods {
-			prc.RoutesByMethod[m] = &route.Route{
-				ExactMatch: true,
-				Method:     m,
-				Host:       h,
-				Path:       path,
-				Handler:    handler,
-			}
-			if m == http.MethodGet {
-				if _, ok := prc.RoutesByMethod[http.MethodHead]; !ok {
-					prc.RoutesByMethod[http.MethodHead] = &route.Route{
-						ExactMatch: true,
-						Method:     http.MethodHead,
-						Host:       h,
-						Path:       path,
-						Handler:    handler,
-					}
+			registerMethods(prc.RoutesByMethod, path, h, methods, handler, true)
+		case matching.PathMatchTypeRegex:
+			rrs, ok := hrc.RegexMatchRoutesLkp[path]
+			if rrs == nil || !ok {
+				rrs = &route.RegexRouteSet{
+					Pattern:        path,
+					PatternLen:     pl,
+					Regexp:         re,
+					RoutesByMethod: make(route.Lookup),
 				}
+				hrc.RegexMatchRoutesLkp[path] = rrs
+				hrc.RegexMatchRoutes = append(hrc.RegexMatchRoutes, rrs)
 			}
+			registerMethods(rrs.RoutesByMethod, path, h, methods, handler, false)
 		}
 	}
 	rt.sort()
 	return nil
 }
 
-// this sorts the prefix-match paths longest to shortest
-func (rt *lmRouter) sort() {
-	for _, hrc := range rt.routes {
-		if len(hrc.PrefixMatchRoutes) == 0 {
-			continue
+// registerMethods populates the method lookup for a route path, including the
+// implicit HEAD-for-GET registration
+func registerMethods(rl route.Lookup, path, host string, methods []string,
+	handler http.Handler, exactMatch bool,
+) {
+	for _, m := range methods {
+		rl[m] = &route.Route{
+			ExactMatch: exactMatch,
+			Method:     m,
+			Host:       host,
+			Path:       path,
+			Handler:    handler,
 		}
-		prs := prefixRouteSets(hrc.PrefixMatchRoutes)
-		slices.SortFunc(prs, func(a, b *route.PrefixRouteSet) int {
-			return cmp.Compare(b.PathLen, a.PathLen)
-		})
-		hrc.PrefixMatchRoutes = route.PrefixRouteSets(prs)
+		if m == http.MethodGet {
+			if _, ok := rl[http.MethodHead]; !ok {
+				rl[http.MethodHead] = &route.Route{
+					ExactMatch: exactMatch,
+					Method:     http.MethodHead,
+					Host:       host,
+					Path:       path,
+					Handler:    handler,
+				}
+			}
+		}
 	}
 }
 
+// this sorts the prefix-match paths longest to shortest, and the regex
+// patterns longest to shortest with registration order breaking ties (stable),
+// so regex evaluation order is deterministic
+func (rt *lmRouter) sort() {
+	for _, hrc := range rt.routes {
+		if len(hrc.PrefixMatchRoutes) > 0 {
+			prs := prefixRouteSets(hrc.PrefixMatchRoutes)
+			slices.SortFunc(prs, func(a, b *route.PrefixRouteSet) int {
+				return cmp.Compare(b.PathLen, a.PathLen)
+			})
+			hrc.PrefixMatchRoutes = route.PrefixRouteSets(prs)
+		}
+		if len(hrc.RegexMatchRoutes) > 0 {
+			slices.SortStableFunc(hrc.RegexMatchRoutes,
+				func(a, b *route.RegexRouteSet) int {
+					return cmp.Compare(b.PatternLen, a.PatternLen)
+				})
+		}
+	}
+}
+
+// Handler resolves the request in two passes: first against the request's
+// hostname, then against the global ("") host. Within each pass, matching is
+// exact > longest prefix > regex, so a host-specific classic match wins over a
+// host-specific regex, and a host-specific regex wins over any global route;
+// if a request misses everything on the named host, the global pass repeats
+// exact > prefix > regex.
 func (rt *lmRouter) Handler(r *http.Request) http.Handler {
 	if rt.matchScheme&router.MatchHostname == router.MatchHostname {
 		host := r.Host
@@ -198,20 +229,32 @@ func (rt *lmRouter) matchByHost(method, host, path string) http.Handler {
 			}
 			return r.Handler
 		}
-		if rt.matchScheme&router.MatchPathPrefix != router.MatchPathPrefix {
-			return nil
-		}
-		lp := len(path)
-		for _, prc := range hrc.PrefixMatchRoutes {
-			if prc.PathLen > lp {
-				continue
-			}
-			if strings.HasPrefix(path, prc.Path) {
-				r, ok := prc.RoutesByMethod[method]
-				if !ok || r == nil {
-					return methodNotAllowedHandler
+		if rt.matchScheme&router.MatchPathPrefix == router.MatchPathPrefix {
+			lp := len(path)
+			for _, prc := range hrc.PrefixMatchRoutes {
+				if prc.PathLen > lp {
+					continue
 				}
-				return r.Handler
+				if strings.HasPrefix(path, prc.Path) {
+					r, ok := prc.RoutesByMethod[method]
+					if !ok || r == nil {
+						return methodNotAllowedHandler
+					}
+					return r.Handler
+				}
+			}
+		}
+		// the regex tier is evaluated only after exact and prefix both miss;
+		// iterating a host's empty regex set costs nothing
+		if rt.matchScheme&router.MatchPathRegex == router.MatchPathRegex {
+			for _, rrs := range hrc.RegexMatchRoutes {
+				if rrs.Regexp.MatchString(path) {
+					r, ok := rrs.RoutesByMethod[method]
+					if !ok || r == nil {
+						return methodNotAllowedHandler
+					}
+					return r.Handler
+				}
 			}
 		}
 	}

--- a/pkg/proxy/router/lm/lm_bench_test.go
+++ b/pkg/proxy/router/lm/lm_bench_test.go
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lm
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
+)
+
+var benchHandler = http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+
+// newBenchRouter registers nClassic exact and nClassic prefix routes, and
+// nRegex regex routes, all on the global host
+func newBenchRouter(b *testing.B, nClassic, nRegex int) *lmRouter {
+	r := NewRouter().(*lmRouter)
+	for i := range nClassic {
+		if err := r.RegisterRoute(fmt.Sprintf("/exact/path/%03d", i), nil, nil,
+			matching.PathMatchTypeExact, benchHandler); err != nil {
+			b.Fatal(err)
+		}
+		if err := r.RegisterRoute(fmt.Sprintf("/prefix/path/%03d", i), nil, nil,
+			matching.PathMatchTypePrefix, benchHandler); err != nil {
+			b.Fatal(err)
+		}
+	}
+	for i := range nRegex {
+		if err := r.RegisterRoute(fmt.Sprintf("^/svc%03d/[a-z-]+/[0-9]+", i),
+			nil, nil, matching.PathMatchTypeRegex, benchHandler); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return r
+}
+
+func benchRequest(b *testing.B, r *lmRouter, path string, expectMatch bool) {
+	req, _ := http.NewRequest(http.MethodGet, path, nil)
+	w := httptest.NewRecorder()
+	r.Handler(req).ServeHTTP(w, req)
+	if expectMatch && w.Code != http.StatusOK {
+		b.Fatalf("expected a route match for %s, got status %d", path, w.Code)
+	}
+	if !expectMatch && w.Code != http.StatusNotFound {
+		b.Fatalf("expected no route match for %s, got status %d", path, w.Code)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		r.Handler(req)
+	}
+}
+
+// classic exact matching with no regex routes registered (baseline)
+func BenchmarkClassicExact_RegexRoutes0(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 0), "/exact/path/005", true)
+}
+
+// classic exact matching with 100 regex routes registered; must be
+// zero-delta vs the baseline because the exact tier matches first
+func BenchmarkClassicExact_RegexRoutes100(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 100), "/exact/path/005", true)
+}
+
+// classic prefix matching with no regex routes registered (baseline)
+func BenchmarkClassicPrefix_RegexRoutes0(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 0), "/prefix/path/005/extra", true)
+}
+
+// classic prefix matching with 100 regex routes registered; must be
+// zero-delta vs the baseline because the prefix tier matches first
+func BenchmarkClassicPrefix_RegexRoutes100(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 100), "/prefix/path/005/extra", true)
+}
+
+// all-miss with classic routes only (baseline for the empty-regex fast path)
+func BenchmarkAllMiss_RegexRoutes0(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 0), "/no/such/route", false)
+}
+
+// worst-case regex-tier hit: the request matches only the last-evaluated
+// pattern (equal-length patterns evaluate in registration order, so the
+// highest-numbered service pattern is checked last), meaning every registered
+// pattern is evaluated
+func BenchmarkRegexWorstCaseHit_RegexRoutes1(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 1), "/svc000/detail/42", true)
+}
+
+func BenchmarkRegexWorstCaseHit_RegexRoutes10(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 10), "/svc009/detail/42", true)
+}
+
+func BenchmarkRegexWorstCaseHit_RegexRoutes100(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 100), "/svc099/detail/42", true)
+}
+
+// worst-case all-miss: both classic tiers and every regex pattern evaluated
+func BenchmarkRegexAllMiss_RegexRoutes1(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 1), "/no/such/route", false)
+}
+
+func BenchmarkRegexAllMiss_RegexRoutes10(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 10), "/no/such/route", false)
+}
+
+func BenchmarkRegexAllMiss_RegexRoutes100(b *testing.B) {
+	benchRequest(b, newBenchRouter(b, 10, 100), "/no/such/route", false)
+}

--- a/pkg/proxy/router/lm/lm_fuzz_test.go
+++ b/pkg/proxy/router/lm/lm_fuzz_test.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lm
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
+)
+
+// fuzzRoute is one entry in the mixed route table shared by the router under
+// test and the naive reference implementation
+type fuzzRoute struct {
+	matchType matching.PathMatchType
+	path      string
+	marker    string
+	re        *regexp.Regexp
+}
+
+var fuzzRoutes = []*fuzzRoute{
+	{matching.PathMatchTypeExact, "/api/query", "exact-query", nil},
+	{matching.PathMatchTypeExact, "/foo", "exact-foo", nil},
+	{matching.PathMatchTypePrefix, "/api/", "prefix-api", nil},
+	{matching.PathMatchTypePrefix, "/foo/bar", "prefix-foobar", nil},
+	{matching.PathMatchTypeRegex, "^/api/[0-9]+", "regex-api-num", nil},
+	{matching.PathMatchTypeRegex, "^/[a-z]+/query", "regex-query", nil},
+	{matching.PathMatchTypeRegex, "^/foo/[0-9]+$", "regex-foo-num", nil},
+	{matching.PathMatchTypeRegex, "^/z.*", "regex-z", nil},
+}
+
+// refMatch is a naive reference implementation of the router's selection
+// semantics for GET requests on the global host: exact, then longest prefix,
+// then regex longest-pattern-first with config order breaking ties
+func refMatch(path string) string {
+	for _, fr := range fuzzRoutes {
+		if fr.matchType == matching.PathMatchTypeExact && fr.path == path {
+			return fr.marker
+		}
+	}
+	var prefixBest *fuzzRoute
+	for _, fr := range fuzzRoutes {
+		if fr.matchType == matching.PathMatchTypePrefix &&
+			strings.HasPrefix(path, fr.path) &&
+			(prefixBest == nil || len(fr.path) > len(prefixBest.path)) {
+			prefixBest = fr
+		}
+	}
+	if prefixBest != nil {
+		return prefixBest.marker
+	}
+	regexes := make([]*fuzzRoute, 0, len(fuzzRoutes))
+	for _, fr := range fuzzRoutes {
+		if fr.matchType == matching.PathMatchTypeRegex {
+			regexes = append(regexes, fr)
+		}
+	}
+	sort.SliceStable(regexes, func(i, j int) bool {
+		return len(regexes[i].path) > len(regexes[j].path)
+	})
+	for _, fr := range regexes {
+		if fr.re.MatchString(path) {
+			return fr.marker
+		}
+	}
+	return ""
+}
+
+func FuzzHandler(f *testing.F) {
+	r := NewRouter().(*lmRouter)
+	for _, fr := range fuzzRoutes {
+		if fr.matchType == matching.PathMatchTypeRegex {
+			fr.re = regexp.MustCompile(fr.path)
+		}
+		marker := fr.marker
+		if err := r.RegisterRoute(fr.path, nil, []string{http.MethodGet},
+			fr.matchType, http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) {
+					http.Error(w, marker, http.StatusOK)
+				})); err != nil {
+			f.Fatal(err)
+		}
+	}
+
+	f.Add("/api/query")
+	f.Add("/api/42")
+	f.Add("/api/42/detail")
+	f.Add("/foo")
+	f.Add("/foo/bar/baz")
+	f.Add("/foo/99")
+	f.Add("/zebra")
+	f.Add("/abc/query")
+	f.Add("/no/match/here")
+	f.Add("")
+	f.Add("/")
+	f.Add("^/api/[0-9]+")
+	f.Add("/foo\x00bar")
+	f.Add(strings.Repeat("/foo", 512))
+
+	f.Fuzz(func(t *testing.T, path string) {
+		req := &http.Request{
+			Method: http.MethodGet,
+			URL:    &url.URL{Path: path},
+		}
+		w := httptest.NewRecorder()
+		// must never panic
+		r.Handler(req).ServeHTTP(w, req)
+
+		expected := refMatch(path)
+		if expected == "" {
+			if w.Code != http.StatusNotFound {
+				t.Fatalf("path %q: expected 404, got %d (%q)",
+					path, w.Code, strings.TrimSpace(w.Body.String()))
+			}
+			return
+		}
+		if w.Code != http.StatusOK {
+			t.Fatalf("path %q: expected 200 (%s), got %d",
+				path, expected, w.Code)
+		}
+		if body := strings.TrimSpace(w.Body.String()); body != expected {
+			t.Fatalf("path %q: expected handler %q, got %q",
+				path, expected, body)
+		}
+	})
+}

--- a/pkg/proxy/router/lm/lm_test.go
+++ b/pkg/proxy/router/lm/lm_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/errors"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/router"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/router/route"
 	"github.com/trickstercache/trickster/v2/pkg/testutil/writer"
 
@@ -39,7 +41,7 @@ func TestRegisterRoute(t *testing.T) {
 	const testPathExact1 = "/path1/exact"
 
 	r := NewRouter().(*lmRouter)
-	r.RegisterRoute(testPathExact1, nil, nil, false, notFoundHandler)
+	r.RegisterRoute(testPathExact1, nil, nil, matching.PathMatchTypeExact, notFoundHandler)
 
 	hrs, ok := r.routes[""]
 	if !ok || hrs == nil {
@@ -50,19 +52,19 @@ func TestRegisterRoute(t *testing.T) {
 		t.Fatal("expected non-nil route lookup")
 	}
 
-	err := r.RegisterRoute("", nil, nil, false, notFoundHandler)
+	err := r.RegisterRoute("", nil, nil, matching.PathMatchTypeExact, notFoundHandler)
 	if err != errors.ErrInvalidPath {
 		t.Fatal("expected error for invalid path")
 	}
 
 	err = r.RegisterRoute(testPathPrefix1, nil, []string{"invalidMethod"},
-		false, notFoundHandler)
+		matching.PathMatchTypeExact, notFoundHandler)
 	if err != errors.ErrInvalidMethod {
 		t.Fatal("expected error for invalid method")
 	}
 
 	err = r.RegisterRoute(testPathPrefix1, nil, []string{http.MethodGet},
-		true, notFoundHandler)
+		matching.PathMatchTypePrefix, notFoundHandler)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,10 +72,10 @@ func TestRegisterRoute(t *testing.T) {
 
 func TestHandler(t *testing.T) {
 	r := NewRouter().(*lmRouter)
-	r.RegisterRoute(testPathExact1, nil, nil, false, testResponse1Handler)
-	r.RegisterRoute(testPathPrefix2, []string{"example.com"}, nil, true,
+	r.RegisterRoute(testPathExact1, nil, nil, matching.PathMatchTypeExact, testResponse1Handler)
+	r.RegisterRoute(testPathPrefix2, []string{"example.com"}, nil, matching.PathMatchTypePrefix,
 		testResponse2Handler)
-	r.RegisterRoute(testPathPrefix1, []string{"example.com"}, nil, true,
+	r.RegisterRoute(testPathPrefix1, []string{"example.com"}, nil, matching.PathMatchTypePrefix,
 		testResponse1Handler)
 
 	req, _ := http.NewRequest(http.MethodGet, testPathExact1, nil)
@@ -139,7 +141,7 @@ func TestHandler(t *testing.T) {
 		t.Fatal("expected method not allowed handler")
 	}
 
-	r.RegisterRoute(testPathExact2, []string{"example.com"}, nil, false,
+	r.RegisterRoute(testPathExact2, []string{"example.com"}, nil, matching.PathMatchTypeExact,
 		testResponse2Handler)
 	req, _ = http.NewRequest(http.MethodGet, testPathExact2, nil)
 	req.Host = "example.com:8080"
@@ -169,7 +171,7 @@ func TestHandler(t *testing.T) {
 
 func TestServeHTTP(t *testing.T) {
 	r := NewRouter().(*lmRouter)
-	r.RegisterRoute("/", nil, nil, true, testResponse1Handler)
+	r.RegisterRoute("/", nil, nil, matching.PathMatchTypePrefix, testResponse1Handler)
 	w := writer.NewWriter().(*writer.TestResponseWriter)
 	req, _ := http.NewRequest(http.MethodGet, testPathPrefix1, nil)
 	req.RequestURI = "*"
@@ -242,6 +244,188 @@ func verifyBadRequest(w *writer.TestResponseWriter) bool {
 	return w.StatusCode == http.StatusBadRequest
 }
 
+func TestRegisterRouteRegex(t *testing.T) {
+	r := NewRouter().(*lmRouter)
+
+	// an invalid pattern is a registration error
+	err := r.RegisterRoute("^/bad/(unclosed", nil, nil,
+		matching.PathMatchTypeRegex, testResponse1Handler)
+	if err == nil {
+		t.Fatal("expected error for invalid regex pattern")
+	}
+
+	// an unknown match type is a registration error
+	err = r.RegisterRoute("/path", nil, nil, matching.PathMatchType(27),
+		testResponse1Handler)
+	if err != errors.ErrInvalidMatchType {
+		t.Fatal("expected error for invalid match type")
+	}
+
+	err = r.RegisterRoute("^/results/[0-9]+", nil, nil,
+		matching.PathMatchTypeRegex, testResponse1Handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hrs := r.routes[""]
+	require.NotNil(t, hrs)
+	require.Equal(t, 1, len(hrs.RegexMatchRoutes))
+	rrs := hrs.RegexMatchRoutes[0]
+	require.Equal(t, "^/results/[0-9]+", rrs.Pattern)
+	require.Equal(t, len(rrs.Pattern), rrs.PatternLen)
+	require.NotNil(t, rrs.Regexp)
+	// implicit HEAD-for-GET
+	require.NotNil(t, rrs.RoutesByMethod[http.MethodGet])
+	require.NotNil(t, rrs.RoutesByMethod[http.MethodHead])
+
+	// re-registering the same pattern reuses the set rather than appending
+	err = r.RegisterRoute("^/results/[0-9]+", nil, []string{http.MethodPost},
+		matching.PathMatchTypeRegex, testResponse2Handler)
+	if err != nil {
+		t.Fatal(err)
+	}
+	require.Equal(t, 1, len(hrs.RegexMatchRoutes))
+	require.NotNil(t, rrs.RoutesByMethod[http.MethodPost])
+}
+
+func TestHandlerRegex(t *testing.T) {
+	r := NewRouter().(*lmRouter)
+	// all three tiers on one host, plus a host-specific regex
+	r.RegisterRoute("/api/exact", nil, nil, matching.PathMatchTypeExact,
+		testResponse1Handler)
+	r.RegisterRoute("/api/prefix", nil, nil, matching.PathMatchTypePrefix,
+		testResponse1Handler)
+	r.RegisterRoute("^/api/[0-9]+", nil, nil, matching.PathMatchTypeRegex,
+		testResponse1Handler)
+	r.RegisterRoute("^/api/[0-9]+/detail", nil, nil, matching.PathMatchTypeRegex,
+		testResponse2Handler)
+	r.RegisterRoute("^/hosted/[0-9]+", []string{"example.com"}, nil,
+		matching.PathMatchTypeRegex, testResponse2Handler)
+
+	// regex sets are sorted longest pattern first
+	prs := r.routes[""].RegexMatchRoutes
+	require.Equal(t, 2, len(prs))
+	require.Equal(t, "^/api/[0-9]+/detail", prs[0].Pattern)
+
+	w := writer.NewWriter().(*writer.TestResponseWriter)
+
+	// classic tiers still win over regex
+	req, _ := http.NewRequest(http.MethodGet, "/api/exact", nil)
+	if !serveAndVerifyTestResponse1(r.Handler(req), w, req) {
+		t.Fatal("expected exact-tier test response 1 handler")
+	}
+	req, _ = http.NewRequest(http.MethodGet, "/api/prefix/42", nil)
+	w.Reset()
+	if !serveAndVerifyTestResponse1(r.Handler(req), w, req) {
+		t.Fatal("expected prefix-tier test response 1 handler")
+	}
+
+	// longest pattern evaluated first
+	req, _ = http.NewRequest(http.MethodGet, "/api/42/detail", nil)
+	w.Reset()
+	if !verifyTestResponse2(r.Handler(req), w, req) {
+		t.Fatal("expected longest-pattern test response 2 handler")
+	}
+	req, _ = http.NewRequest(http.MethodGet, "/api/42", nil)
+	w.Reset()
+	if !serveAndVerifyTestResponse1(r.Handler(req), w, req) {
+		t.Fatal("expected test response 1 handler")
+	}
+
+	// implicit HEAD, and 405 for an unregistered method
+	req, _ = http.NewRequest(http.MethodHead, "/api/42", nil)
+	w.Reset()
+	r.Handler(req).ServeHTTP(w, req)
+	if w.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for implicit HEAD, got %d", w.StatusCode)
+	}
+	req, _ = http.NewRequest(http.MethodPost, "/api/42", nil)
+	w.Reset()
+	if !verifyMethodNotAllowed(r.Handler(req), w, req) {
+		t.Fatal("expected method not allowed handler")
+	}
+
+	// host-specific regex is matched in the host pass, with global fallback
+	req, _ = http.NewRequest(http.MethodGet, "/hosted/1", nil)
+	req.Host = "example.com:8080"
+	w.Reset()
+	if !verifyTestResponse2(r.Handler(req), w, req) {
+		t.Fatal("expected host-specific test response 2 handler")
+	}
+	req, _ = http.NewRequest(http.MethodGet, "/api/42", nil)
+	req.Host = "example.com:8080"
+	w.Reset()
+	if !serveAndVerifyTestResponse1(r.Handler(req), w, req) {
+		t.Fatal("expected global regex fallback test response 1 handler")
+	}
+
+	// a scheme without MatchPathRegex never evaluates the regex tier
+	r.SetMatchingScheme(router.MatchHostname | router.MatchPathPrefix)
+	req, _ = http.NewRequest(http.MethodGet, "/api/42", nil)
+	w.Reset()
+	if !verifyNotFound(r.Handler(req), w, req) {
+		t.Fatal("expected 404 with regex matching disabled")
+	}
+}
+
+// TestGatewayMixedTierPrecedence verifies the routing semantics the Kubernetes
+// Ingress/Gateway controller relies upon: a kube-generated backend maps
+// HTTPRoute Exact -> exact, Prefix -> prefix and RegularExpression -> regex
+// paths on the same backend, and the router's classic-first evaluation order
+// implements Gateway API precedence (Exact > Prefix > RegularExpression)
+func TestGatewayMixedTierPrecedence(t *testing.T) {
+	mkHandler := func(body string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, body, http.StatusOK)
+		})
+	}
+	serve := func(r *lmRouter, path string) string {
+		req, _ := http.NewRequest(http.MethodGet, path, nil)
+		w := writer.NewWriter().(*writer.TestResponseWriter)
+		r.Handler(req).ServeHTTP(w, req)
+		return strings.TrimSpace(string(w.Bytes))
+	}
+
+	r := NewRouter().(*lmRouter)
+	r.RegisterRoute("/api/query", nil, nil, matching.PathMatchTypeExact,
+		mkHandler("exact"))
+	r.RegisterRoute("/api/", nil, nil, matching.PathMatchTypePrefix,
+		mkHandler("prefix"))
+	r.RegisterRoute("^/[a-z]+/query", nil, nil, matching.PathMatchTypeRegex,
+		mkHandler("regex"))
+
+	if body := serve(r, "/api/query"); body != "exact" {
+		t.Fatalf("expected exact to beat prefix and regex, got %q", body)
+	}
+	if body := serve(r, "/api/other"); body != "prefix" {
+		t.Fatalf("expected prefix to beat regex, got %q", body)
+	}
+	if body := serve(r, "/other/query"); body != "regex" {
+		t.Fatalf("expected regex after classic tiers miss, got %q", body)
+	}
+
+	// regex precedence is deterministic: longest pattern first, and equal
+	// length patterns evaluate in registration (config) order, giving the
+	// controller a stable lever over relative regex priority
+	r2 := NewRouter().(*lmRouter)
+	r2.RegisterRoute("^/tie/[ab]+", nil, nil, matching.PathMatchTypeRegex,
+		mkHandler("first"))
+	r2.RegisterRoute("^/tie/[ba]+", nil, nil, matching.PathMatchTypeRegex,
+		mkHandler("second"))
+	if body := serve(r2, "/tie/ab"); body != "first" {
+		t.Fatalf("expected registration order to break the tie, got %q", body)
+	}
+
+	r3 := NewRouter().(*lmRouter)
+	r3.RegisterRoute("^/tie/[ba]+", nil, nil, matching.PathMatchTypeRegex,
+		mkHandler("second"))
+	r3.RegisterRoute("^/tie/[ab]+", nil, nil, matching.PathMatchTypeRegex,
+		mkHandler("first"))
+	if body := serve(r3, "/tie/ab"); body != "second" {
+		t.Fatalf("expected reversed registration order to flip the winner, got %q",
+			body)
+	}
+}
+
 func Test_lmRouter(t *testing.T) {
 	l := lmRouter{
 		routes: map[string]*route.HostRouteSet{
@@ -250,6 +434,11 @@ func Test_lmRouter(t *testing.T) {
 					{Path: "/baz", PathLen: 3},
 					{Path: "/quxx", PathLen: 4},
 					{Path: "/ab", PathLen: 2},
+				},
+				RegexMatchRoutes: []*route.RegexRouteSet{
+					{Pattern: "^/[ab]", PatternLen: 5},
+					{Pattern: "^/long/.*", PatternLen: 9},
+					{Pattern: "^/[ba]", PatternLen: 5},
 				},
 			},
 		},
@@ -266,4 +455,12 @@ func Test_lmRouter(t *testing.T) {
 	require.Equal(t, 3, prefixes[1].PathLen)
 	require.Equal(t, "/ab", prefixes[2].Path)
 	require.Equal(t, 2, prefixes[2].PathLen)
+
+	// regex sets sort longest pattern first, with registration order
+	// preserved for equal-length patterns (stable)
+	regexes := route.RegexMatchRoutes
+	require.Equal(t, 3, len(regexes))
+	require.Equal(t, "^/long/.*", regexes[0].Pattern)
+	require.Equal(t, "^/[ab]", regexes[1].Pattern)
+	require.Equal(t, "^/[ba]", regexes[2].Pattern)
 }

--- a/pkg/proxy/router/route/route.go
+++ b/pkg/proxy/router/route/route.go
@@ -17,7 +17,10 @@
 // package route provides a Route data structure for Request Routing
 package route
 
-import "net/http"
+import (
+	"net/http"
+	"regexp"
+)
 
 type Route struct {
 	ExactMatch bool
@@ -45,10 +48,38 @@ type (
 	PrefixRouteSetLookup map[string]*PrefixRouteSet
 )
 
+// RegexRouteSet represents a regex path route, evaluated only after exact and
+// prefix matching both miss
+//
+// Capture-group design (not yet implemented): request rewriters (ingress-nginx
+// rewrite-target migration, Gateway API URLRewrite) will need submatch values
+// from the winning pattern. The router's hot path stays capture-free: the lm
+// router matches with MatchString only, which never allocates. When a path's
+// config declares it needs captures, registration wraps that route's handler
+// in a middleware that re-runs FindStringSubmatch (plus SubexpNames for named
+// groups) against the request path and stashes the results in the request
+// context for pkg/proxy/request/rewriter consumption. Because the wrapper is
+// attached per-route at registration time, no-capture routes and the router
+// itself require no changes, and extraction cost is paid only by routes that
+// opted in.
+type RegexRouteSet struct {
+	Pattern        string
+	PatternLen     int
+	Regexp         *regexp.Regexp
+	RoutesByMethod Lookup
+}
+
+type (
+	RegexRouteSets      []*RegexRouteSet
+	RegexRouteSetLookup map[string]*RegexRouteSet
+)
+
 type HostRouteSet struct {
 	ExactMatchRoutes     LookupLookup
 	PrefixMatchRoutes    PrefixRouteSets
 	PrefixMatchRoutesLkp PrefixRouteSetLookup
+	RegexMatchRoutes     RegexRouteSets
+	RegexMatchRoutesLkp  RegexRouteSetLookup
 }
 
 type HostRouteSetLookup map[string]*HostRouteSet

--- a/pkg/proxy/router/router.go
+++ b/pkg/proxy/router/router.go
@@ -19,17 +19,22 @@ package router
 
 import (
 	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/paths/matching"
 )
 
 type Router interface {
 	// ServeHTTP services the provided HTTP Request and write the Response
 	ServeHTTP(http.ResponseWriter, *http.Request)
 	// RegisterRoute registers a handler for the provided path/host/method(s)
+	// matchType indicates how the path is matched against incoming requests
+	// (exact, prefix or regex); regex paths are evaluated only after exact and
+	// prefix matching both miss
 	// If hosts is nil, the route uses global-routing instead of host-based
 	// If methods is nil, the route is applicable to GET and HEAD requests
 	// If methods includes GET but not HEAD, HEAD is automatically included
-	RegisterRoute(path string, hosts, methods []string, matchPrefix bool,
-		handler http.Handler) error
+	RegisterRoute(path string, hosts, methods []string,
+		matchType matching.PathMatchType, handler http.Handler) error
 	// Handler returns the handler matching the method/host/path in the Request
 	Handler(*http.Request) http.Handler
 	// SetMatchingScheme specifies the ways the Router matches requests
@@ -42,6 +47,8 @@ const (
 	MatchExactPath  MatchingScheme = 0
 	MatchHostname   MatchingScheme = 1
 	MatchPathPrefix MatchingScheme = 2
+	MatchPathRegex  MatchingScheme = 4
 
-	DefaultMatchingScheme MatchingScheme = MatchHostname | MatchPathPrefix
+	DefaultMatchingScheme MatchingScheme = MatchHostname | MatchPathPrefix |
+		MatchPathRegex
 )

--- a/pkg/routing/routing.go
+++ b/pkg/routing/routing.go
@@ -187,7 +187,8 @@ func registerProxyRoutes(conf *config.Config, clients backends.Backends,
 func RegisterHealthHandler(router router.Router, path string,
 	hc healthcheck.HealthChecker, backends backends.Backends,
 ) {
-	router.RegisterRoute(path, nil, nil, false, health.StatusHandler(nil, hc, backends))
+	router.RegisterRoute(path, nil, nil, matching.PathMatchTypeExact,
+		health.StatusHandler(nil, hc, backends))
 }
 
 func registerBackendRoutes(r router.Router, metricsRouter router.Router,
@@ -241,7 +242,7 @@ func registerBackendRoutes(r router.Router, metricsRouter router.Router,
 					"upstreamPath": o.HealthCheck.Path,
 					"upstreamVerb": o.HealthCheck.Verb,
 				})
-			metricsRouter.RegisterRoute(hp, nil, nil, false,
+			metricsRouter.RegisterRoute(hp, nil, nil, matching.PathMatchTypeExact,
 				middleware.WithResourcesContext(client, o, nil,
 					nil, nil, h))
 		}
@@ -298,6 +299,12 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 
 	or := client.Router().(router.Router)
 
+	if o.Paths.RegexShadowedByCatchAll() {
+		logger.Warn("regex paths are unreachable behind a catch-all prefix path;"+
+			" convert the catch-all to a regex (e.g., ^/.*) to make them reachable",
+			logging.Pairs{"backendName": o.Name})
+	}
+
 	for _, p := range o.Paths {
 		if p.Handler == nil && p.HandlerName != "" {
 			if h, ok := handlers[p.HandlerName]; ok && h != nil {
@@ -306,7 +313,17 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 		}
 
 		pathPrefix := "/" + o.Name
-		handledPath := pathPrefix + p.Path
+		var handledPath string
+		if p.MatchType == matching.PathMatchTypeRegex {
+			// splice the backend name between the pattern's leading ^ anchor
+			// (guaranteed by path Options Initialize) and the remainder, so
+			// ^/[^/]+/results becomes ^/backendName/[^/]+/results; this works
+			// for the escaped ^\/ form too, and StripPathPrefix is unaffected
+			// because the literal request path begins with /backendName
+			handledPath = "^/" + o.Name + strings.TrimPrefix(p.Path, "^")
+		} else {
+			handledPath = pathPrefix + p.Path
+		}
 
 		logger.Debug("registering backend handler path",
 			logging.Pairs{
@@ -322,15 +339,15 @@ func RegisterPathRoutes(r router.Router, conf *config.Config, handlers handlers.
 			}
 			if len(o.Hosts) > 0 {
 				r.RegisterRoute(p.Path, o.Hosts, p.Methods,
-					p.MatchType == matching.PathMatchTypePrefix, applyMiddleware(p))
+					p.MatchType, applyMiddleware(p))
 			}
 			if !o.PathRoutingDisabled {
 				r.RegisterRoute(handledPath, nil, p.Methods,
-					p.MatchType == matching.PathMatchTypePrefix,
+					p.MatchType,
 					middleware.StripPathPrefix(pathPrefix, applyMiddleware(p)))
 			}
 			or.RegisterRoute(p.Path, nil, p.Methods,
-				p.MatchType == matching.PathMatchTypePrefix, applyMiddleware(p))
+				p.MatchType, applyMiddleware(p))
 		}
 	}
 
@@ -412,12 +429,17 @@ func registerDefaultBackendRoutes(routerFor func(*bo.Options) router.Router, con
 							"matchType":   p.MatchType,
 						})
 
-					if p.MatchType == matching.PathMatchTypePrefix {
+					// a prefix path is also registered for exact matching so
+					// requests to the exact path route without a prefix scan
+					mt := p.MatchType
+					if mt == matching.PathMatchTypePrefix {
 						r.RegisterRoute(p.Path, nil, p.Methods,
-							true, applyMiddleware(o, p, tr, b.Cache(), b))
+							matching.PathMatchTypePrefix,
+							applyMiddleware(o, p, tr, b.Cache(), b))
+						mt = matching.PathMatchTypeExact
 					}
 					r.RegisterRoute(p.Path, nil, p.Methods,
-						false, applyMiddleware(o, p, tr, b.Cache(), b))
+						mt, applyMiddleware(o, p, tr, b.Cache(), b))
 				}
 			}
 		}

--- a/pkg/routing/routing_test.go
+++ b/pkg/routing/routing_test.go
@@ -17,8 +17,10 @@
 package routing
 
 import (
+	"bytes"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/trickstercache/trickster/v2/pkg/backends"
@@ -416,6 +418,118 @@ func TestRegisterPathRoutes(t *testing.T) {
 		}
 	}
 	RegisterPathRoutes(router, conf, handlers, rpc, oo, nil, nil)
+}
+
+func TestRegisterPathRoutesRegex(t *testing.T) {
+	logger.SetLogger(logging.ConsoleLogger(level.Info))
+	conf, err := config.Load([]string{
+		"-origin-url", "http://1", "-provider", providers.ReverseProxyCacheShort,
+	})
+	if err != nil {
+		t.Fatalf("Could not load configuration: %s", err.Error())
+	}
+
+	oo := conf.Backends["default"]
+	oo.Hosts = []string{"example.com"}
+	rpc, _ := reverseproxycache.NewClient("default", oo, lm.NewRouter(), nil, nil, nil)
+
+	testHandler := http.HandlerFunc(testutil.BasicHTTPHandler)
+	hl := handlers.Lookup{"testHandler": testHandler}
+
+	newRegexPaths := func() po.List {
+		p := po.New()
+		p.Path = "^/results/[0-9]+"
+		p.HandlerName = "testHandler"
+		p.Methods = []string{http.MethodGet}
+		if err := p.Initialize(""); err != nil {
+			t.Fatal(err)
+		}
+		return po.List{p}
+	}
+
+	serve := func(r router.Router, path, host string) int {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		if host != "" {
+			req.Host = host
+		}
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	oo.Paths = newRegexPaths()
+	rtr := lm.NewRouter()
+	RegisterPathRoutes(rtr, conf, hl, rpc, oo, nil, nil)
+
+	// path-routing mode: the handledPath rewrite splices the backend name
+	// into the pattern, so /default/results/42 matches ^/default/results/[0-9]+
+	if code := serve(rtr, "/default/results/42", ""); code != http.StatusOK {
+		t.Fatalf("expected 200 for path-routing regex, got %d", code)
+	}
+	if code := serve(rtr, "/default/results/notanumber", ""); code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-matching path, got %d", code)
+	}
+
+	// hosts registration passes the pattern through unmodified
+	if code := serve(rtr, "/results/42", "example.com"); code != http.StatusOK {
+		t.Fatalf("expected 200 for host-based regex, got %d", code)
+	}
+
+	// the backend-local router also receives the unmodified pattern
+	if code := serve(oo.Router.(router.Router), "/results/42", ""); code != http.StatusOK {
+		t.Fatalf("expected 200 for backend-local regex, got %d", code)
+	}
+
+	// path_routing_disabled skips the handledPath registration
+	oo.PathRoutingDisabled = true
+	oo.Paths = newRegexPaths()
+	rtr = lm.NewRouter()
+	RegisterPathRoutes(rtr, conf, hl, rpc, oo, nil, nil)
+	if code := serve(rtr, "/default/results/42", ""); code != http.StatusNotFound {
+		t.Fatalf("expected 404 with path routing disabled, got %d", code)
+	}
+	if code := serve(rtr, "/results/42", "example.com"); code != http.StatusOK {
+		t.Fatalf("expected 200 for host-based regex, got %d", code)
+	}
+}
+
+func TestRegisterPathRoutesRegexShadowWarning(t *testing.T) {
+	buf := &bytes.Buffer{}
+	prev := logger.Logger()
+	l := logging.StreamLogger(buf, level.Warn)
+	l.SetLogAsynchronous(false)
+	logger.SetLogger(l)
+	t.Cleanup(func() { logger.SetLogger(prev) })
+
+	conf, err := config.Load([]string{
+		"-origin-url", "http://1", "-provider", providers.ReverseProxyCacheShort,
+	})
+	if err != nil {
+		t.Fatalf("Could not load configuration: %s", err.Error())
+	}
+	oo := conf.Backends["default"]
+	rpc, _ := reverseproxycache.NewClient("default", oo, lm.NewRouter(), nil, nil, nil)
+	testHandler := http.HandlerFunc(testutil.BasicHTTPHandler)
+	hl := handlers.Lookup{"testHandler": testHandler}
+
+	regex := po.New()
+	regex.Path = "^/results/[0-9]+"
+	regex.HandlerName = "testHandler"
+	regex.Methods = []string{http.MethodGet}
+	catchAll := po.New()
+	catchAll.Path = "/"
+	catchAll.MatchTypeName = matching.PathMatchNamePrefix
+	catchAll.HandlerName = "testHandler"
+	catchAll.Methods = []string{http.MethodGet}
+	oo.Paths = po.List{regex, catchAll}
+	if err := oo.Paths.Initialize(); err != nil {
+		t.Fatal(err)
+	}
+
+	RegisterPathRoutes(lm.NewRouter(), conf, hl, rpc, oo, nil, nil)
+	if !strings.Contains(buf.String(), "unreachable") {
+		t.Fatalf("expected catch-all shadow warning in log, got %q", buf.String())
+	}
 }
 
 func TestValidateRuleClients(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- Describe changes and the problem solved -->
This extends the LM (Longest Match) Router to support regex matching. The Longest Match performance is still stellar and unaffected. Regex match paths are only checked on a request after all classic LM routes have been evaluated and exausted without a match; only then are regex matches checked, longest to shortest.  Regex Paths are indicated in the config by setting a path's `match_type` to `regex`, or starting the path with `^/` instead of `/`.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [ ] Bug fix
- - [x] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [x] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
