### PR TITLE
fix: flaky test TestFRPanicAllMembersDoesNotCrashRequest

### DIFF
--- a/pkg/backends/alb/mech/fr/first_response_panic_test.go
+++ b/pkg/backends/alb/mech/fr/first_response_panic_test.go
@@ -29,21 +29,24 @@ import (
 // kills the test goroutine running ServeHTTP.
 func TestFRPanicMemberDoesNotCrashRequest(t *testing.T) {
 	p, _, _ := albpool.NewHealthy([]http.Handler{
-		albpool.StatusHandler(http.StatusOK, "body-ok"),
 		albpool.PanicHandler(),
+		albpool.StatusHandler(http.StatusOK, "body-ok"),
 	})
 	defer p.Stop()
 	albpool.WaitHealthy(t, p, 2)
 
+	// Drain the panic before the winning response so its metric cannot leak into the next test.
+	limit := 1
 	h := &handler{}
+	h.options.ConcurrencyOptions.QueryConcurrencyLimit = &limit
 	h.SetPool(p)
 	w := httptest.NewRecorder()
-	albpool.ServeAndWait(t, h, w, albpool.NewParentGET(t))
+	albpool.RequireFanoutFailureDelta(t, "fr", "", "panic", 1, func() {
+		albpool.ServeAndWait(t, h, w, albpool.NewParentGET(t))
+	})
 
-	// either outcome is acceptable: 200 from the healthy member, or a 5xx if
-	// the mech surfaces the failure as a gateway error. the bar is no panic.
-	if w.Code != http.StatusOK && w.Code < 500 {
-		t.Errorf("expected 200 or 5xx got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected %d, got %d", http.StatusOK, w.Code)
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Describe changes and the problem solved -->
Fixes flaky `TestFRPanicAllMembersDoesNotCrashRequest` test, which was intermittently failing due to a race against the previous test's connections still draining before the next test started.

```
=== RUN   TestFRPanicAllMembersDoesNotCrashRequest
time=2026-08-26T21:40:16.296218Z app=trickster level=error event="alb fanout member panic" caller=pkg/backends/alb/mech/recover.go:39 mech=fr member=1 panic="simulated upstream nil deref" stack="goroutine 116 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.27.0/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/trickstercache/trickster/v2/pkg/backends/alb/mech.RecoverFanoutPanic({0x10508a7c0, 0x2}, {0x0, 0x0}, 0x1, 0x241521d46ec8)
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/pkg/backends/alb/mech/recover.go:44 +0x1b4
panic({0x105b74538?, 0x1059a93e0?})
        /opt/homebrew/Cellar/go/1.27.0/libexec/src/runtime/panic.go:859 +0x120
github.com/trickstercache/trickster/v2/pkg/testutil/albpool.PanicHandler.func1({0x241521c9adc0?,0x241521c9b180?}, 0x24152211e5d0?)
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/pkg/testutil/albpool/albpool.go:167 +0x2c
net/http.HandlerFunc.ServeHTTP(0x105c46190?, {0x105c447c0?, 0x24152219c660?}, 0x1?)
        /opt/homebrew/Cellar/go/1.27.0/libexec/src/net/http/server.go:2338 +0x38
github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/fanout.scatterInto.func2()
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/pkg/backends/alb/mech/fanout/fanout.go:407 +0x25c
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/vendor/golang.org/x/sync/errgroup/errgroup.go:93 +0x4c
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 114
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/vendor/golang.org/x/sync/errgroup/errgroup.go:78 +0x98
" variant=
time=2026-08-26T21:40:16.296218Z app=trickster level=error event="alb fanout member panic" caller=pkg/backends/alb/mech/recover.go:39 mech=fr member=0 panic="simulated upstream nil deref" stack="goroutine 136 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.27.0/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/trickstercache/trickster/v2/pkg/backends/alb/mech.RecoverFanoutPanic({0x10508a7c0, 0x2}, {0x0, 0x0}, 0x0, 0x2415223c3ec8)
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/pkg/backends/alb/mech/recover.go:44 +0x1b4
panic({0x105b74538?, 0x1059a93e0?})
        /opt/homebrew/Cellar/go/1.27.0/libexec/src/runtime/panic.go:859 +0x120
github.com/trickstercache/trickster/v2/pkg/testutil/albpool.PanicHandler.func1({0x241521da0140?,0x241521da0280?}, 0x241521d7c780?)
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/pkg/testutil/albpool/albpool.go:167 +0x2c
net/http.HandlerFunc.ServeHTTP(0x105c46190?, {0x105c447c0?, 0x241521d64180?}, 0x0?)
        /opt/homebrew/Cellar/go/1.27.0/libexec/src/net/http/server.go:2338 +0x38
github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/fanout.scatterInto.func2()
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/pkg/backends/alb/mech/fanout/fanout.go:407 +0x25c
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/vendor/golang.org/x/sync/errgroup/errgroup.go:93 +0x4c
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 135
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/vendor/golang.org/x/sync/errgroup/errgroup.go:78 +0x98
" variant=
time=2026-08-26T21:40:16.296224Z app=trickster level=error event="alb fanout member panic" caller=pkg/backends/alb/mech/recover.go:39 mech=fr member=1 panic="simulated upstream nil deref" stack="goroutine 137 [running]:
runtime/debug.Stack()
        /opt/homebrew/Cellar/go/1.27.0/libexec/src/runtime/debug/stack.go:26 +0x64
github.com/trickstercache/trickster/v2/pkg/backends/alb/mech.RecoverFanoutPanic({0x10508a7c0, 0x2}, {0x0, 0x0}, 0x1, 0x241521d41ec8)
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/pkg/backends/alb/mech/recover.go:44 +0x1b4
panic({0x105b74538?, 0x1059a93e0?})
        /opt/homebrew/Cellar/go/1.27.0/libexec/src/runtime/panic.go:859 +0x120
github.com/trickstercache/trickster/v2/pkg/testutil/albpool.PanicHandler.func1({0x241522112a00?,0x241522112b40?}, 0x2415221858c0?)
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/pkg/testutil/albpool/albpool.go:167 +0x2c
net/http.HandlerFunc.ServeHTTP(0x105c46190?, {0x105c447c0?, 0x2415223b6420?}, 0x1?)
        /opt/homebrew/Cellar/go/1.27.0/libexec/src/net/http/server.go:2338 +0x38
github.com/trickstercache/trickster/v2/pkg/backends/alb/mech/fanout.scatterInto.func2()
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/pkg/backends/alb/mech/fanout/fanout.go:407 +0x25c
golang.org/x/sync/errgroup.(*Group).Go.func1()
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/vendor/golang.org/x/sync/errgroup/errgroup.go:93 +0x4c
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 135
        /Users/jranson/src/go/github.com/trickstercache/features/trickster-tlsmonitor/vendor/golang.org/x/sync/errgroup/errgroup.go:78 +0x98
" variant=
    first_response_panic_test.go:60: counter delta = 3, want 2 (labels=[fr  panic])
--- FAIL: TestFRPanicAllMembersDoesNotCrashRequest (0.00s)
```

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [x] Bug fix
- - [ ] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
