### PR TITLE
feat: add tls monitor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,10 @@ style:
 check-imports:
 	@go run hack/check-imports/main.go
 
+.PHONY: gofix-apply
+gofix-apply:
+	@go fix ./...
+
 .PHONY: gofix-diff
 gofix-diff:
 	@go fix -diff ./...

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -116,6 +116,33 @@ The following metrics are available for polling with any Trickster configuration
   * labels:
     * `backend_name` - the name of the configured ALB backend
 
+* `trickster_tls_certificate_expiration_time_seconds` (Gauge) - NotAfter time of a serving TLS certificate, as unix seconds. See [tls.md](./tls.md).
+  * labels:
+    * `listener` - the name of the listener serving the certificate
+    * `entry` - the certificate's source identity
+
+* `trickster_tls_certificate_last_load_time_seconds` (Gauge) - Epoch timestamp a serving TLS certificate was last loaded from its source
+  * labels:
+    * `listener` - the name of the listener serving the certificate
+    * `entry` - the certificate's source identity
+
+* `trickster_tls_certificate_swaps_total` (Counter) - Count of TLS certificates hot-swapped into a live listener by rotation detection
+  * labels:
+    * `listener` - the name of the listener serving the certificate
+    * `entry` - the certificate's source identity
+
+* `trickster_tls_certificate_validation_failures_total` (Counter) - Count of detected TLS certificate source changes that failed pair validation (e.g. a mid-rotation partial write) and were not swapped in
+  * labels:
+    * `entry` - the certificate's source identity
+
+* `trickster_tls_watcher_errors_total` (Counter) - Count of errors reading watched TLS certificate source files
+  * labels:
+    * `entry` - the certificate's source identity
+
+* `trickster_tls_certificate_store_size` (Gauge) - Number of certificates in a listener's TLS certificate store
+  * labels:
+    * `listener` - the name of the listener
+
 ---
 
 The following metrics are available only for Caches Types whose object lifecycle Trickster manages internally (Memory, Filesystem and bbolt):

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -37,11 +37,61 @@ backends:
 
 ## Server Configs - used when responding to clients
 
-Each backend can handle encryption with exactly 1 certificate and key pair, as configured in the TLS section of the backend config (demonstrated above).
+Each backend contributes up to 1 certificate and key pair, as configured in the TLS section of the backend config (demonstrated above). A listener serves the certificates of all backends mapped to it, selecting per-handshake by SNI (see [Certificate Selection (SNI)](#certificate-selection-sni) below), so a single TLS listener can serve many hostnames.
 
 If the path to any configured Certificate or Key file is unreachable or unparsable, Trickster will exit upon startup with an error providing reasonable context.
 
 You may use the same TLS certificate and key for multiple backends, depending upon how your Trickster configurations are laid out. Any certificates configured by Trickster must match the hostname header of the inbound http request (exactly, or by wildcard interpolation), or clients will likely reject the certificate for security issues.
+
+## Certificate Selection (SNI)
+
+When a listener has multiple certificates, Trickster selects the certificate for each TLS handshake in this order:
+
+1. Exact match of the client's SNI hostname against a certificate's Subject Alternative Names
+2. Wildcard match (e.g. a `*.example.com` certificate for `foo.example.com`)
+3. A linear compatibility scan (covers clients that send no SNI, and IP SANs)
+4. The listener's first certificate, if nothing else matches
+
+The exact and wildcard lookups are index-based, so per-handshake selection cost is independent of the number of certificates a listener serves.
+
+## Automatic Certificate Rotation Detection
+
+Trickster automatically detects when a serving certificate is renewed in place on disk — same file paths, config untouched, as performed by tools like certbot or cert-manager — and hot-swaps the renewed certificate into the live listener. This is entirely independent of configuration reloads: no manual reload, `auto_reload_interval`, or config change is required.
+
+- Detection is hybrid: filesystem events (via fsnotify) trigger a near-immediate check where the platform and filesystem support them, and a timer-based poll runs regardless — both as the fallback for deployments where filesystem events don't work (e.g. some network and FUSE filesystems) and as a self-healing backstop for missed events. If event watching is unavailable, detection silently degrades to poll-only.
+- Every check compares file contents (not modification times or event payloads), so detection works across platforms and through the atomic symlink swaps used by Kubernetes Secret and projected volumes.
+- The certificate, key (and any associated CA bundle) files are watched and validated as one unit: if a poll observes a mid-rotation partial state (e.g. the cert file updated before the key file), the mismatched pair is never served; the last-good pair keeps serving and the change is retried on the next poll.
+- Read errors and invalid content never disable detection: the watcher keeps retrying, logs a warning after sustained failures, and the last-good certificate keeps serving. Deleting the files is treated as a persistent failure, not as certificate removal.
+- Startup behavior is unchanged: an unreadable or invalid configured certificate is still a fatal startup error. Only post-startup source failures are tolerated.
+
+Rotation detection is on by default and is configured per listener. `tls_watch_interval` sets the fallback/backstop poll cadence (default 30s); filesystem events, where available, apply rotations within moments regardless of the interval. Setting the interval to 0 disables rotation detection entirely (events included):
+
+```yaml
+listeners:
+  default:
+    tls_port: 8483
+    # backstop poll interval for the cert/key files of mapped backends
+    # (default 30s); filesystem events accelerate detection where supported.
+    # set to 0 to disable automatic rotation detection.
+    tls_watch_interval: 30s
+```
+
+Note: automatic rotation detection currently applies to HTTP(S) listeners. Native-protocol listeners (e.g. `mysql`) pick up rotated certificates on config reload.
+
+## Hot Swap and No-Close Semantics
+
+Certificate swaps — whether from a config reload or automatic rotation detection — never restart, drain, or rebind the listener:
+
+- The certificate is consulted only at handshake time, so established connections (including keep-alive connections and in-flight requests) are untouched by a swap; they continue on the certificate they were handshaken with until they close naturally.
+- Only new handshakes see the new certificate.
+
+## Certificate Inventory (mgmt)
+
+The mgmt listener exposes a read-only, per-listener certificate inventory at `/trickster/certificates` (configurable via `mgmt.certificates_handler_path`). Each entry reports the certificate's id, source kind (`file`, `memory` or `config`), common name, subject alternative names, validity window and last-load time. The inventory never includes key material.
+
+## Observability
+
+Certificate rotation and inventory are covered by the following metrics: `trickster_tls_certificate_expiration_time_seconds`, `trickster_tls_certificate_last_load_time_seconds`, `trickster_tls_certificate_swaps_total`, `trickster_tls_certificate_validation_failures_total`, `trickster_tls_watcher_errors_total`, and `trickster_tls_certificate_store_size`. See [metrics.md](./metrics.md) and the example alerting rules in [examples/alerting](../examples/alerting/tls-certificates-alerts.yaml) for cert-expiry, sustained-validation-failure and watcher-staleness alerts.
 
 ## Client Configs - used when proxying to an origin
 

--- a/examples/alerting/tls-certificates-alerts.yaml
+++ b/examples/alerting/tls-certificates-alerts.yaml
@@ -1,0 +1,61 @@
+# Example Prometheus alerting rules for Trickster TLS certificate rotation.
+# See docs/tls.md (Automatic Certificate Rotation Detection) and
+# docs/metrics.md for the metrics referenced here.
+groups:
+  - name: trickster-tls-certificates
+    rules:
+      # A serving certificate is approaching expiry. With rotation detection
+      # enabled (tls_watch_interval > 0), a renewal placed at the configured
+      # file paths is picked up automatically; this alert firing usually
+      # means the external renewal tooling has not produced a new cert.
+      - alert: TricksterTLSCertificateExpiringSoon
+        expr: |
+          (trickster_tls_certificate_expiration_time_seconds - time()) < (14 * 86400)
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Trickster serving certificate expires in under 14 days"
+          description: >-
+            Certificate {{ $labels.entry }} on listener {{ $labels.listener }}
+            expires at {{ $value | humanizeTimestamp }}.
+
+      - alert: TricksterTLSCertificateExpired
+        expr: |
+          (trickster_tls_certificate_expiration_time_seconds - time()) < 0
+        labels:
+          severity: critical
+        annotations:
+          summary: "Trickster is serving an expired certificate"
+          description: >-
+            Certificate {{ $labels.entry }} on listener {{ $labels.listener }}
+            has expired. Clients will reject handshakes.
+
+      # A rotated certificate keeps failing validation (e.g. a mismatched
+      # cert/key pair was written); Trickster keeps serving the last-good
+      # pair, but the renewal is not taking effect.
+      - alert: TricksterTLSCertificateValidationFailing
+        expr: |
+          increase(trickster_tls_certificate_validation_failures_total[15m]) > 3
+        labels:
+          severity: warning
+        annotations:
+          summary: "Trickster TLS certificate rotation is failing validation"
+          description: >-
+            The certificate source {{ $labels.entry }} has repeatedly failed
+            pair validation over the last 15 minutes; the previous certificate
+            is still being served.
+
+      # The watcher cannot read the certificate source files (deleted paths,
+      # permissions, unmounted volume). The last-good certificate keeps
+      # serving, but rotation detection is effectively stalled.
+      - alert: TricksterTLSWatcherStale
+        expr: |
+          increase(trickster_tls_watcher_errors_total[15m]) > 3
+        labels:
+          severity: warning
+        annotations:
+          summary: "Trickster TLS certificate watcher cannot read its sources"
+          description: >-
+            The watcher for {{ $labels.entry }} has repeatedly failed to read
+            its certificate source files over the last 15 minutes.

--- a/examples/conf/example.full.yaml
+++ b/examples/conf/example.full.yaml
@@ -47,6 +47,10 @@
 #     tls_port: 8483
 #     # tls_address is empty by default, meaning listen on all interfaces.
 #     tls_address: ''
+#     # tls_watch_interval is the backstop poll for out-of-band cert/key
+#     # rotation (e.g. certbot). FS events accelerate detection where supported.
+#     # Changes are hot-swapped without restart. default 30s; 0 disables
+#     tls_watch_interval: 30s
 #     # connections_limit defines the maximum number of concurrent connections
 #     # the listener may handle at any time. 0 means unlimited
 #     connections_limit: 0
@@ -864,6 +868,11 @@ backends:
 #   # config_handler_listener provides the HTTP listener that hosts the config endpoints
 #   # Options are: "metrics", "mgmt", "both", or "off"; default is mgmt
 #   config_handler_listener: mgmt
+
+#   # certificates_handler_path provides the HTTP path to view a read-only JSON inventory
+#   # of the TLS certificates served by each listener (metadata only; never key material)
+#   # default is /trickster/certificates
+#   certificates_handler_path: /trickster/certificates
 
 #   # ping_handler_path provides the HTTP path you will use to perform an uptime health check against Trickster
 #   # which can be reached at http://your-trickster-endpoint:port/$ping_handler_path

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/dgraph-io/badger/v4 v4.9.6
 	github.com/dgraph-io/ristretto/v2 v2.4.2
+	github.com/fsnotify/fsnotify v1.9.0
 	github.com/influxdata/influxdb v1.12.4
 	github.com/influxdata/influxql v1.4.1
 	github.com/klauspost/compress v1.19.2
@@ -108,7 +109,6 @@ require (
 	github.com/fatih/color v1.19.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/firefart/nonamedreturns v1.0.8 // indirect
-	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/ghostiam/protogetter v0.3.21 // indirect
 	github.com/go-critic/go-critic v0.14.4 // indirect

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/dgraph-io/badger/v4 v4.9.6 // indirect
 	github.com/dgraph-io/ristretto/v2 v2.4.2 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -96,6 +96,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/felixge/httpsnoop v1.1.0 h1:3YtUj32ZZkqZtt3sZZsClsymw/QDuVfpNhoA31zeORc=
 github.com/felixge/httpsnoop v1.1.0/go.mod h1:Zqxgdd+1Rkcz8euOqdr7lqgCRJztwr5hp9vDSi5UZCE=
+github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
+github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/go-faster/city v1.0.1 h1:4WAxSZ3V2Ws4QRDrscLEDcibJY8uf41H6AhXDrNDcGw=
 github.com/go-faster/city v1.0.1/go.mod h1:jKcUJId49qdW3L1qKHH/3wPeUstCVpVSXTM6vO3VcTw=
 github.com/go-faster/errors v0.7.1 h1:MkJTnDoEdi9pDabt1dpWf7AA8/BaSYZqibYyhZ20AYg=

--- a/pkg/backends/alb/client_test.go
+++ b/pkg/backends/alb/client_test.go
@@ -652,8 +652,7 @@ func TestValidateAndStartUserRouterErrors(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = cl.validateAndStartUserRouter(backends.Backends{"tenant-a": member}, nil)
-	var credErr *errors.InvalidALBOptionsError
-	if !goerrors.As(err, &credErr) {
+	if _, ok := goerrors.AsType[*errors.InvalidALBOptionsError](err); !ok {
 		t.Fatalf("validateAndStartUserRouter() = %v, want InvalidALBOptionsError", err)
 	}
 	want := errors.NewErrInvalidUserRouterCreds("ur-edge")

--- a/pkg/backends/alb/errors/errors_test.go
+++ b/pkg/backends/alb/errors/errors_test.go
@@ -25,8 +25,7 @@ import (
 func TestNewErrInvalidALBOptions(t *testing.T) {
 	t.Parallel()
 	err := NewErrInvalidALBOptions("backend1")
-	var e *InvalidALBOptionsError
-	if !errors.As(err, &e) {
+	if _, ok := errors.AsType[*InvalidALBOptionsError](err); !ok {
 		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
 	}
 	if !strings.Contains(err.Error(), "backend1") {
@@ -37,8 +36,7 @@ func TestNewErrInvalidALBOptions(t *testing.T) {
 func TestNewErrInvalidPoolMemberName(t *testing.T) {
 	t.Parallel()
 	err := NewErrInvalidPoolMemberName("alb1", "missing")
-	var e *InvalidALBOptionsError
-	if !errors.As(err, &e) {
+	if _, ok := errors.AsType[*InvalidALBOptionsError](err); !ok {
 		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
 	}
 	msg := err.Error()
@@ -50,8 +48,7 @@ func TestNewErrInvalidPoolMemberName(t *testing.T) {
 func TestNewErrInvalidBackendName(t *testing.T) {
 	t.Parallel()
 	err := NewErrInvalidBackendName("alb1", "bad")
-	var e *InvalidALBOptionsError
-	if !errors.As(err, &e) {
+	if _, ok := errors.AsType[*InvalidALBOptionsError](err); !ok {
 		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
 	}
 	msg := err.Error()
@@ -63,8 +60,7 @@ func TestNewErrInvalidBackendName(t *testing.T) {
 func TestNewErrInvalidUserRouterCreds(t *testing.T) {
 	t.Parallel()
 	err := NewErrInvalidUserRouterCreds("alb1")
-	var e *InvalidALBOptionsError
-	if !errors.As(err, &e) {
+	if _, ok := errors.AsType[*InvalidALBOptionsError](err); !ok {
 		t.Fatalf("expected *InvalidALBOptionsError, got %T", err)
 	}
 	if !strings.Contains(err.Error(), "alb1") {

--- a/pkg/backends/alb/mech/ur/options/options_test.go
+++ b/pkg/backends/alb/mech/ur/options/options_test.go
@@ -80,8 +80,7 @@ func TestValidate(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid default backend error")
 	}
-	var ie *InvalidUserRouterOptionsError
-	if !errors.As(err, &ie) {
+	if _, ok := errors.AsType[*InvalidUserRouterOptionsError](err); !ok {
 		t.Fatalf("Validate() = %T, want InvalidUserRouterOptionsError", err)
 	}
 
@@ -131,8 +130,7 @@ func TestNewErrInvalidUserRouterOptions(t *testing.T) {
 	t.Parallel()
 
 	err := NewErrInvalidUserRouterOptions("edge")
-	var ie *InvalidUserRouterOptionsError
-	if !errors.As(err, &ie) {
+	if _, ok := errors.AsType[*InvalidUserRouterOptionsError](err); !ok {
 		t.Fatalf("error type = %T, want InvalidUserRouterOptionsError", err)
 	}
 }

--- a/pkg/backends/tree/tree_test.go
+++ b/pkg/backends/tree/tree_test.go
@@ -24,11 +24,11 @@ import (
 
 func TestEntriesValidate(t *testing.T) {
 	tests := []struct {
-		name           string
-		entries        Entries
-		wantErr        bool
-		errContains    string
-		wantTarget     map[string]string // entry name -> expected TargetProvider
+		name        string
+		entries     Entries
+		wantErr     bool
+		errContains string
+		wantTarget  map[string]string // entry name -> expected TargetProvider
 	}{
 		{
 			name: "valid no cycles",
@@ -39,7 +39,7 @@ func TestEntriesValidate(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "empty entries",
+			name:    "empty entries",
 			entries: Entries{},
 			wantErr: false,
 		},
@@ -205,8 +205,7 @@ func TestEntriesValidate(t *testing.T) {
 				if !strings.Contains(err.Error(), tt.errContains) {
 					t.Errorf("Validate() error = %v, want containing %q", err, tt.errContains)
 				}
-				var ibre *InvalidBackendRoutingError
-				if !errors.As(err, &ibre) {
+				if _, ok := errors.AsType[*InvalidBackendRoutingError](err); !ok {
 					t.Errorf("Validate() error type = %T, want *InvalidBackendRoutingError", err)
 				}
 			}
@@ -234,8 +233,7 @@ func findEntry(entries Entries, name string) *Entry {
 
 func TestNewErrInvalidBackendRouting(t *testing.T) {
 	err := NewErrInvalidBackendRouting("entry '%s' bad", "x")
-	var ibre *InvalidBackendRoutingError
-	if !errors.As(err, &ibre) {
+	if _, ok := errors.AsType[*InvalidBackendRoutingError](err); !ok {
 		t.Fatalf("expected *InvalidBackendRoutingError, got %T", err)
 	}
 	if got := err.Error(); got != "entry 'x' bad" {

--- a/pkg/config/listener/listener.go
+++ b/pkg/config/listener/listener.go
@@ -19,6 +19,7 @@ package listener
 
 import (
 	"fmt"
+	"time"
 
 	mo "github.com/trickstercache/trickster/v2/pkg/backends/mysql/options"
 	"github.com/trickstercache/trickster/v2/pkg/config/mgmt"
@@ -36,6 +37,9 @@ const (
 	ProtocolHTTP = "http"
 	// ProtocolMySQL is the MySQL wire-protocol listener protocol.
 	ProtocolMySQL = "mysql"
+	// DefaultTLSWatchInterval is the default poll interval for detecting
+	// out-of-band TLS certificate rotation.
+	DefaultTLSWatchInterval = timeconv.Duration(30 * time.Second)
 )
 
 // Options describes one inbound listener.
@@ -58,6 +62,9 @@ type Options struct {
 	ReadHeaderTimeout timeconv.Duration `yaml:"read_header_timeout,omitempty"`
 	// Protocol selects the protocol served by this listener.
 	Protocol string `yaml:"protocol,omitempty"`
+	// TLSWatchInterval is the backstop poll for out-of-band cert/key rotation
+	// (e.g. certbot). Changes are hot-swapped without restart. 0 disables.
+	TLSWatchInterval timeconv.Duration `yaml:"tls_watch_interval,omitempty"`
 	// MySQL contains downstream limits when protocol is mysql.
 	MySQL *mo.ListenerOptions `yaml:"mysql,omitempty"`
 	// ServeTLS indicates that this listener has at least one usable certificate.
@@ -73,6 +80,7 @@ type Lookup map[string]*Options
 func New(name string) *Options {
 	o := FromFrontend(frontend.New())
 	o.Protocol = ProtocolHTTP
+	o.TLSWatchInterval = DefaultTLSWatchInterval
 	switch name {
 	case DefaultFrontendName:
 		o.Active = true
@@ -177,7 +185,8 @@ func (o *Options) Equal(other *Options) bool {
 		o.TLSListenAddress != other.TLSListenAddress || o.TLSListenPort != other.TLSListenPort ||
 		o.ConnectionsLimit != other.ConnectionsLimit ||
 		o.TruncateRequestBodyTooLarge != other.TruncateRequestBodyTooLarge ||
-		o.ReadHeaderTimeout != other.ReadHeaderTimeout || o.ServeTLS != other.ServeTLS {
+		o.ReadHeaderTimeout != other.ReadHeaderTimeout || o.ServeTLS != other.ServeTLS ||
+		o.TLSWatchInterval != other.TLSWatchInterval {
 		return false
 	}
 	if (o.MySQL == nil) != (other.MySQL == nil) || o.MySQL != nil && *o.MySQL != *other.MySQL {

--- a/pkg/config/mgmt/defaults.go
+++ b/pkg/config/mgmt/defaults.go
@@ -44,4 +44,7 @@ const (
 	DefaultRateLimit = 3 * time.Second
 	// DefaultReloadHandlerPath defines the default path for the Reload Handler
 	DefaultReloadHandlerPath = "/trickster/config/reload"
+	// DefaultCertificatesHandlerPath defines the default path for the TLS
+	// certificate inventory handler
+	DefaultCertificatesHandlerPath = "/trickster/certificates"
 )

--- a/pkg/config/mgmt/mgmt.go
+++ b/pkg/config/mgmt/mgmt.go
@@ -45,6 +45,9 @@ type Options struct {
 	PurgeByKeyHandlerPath string `yaml:"purge_by_key_path,omitempty"`
 	// PurgeByKeyHandlerPath provides the base Cache Purge-by-Path Handler path
 	PurgeByPathHandlerPath string `yaml:"purge_by_path_path,omitempty"`
+	// CertificatesHandlerPath provides the path to register the read-only TLS
+	// certificate inventory handler
+	CertificatesHandlerPath string `yaml:"certificates_handler_path,omitempty"`
 	// PprofListener provides the name of the http listener that will host the pprof debugging routes
 	// Options are: "metrics", "mgmt", "both", or "off"; default is both
 	PprofListener string `yaml:"pprof_listener,omitempty"`
@@ -76,18 +79,19 @@ var ErrInvalidAutoReloadInterval = errors.New("auto reload interval cannot be ne
 // New returns a new Options references with Default Values set
 func New() *Options {
 	return &Options{
-		ListenPort:             DefaultPort,
-		ListenAddress:          DefaultAddress,
-		ConfigHandlerPath:      DefaultConfigHandlerPath,
-		ConfigHandlerListener:  DefaultConfigHandlerListenerName,
-		PingHandlerPath:        DefaultPingHandlerPath,
-		HealthHandlerPath:      DefaultHealthHandlerPath,
-		PurgeByKeyHandlerPath:  DefaultPurgeByKeyHandlerPath,
-		PurgeByPathHandlerPath: DefaultPurgeByPathHandlerPath,
-		PprofListener:          DefaultPprofListenerName,
-		ReloadHandlerPath:      DefaultReloadHandlerPath,
-		ReloadDrainTimeout:     timeconv.Duration(DefaultDrainTimeout),
-		ReloadRateLimit:        timeconv.Duration(DefaultRateLimit),
+		ListenPort:              DefaultPort,
+		ListenAddress:           DefaultAddress,
+		ConfigHandlerPath:       DefaultConfigHandlerPath,
+		ConfigHandlerListener:   DefaultConfigHandlerListenerName,
+		PingHandlerPath:         DefaultPingHandlerPath,
+		HealthHandlerPath:       DefaultHealthHandlerPath,
+		PurgeByKeyHandlerPath:   DefaultPurgeByKeyHandlerPath,
+		PurgeByPathHandlerPath:  DefaultPurgeByPathHandlerPath,
+		CertificatesHandlerPath: DefaultCertificatesHandlerPath,
+		PprofListener:           DefaultPprofListenerName,
+		ReloadHandlerPath:       DefaultReloadHandlerPath,
+		ReloadDrainTimeout:      timeconv.Duration(DefaultDrainTimeout),
+		ReloadRateLimit:         timeconv.Duration(DefaultRateLimit),
 	}
 }
 

--- a/pkg/config/testdata/example.alb.yaml
+++ b/pkg/config/testdata/example.alb.yaml
@@ -320,12 +320,14 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   metrics:
     port: 8481
     max_request_body_size_bytes: 10485760
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   mgmt:
     address: 127.0.0.1
     port: 8484
@@ -333,6 +335,7 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
 logging:
   log_level: INFO
 metrics:
@@ -353,6 +356,7 @@ mgmt:
   health_handler_path: /trickster/health
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
+  certificates_handler_path: /trickster/certificates
   pprof_listener: both
   reload_handler_path: /trickster/config/reload
   reload_drain_timeout: 30s

--- a/pkg/config/testdata/example.auth.yaml
+++ b/pkg/config/testdata/example.auth.yaml
@@ -196,12 +196,14 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   metrics:
     port: 8481
     max_request_body_size_bytes: 10485760
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   mgmt:
     address: 127.0.0.1
     port: 8484
@@ -209,6 +211,7 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
 logging:
   log_level: INFO
 metrics:
@@ -229,6 +232,7 @@ mgmt:
   health_handler_path: /trickster/health
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
+  certificates_handler_path: /trickster/certificates
   pprof_listener: both
   reload_handler_path: /trickster/config/reload
   reload_drain_timeout: 30s

--- a/pkg/config/testdata/example.full.yaml
+++ b/pkg/config/testdata/example.full.yaml
@@ -83,12 +83,14 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   metrics:
     port: 8481
     max_request_body_size_bytes: 10485760
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   mgmt:
     address: 127.0.0.1
     port: 8484
@@ -96,6 +98,7 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
 logging:
   log_level: INFO
 metrics:
@@ -116,6 +119,7 @@ mgmt:
   health_handler_path: /trickster/health
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
+  certificates_handler_path: /trickster/certificates
   pprof_listener: both
   reload_handler_path: /trickster/config/reload
   reload_drain_timeout: 30s

--- a/pkg/config/testdata/exmple.sharding.yaml
+++ b/pkg/config/testdata/exmple.sharding.yaml
@@ -84,12 +84,14 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   metrics:
     port: 8481
     max_request_body_size_bytes: 10485760
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   mgmt:
     address: 127.0.0.1
     port: 8484
@@ -97,6 +99,7 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
 logging:
   log_level: info
 metrics:
@@ -117,6 +120,7 @@ mgmt:
   health_handler_path: /trickster/health
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
+  certificates_handler_path: /trickster/certificates
   pprof_listener: both
   reload_handler_path: /trickster/config/reload
   reload_drain_timeout: 30s

--- a/pkg/config/testdata/mysql-user-router.yaml
+++ b/pkg/config/testdata/mysql-user-router.yaml
@@ -274,12 +274,14 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   metrics:
     port: 8481
     max_request_body_size_bytes: 10485760
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   mgmt:
     address: 127.0.0.1
     port: 8484
@@ -287,6 +289,7 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   mysql-routed:
     port: 8486
     connections_limit: 200
@@ -294,6 +297,7 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: mysql
+    tls_watch_interval: 30s
     mysql:
       handshake_timeout: 10s
       read_timeout: 30s
@@ -321,6 +325,7 @@ mgmt:
   health_handler_path: /trickster/health
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
+  certificates_handler_path: /trickster/certificates
   pprof_listener: both
   reload_handler_path: /trickster/config/reload
   reload_drain_timeout: 30s

--- a/pkg/config/testdata/simple.prometheus.yaml
+++ b/pkg/config/testdata/simple.prometheus.yaml
@@ -82,12 +82,14 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   metrics:
     port: 8481
     max_request_body_size_bytes: 10485760
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   mgmt:
     address: 127.0.0.1
     port: 8484
@@ -95,12 +97,14 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   prom_port:
     port: 9090
     max_request_body_size_bytes: 10485760
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
 logging:
   log_level: info
 metrics:
@@ -121,6 +125,7 @@ mgmt:
   health_handler_path: /trickster/health
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
+  certificates_handler_path: /trickster/certificates
   pprof_listener: both
   reload_handler_path: /trickster/config/reload
   reload_drain_timeout: 30s

--- a/pkg/config/testdata/simple.reverseproxycache.yaml
+++ b/pkg/config/testdata/simple.reverseproxycache.yaml
@@ -82,18 +82,21 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   default_listener:
     port: 8480
     max_request_body_size_bytes: 10485760
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   metrics:
     port: 8481
     max_request_body_size_bytes: 10485760
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
   mgmt:
     address: 127.0.0.1
     port: 8484
@@ -101,6 +104,7 @@ listeners:
     truncate_request_body_too_large: false
     read_header_timeout: 10s
     protocol: http
+    tls_watch_interval: 30s
 logging:
   log_level: info
 metrics:
@@ -121,6 +125,7 @@ mgmt:
   health_handler_path: /trickster/health
   purge_by_key_path: /trickster/purge/key/
   purge_by_path_path: /trickster/purge/path/
+  certificates_handler_path: /trickster/certificates
   pprof_listener: both
   reload_handler_path: /trickster/config/reload
   reload_drain_timeout: 30s

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -38,6 +38,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/tls/monitor"
 	"github.com/trickstercache/trickster/v2/pkg/util/safego"
 )
 
@@ -95,7 +96,8 @@ func Start(ctx context.Context, args ...string) error {
 	}
 
 	si := &instance.ServerInstance{
-		Listeners: listener.NewGroup(),
+		Listeners:   listener.NewGroup(),
+		CertMonitor: monitor.New(),
 	}
 	hupFunc := newHupFunc(si, args)
 	autoReloader := bindAutoReloader(ctx, si, hupFunc)
@@ -119,11 +121,13 @@ func Start(ctx context.Context, args ...string) error {
 		}
 	}
 	autoReloader.Update(conf)
+	si.CertMonitor.Apply(conf, si.Listeners)
 
 	skipUnlock = true
 	mtx.Unlock()
 	signaling.Wait(ctx, hupFunc)
 	autoReloader.Close()
+	si.CertMonitor.Close()
 	if si.Listeners != nil {
 		si.Listeners.Shutdown(0)
 	}
@@ -203,6 +207,12 @@ func Hup(si *instance.ServerInstance, source string, args ...string) (bool, erro
 			logger.Warn("reload completed but some listeners not ready",
 				logging.Pairs{"error": err.Error(), "source": source})
 		}
+	}
+
+	if si.CertMonitor != nil {
+		// rebuild the cert stores from the new config while preserving watcher
+		// continuity for unchanged certificate file sets
+		si.CertMonitor.Apply(newConf, si.Listeners)
 	}
 
 	if oldClients != nil {

--- a/pkg/daemon/instance/instance.go
+++ b/pkg/daemon/instance/instance.go
@@ -22,6 +22,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/cache"
 	"github.com/trickstercache/trickster/v2/pkg/config"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/tls/monitor"
 )
 
 type ServerInstance struct {
@@ -31,4 +32,5 @@ type ServerInstance struct {
 	Backends         backends.Backends
 	Listeners        *listener.Group
 	OnConfigReloaded func(*config.Config)
+	CertMonitor      *monitor.Monitor
 }

--- a/pkg/daemon/setup/listeners.go
+++ b/pkg/daemon/setup/listeners.go
@@ -18,7 +18,6 @@ package setup
 
 import (
 	"crypto/tls"
-	"fmt"
 	"net/http"
 	"slices"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	"github.com/trickstercache/trickster/v2/pkg/observability/pprof"
 	"github.com/trickstercache/trickster/v2/pkg/observability/tracing"
+	certs "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/certificates"
 	ch "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/config"
 	ph "github.com/trickstercache/trickster/v2/pkg/proxy/handlers/trickster/purge"
 	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
@@ -71,7 +71,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 
 	metricsRouter.RegisterRoute("/metrics", nil, nil, false, metrics.Handler())
 	if listenerEnabledOn(conf.MgmtConfig.ConfigHandlerListener, mgmt.ListenerNameMetrics) {
-		registerConfigRoutes(conf, metricsRouter)
+		registerConfigRoutes(conf, metricsRouter, lg)
 	}
 	if listenerEnabledOn(conf.MgmtConfig.PprofListener, mgmt.ListenerNameMetrics) {
 		pprof.RegisterRoutes(mgmt.ListenerNameMetrics, metricsRouter)
@@ -79,7 +79,7 @@ func applyListenerConfigs(conf, oldConf *config.Config,
 
 	managementRouter := lm.NewRouter()
 	if listenerEnabledOn(conf.MgmtConfig.ConfigHandlerListener, mgmt.ListenerNameMgmt) {
-		registerConfigRoutes(conf, managementRouter)
+		registerConfigRoutes(conf, managementRouter, lg)
 	}
 	managementRouter.RegisterRoute(conf.MgmtConfig.ReloadHandlerPath, nil, nil,
 		false, reloadHandler)
@@ -242,14 +242,7 @@ func nativeBuildRequest(conf *config.Config, desired desiredListener, tracers tr
 }
 
 func listenerKey(listenerName, protocol string, tls bool) string {
-	scheme := protocol
-	if scheme == "" {
-		scheme = listenerconfig.ProtocolHTTP
-	}
-	if tls {
-		scheme = "https"
-	}
-	return fmt.Sprintf("listener.%s.%s", listenerName, scheme)
+	return listener.GroupKey(listenerName, protocol, tls)
 }
 
 func listenerNeedsRestart(old, current desiredListener) bool {
@@ -271,11 +264,15 @@ func runtimeListenerNeedsRestart(lg *listener.Group, key string, old, current de
 	return false
 }
 
-func registerConfigRoutes(conf *config.Config, r router.Router) {
+func registerConfigRoutes(conf *config.Config, r router.Router, lg *listener.Group) {
 	r.RegisterRoute(conf.MgmtConfig.ConfigHandlerPath, nil, nil,
 		false, http.HandlerFunc(ch.HandlerFunc(conf)))
 	r.RegisterRoute(ch.SanitizedHandlerPath(conf.MgmtConfig.ConfigHandlerPath), nil, nil,
 		false, http.HandlerFunc(ch.SanitizedHandlerFunc(conf)))
+	if conf.MgmtConfig.CertificatesHandlerPath != "" {
+		r.RegisterRoute(conf.MgmtConfig.CertificatesHandlerPath, nil, nil,
+			false, http.HandlerFunc(certs.HandlerFunc(lg)))
+	}
 }
 
 func updateListenerCertificates(conf *config.Config, desired desiredListener, lg *listener.Group) {

--- a/pkg/observability/metrics/metrics.go
+++ b/pkg/observability/metrics/metrics.go
@@ -37,6 +37,7 @@ const (
 	healthSubsystem   = "healthcheck"
 	sqlSubsystem      = "sql"
 	mysqlSubsystem    = "mysql"
+	tlsSubsystem      = "tls"
 )
 
 // Default histogram buckets used by trickster
@@ -610,6 +611,79 @@ var (
 		[]string{"backend_name"},
 	)
 
+	// TLSCertificateNotAfter is a Gauge of each serving certificate's
+	// NotAfter (expiration) time as unix seconds, by listener and entry.
+	TLSCertificateNotAfter = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: tlsSubsystem,
+			Name:      "certificate_expiration_time_seconds",
+			Help:      "NotAfter time of a serving TLS certificate, as unix seconds.",
+		},
+		[]string{"listener", "entry"},
+	)
+
+	// TLSCertificateLastLoad is a Gauge of the time each serving certificate
+	// was last successfully loaded from its source, as unix seconds.
+	TLSCertificateLastLoad = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: tlsSubsystem,
+			Name:      "certificate_last_load_time_seconds",
+			Help:      "Time a serving TLS certificate was last loaded from its source, as unix seconds.",
+		},
+		[]string{"listener", "entry"},
+	)
+
+	// TLSCertificateSwapsTotal counts hot swaps of a rotated certificate into
+	// a live listener.
+	TLSCertificateSwapsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: tlsSubsystem,
+			Name:      "certificate_swaps_total",
+			Help:      "Count of TLS certificates hot-swapped into a live listener.",
+		},
+		[]string{"listener", "entry"},
+	)
+
+	// TLSCertificateValidationFailures counts detected certificate source
+	// changes that failed pair validation (e.g. a mid-rotation partial write)
+	// and were not swapped in; the last-good certificate keeps serving.
+	TLSCertificateValidationFailures = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: tlsSubsystem,
+			Name:      "certificate_validation_failures_total",
+			Help:      "Count of TLS certificate source changes that failed validation.",
+		},
+		[]string{"entry"},
+	)
+
+	// TLSWatcherErrors counts errors reading watched TLS certificate source
+	// files; the last-good certificate keeps serving.
+	TLSWatcherErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metricNamespace,
+			Subsystem: tlsSubsystem,
+			Name:      "watcher_errors_total",
+			Help:      "Count of errors reading watched TLS certificate source files.",
+		},
+		[]string{"entry"},
+	)
+
+	// TLSCertificateStoreSize is a Gauge of the number of certificates in
+	// each listener's certificate store.
+	TLSCertificateStoreSize = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metricNamespace,
+			Subsystem: tlsSubsystem,
+			Name:      "certificate_store_size",
+			Help:      "Number of certificates in a listener's TLS certificate store.",
+		},
+		[]string{"listener"},
+	)
+
 	// ALBPoolFloorReset flags ALB pools whose healthy_floor was reset to 0 at
 	// startup because one or more pool members have no health check and could
 	// never reach the configured floor (>= Passing), which would otherwise
@@ -675,6 +749,12 @@ func init() {
 	prometheus.MustRegister(MySQLConnectionErrors)
 	prometheus.MustRegister(MySQLRouteSelections)
 	prometheus.MustRegister(MySQLCommandLatency)
+	prometheus.MustRegister(TLSCertificateNotAfter)
+	prometheus.MustRegister(TLSCertificateLastLoad)
+	prometheus.MustRegister(TLSCertificateSwapsTotal)
+	prometheus.MustRegister(TLSCertificateValidationFailures)
+	prometheus.MustRegister(TLSWatcherErrors)
+	prometheus.MustRegister(TLSCertificateStoreSize)
 }
 
 // Handler returns the http handler for the listener

--- a/pkg/proxy/engines/tracing_test.go
+++ b/pkg/proxy/engines/tracing_test.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 	"time"
 
@@ -289,9 +290,9 @@ func resourceAttributeStrings(rsc *request.Resources) map[string]string {
 func latestEndedSpan(t testing.TB, sr *tracetest.SpanRecorder, name string) sdktrace.ReadOnlySpan {
 	t.Helper()
 	spans := sr.Ended()
-	for i := len(spans) - 1; i >= 0; i-- {
-		if spans[i].Name() == name {
-			return spans[i]
+	for _, span := range slices.Backward(spans) {
+		if span.Name() == name {
+			return span
 		}
 	}
 	t.Fatalf("span %q not found in %d ended spans", name, len(spans))

--- a/pkg/proxy/handlers/trickster/certificates/certificates.go
+++ b/pkg/proxy/handlers/trickster/certificates/certificates.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package certificates provides a read-only mgmt handler that reports the
+// TLS certificate inventory of each running listener. The output includes
+// only certificate metadata (ids, subjects, expiry, source kind, last load
+// time) and never any key material.
+package certificates
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/headers"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+	tr "github.com/trickstercache/trickster/v2/pkg/proxy/tls"
+)
+
+type inventory struct {
+	Listeners map[string][]tr.EntryInfo `json:"listeners"`
+}
+
+// HandlerFunc responds to the HTTP request with the per-listener TLS
+// certificate inventory
+func HandlerFunc(lg *listener.Group) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		out := inventory{Listeners: make(map[string][]tr.EntryInfo)}
+		if lg != nil {
+			for _, key := range lg.Keys() {
+				l := lg.Get(key)
+				if l == nil || l.CertSwapper() == nil {
+					continue
+				}
+				store, ok := l.CertSwapper().(tr.CertStore)
+				if !ok {
+					continue
+				}
+				out.Listeners[key] = store.Entries()
+			}
+		}
+		w.Header().Set(headers.NameContentType, headers.ValueApplicationJSON)
+		w.Header().Set(headers.NameCacheControl, headers.ValueNoCache)
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(out)
+	}
+}

--- a/pkg/proxy/handlers/trickster/certificates/certificates_test.go
+++ b/pkg/proxy/handlers/trickster/certificates/certificates_test.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package certificates
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+	tr "github.com/trickstercache/trickster/v2/pkg/proxy/tls"
+	tlstest "github.com/trickstercache/trickster/v2/pkg/testutil/tls"
+)
+
+func TestHandlerFunc(t *testing.T) {
+	k, c, err := tlstest.GetTestKeyAndCertWithNames("inventory.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := tls.X509KeyPair(c, k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lg := listener.NewGroup()
+	key := listener.GroupKey("default", "", true)
+	go lg.StartListener(key, "127.0.0.1", 0, 0,
+		&tls.Config{Certificates: []tls.Certificate{cert}, MinVersion: tls.VersionTLS12},
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}),
+		nil, nil, time.Second, time.Second)
+	t.Cleanup(func() { lg.Shutdown(0) })
+	deadline := time.Now().Add(5 * time.Second)
+	for lg.Get(key) == nil && time.Now().Before(deadline) {
+		time.Sleep(2 * time.Millisecond)
+	}
+	if l := lg.Get(key); l == nil || !l.WaitForReady(5*time.Second) {
+		t.Fatal("listener not ready")
+	}
+
+	w := httptest.NewRecorder()
+	HandlerFunc(lg)(w, httptest.NewRequest(http.MethodGet, "/trickster/certificates", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	body := w.Body.String()
+	if strings.Contains(body, "PRIVATE KEY") {
+		t.Fatal("inventory must never contain key material")
+	}
+	out := struct {
+		Listeners map[string][]tr.EntryInfo `json:"listeners"`
+	}{}
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		t.Fatal(err)
+	}
+	entries, ok := out.Listeners[key]
+	if !ok || len(entries) != 1 {
+		t.Fatalf("expected 1 entry for %s, got %+v", key, out.Listeners)
+	}
+	if entries[0].CommonName != "inventory.example.com" ||
+		entries[0].SourceKind != tr.SourceKindConfig || entries[0].NotAfter.IsZero() {
+		t.Errorf("unexpected inventory entry: %+v", entries[0])
+	}
+
+	// a nil group yields an empty inventory, not an error
+	w = httptest.NewRecorder()
+	HandlerFunc(nil)(w, httptest.NewRequest(http.MethodGet, "/trickster/certificates", nil))
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 for nil group, got %d", w.Code)
+	}
+}

--- a/pkg/proxy/listener/listener.go
+++ b/pkg/proxy/listener/listener.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -74,7 +75,7 @@ type Listener struct {
 	routeSwapper *switcher.SwitchHandler
 	server       server
 	exitOnError  atomic.Bool
-	state        int32
+	state        atomic.Int32
 	readyCh      chan struct{}
 	readyOnce    sync.Once
 }
@@ -144,12 +145,12 @@ func NewGroup() *Group {
 
 // State returns the current state of the listener
 func (l *Listener) State() ListenerState {
-	return ListenerState(atomic.LoadInt32(&l.state))
+	return ListenerState(l.state.Load())
 }
 
 // setState atomically sets the listener state
 func (l *Listener) setState(state ListenerState) {
-	atomic.StoreInt32(&l.state, int32(state))
+	l.state.Store(int32(state))
 }
 
 // markReady signals that the listener is ready to accept connections
@@ -226,6 +227,30 @@ func NewListener(listenAddress string, listenPort, connectionsLimit int,
 	})
 
 	return listener, nil
+}
+
+// GroupKey returns the Group membership key for a listener endpoint
+func GroupKey(listenerName, protocol string, isTLS bool) string {
+	scheme := protocol
+	if scheme == "" {
+		scheme = "http"
+	}
+	if isTLS {
+		scheme = "https"
+	}
+	return fmt.Sprintf("listener.%s.%s", listenerName, scheme)
+}
+
+// Keys returns the keys of all current group members
+func (lg *Group) Keys() []string {
+	lg.listenersLock.Lock()
+	out := make([]string, 0, len(lg.members))
+	for name := range lg.members {
+		out = append(out, name)
+	}
+	lg.listenersLock.Unlock()
+	slices.Sort(out)
+	return out
 }
 
 // Get returns the listener if it exists

--- a/pkg/proxy/tls/monitor/monitor.go
+++ b/pkg/proxy/tls/monitor/monitor.go
@@ -1,0 +1,387 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package monitor detects out-of-band TLS certificate rotation and hot-swaps
+// renewed certificates into live listeners without restart or config reload.
+package monitor
+
+import (
+	"cmp"
+	"fmt"
+	"os"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/config"
+	listenerconfig "github.com/trickstercache/trickster/v2/pkg/config/listener"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+	tr "github.com/trickstercache/trickster/v2/pkg/proxy/tls"
+	"github.com/trickstercache/trickster/v2/pkg/watchers"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	logKeyListenerName = "listenerName"
+	logKeyEntry        = "entry"
+	logKeyDetail       = "detail"
+)
+
+// Monitor owns certificate rotation watchers and swaps validated sources into
+// listener certificate stores. Control-plane only; never on the handshake path.
+type Monitor struct {
+	mtx       sync.Mutex
+	group     *listener.Group
+	watchers  map[string]*watchedSet       // keyed by fileset key + interval
+	cache     map[string]*tr.Entry         // last-good entry per fileset key
+	listeners map[string]*listenerNotifier // keyed by listener group key
+}
+
+type watchedSet struct {
+	fs       tr.FileSet
+	interval time.Duration
+	watcher  watchers.Watcher
+}
+
+type listenerNotifier struct {
+	name     string
+	groupKey string
+	watch    bool
+	fileSets []tr.FileSet
+	memory   map[string]*tr.Entry
+}
+
+type watchSpec struct {
+	key      string
+	fs       tr.FileSet
+	interval time.Duration
+}
+
+// New returns a new Monitor
+func New() *Monitor {
+	return &Monitor{
+		watchers:  make(map[string]*watchedSet),
+		cache:     make(map[string]*tr.Entry),
+		listeners: make(map[string]*listenerNotifier),
+	}
+}
+
+// Apply reconciles watchers and listener stores with conf. Call after the
+// listener group has applied conf.
+func (m *Monitor) Apply(conf *config.Config, lg *listener.Group) {
+	if conf == nil || lg == nil {
+		return
+	}
+	desired := make(map[string]watchSpec)
+	newListeners := make(map[string]*listenerNotifier)
+	backendNames := make([]string, 0, len(conf.Backends))
+	for name := range conf.Backends {
+		backendNames = append(backendNames, name)
+	}
+	slices.Sort(backendNames)
+	for name, o := range conf.Listeners {
+		if o == nil || !o.Active || !o.ServeTLS || o.TLSListenPort <= 0 ||
+			(o.Protocol != "" && o.Protocol != listenerconfig.ProtocolHTTP) {
+			continue
+		}
+		interval := time.Duration(o.TLSWatchInterval)
+		ln := &listenerNotifier{
+			name:     name,
+			groupKey: listener.GroupKey(name, o.Protocol, true),
+			watch:    interval > 0,
+			memory:   make(map[string]*tr.Entry),
+		}
+		for _, backendName := range backendNames {
+			b := conf.Backends[backendName]
+			backendListener := b.ListenerName
+			if backendListener == "" {
+				backendListener = listenerconfig.DefaultFrontendName
+			}
+			if backendListener != name || b.TLS == nil || !b.TLS.ServeTLS ||
+				b.TLS.FullChainCertPath == "" || b.TLS.PrivateKeyPath == "" {
+				continue
+			}
+			fs := tr.FileSet{CertPath: b.TLS.FullChainCertPath, KeyPath: b.TLS.PrivateKeyPath}
+			if slices.ContainsFunc(ln.fileSets,
+				func(f tr.FileSet) bool { return f.Key() == fs.Key() }) {
+				continue
+			}
+			ln.fileSets = append(ln.fileSets, fs)
+			if ln.watch {
+				desired[watchKey(fs, interval)] = watchSpec{
+					key: watchKey(fs, interval), fs: fs, interval: interval,
+				}
+			}
+		}
+		if len(ln.fileSets) == 0 {
+			continue
+		}
+		newListeners[ln.groupKey] = ln
+	}
+
+	var toClose []watchers.Watcher
+	var toStart []watchSpec
+	m.mtx.Lock()
+	m.group = lg
+	for groupKey, ln := range newListeners {
+		if old, ok := m.listeners[groupKey]; ok {
+			ln.memory = old.memory
+		}
+	}
+	for groupKey, old := range m.listeners {
+		if _, ok := newListeners[groupKey]; !ok {
+			clearListenerMetrics(old.name)
+		}
+	}
+	m.listeners = newListeners
+	for key, ws := range m.watchers {
+		if _, ok := desired[key]; !ok {
+			toClose = append(toClose, ws.watcher)
+			delete(m.watchers, key)
+		}
+	}
+	for key, spec := range desired {
+		if _, ok := m.watchers[key]; !ok {
+			toStart = append(toStart, spec)
+		}
+	}
+	groupKeys := make([]string, 0, len(newListeners))
+	for groupKey := range newListeners {
+		groupKeys = append(groupKeys, groupKey)
+	}
+	m.mtx.Unlock()
+
+	for _, w := range toClose {
+		w.Close()
+	}
+	// create outside the lock: initial load may call onLoad, which takes it
+	for _, spec := range toStart {
+		w := tr.NewFileSetWatcher(spec.fs, spec.interval, m.onLoad)
+		if w == nil {
+			continue
+		}
+		m.mtx.Lock()
+		m.watchers[spec.key] = &watchedSet{fs: spec.fs, interval: spec.interval, watcher: w}
+		m.mtx.Unlock()
+	}
+	slices.Sort(groupKeys)
+	for _, groupKey := range groupKeys {
+		m.rebuild(groupKey)
+	}
+}
+
+// Close stops all watchers and waits for their goroutines to exit
+func (m *Monitor) Close() {
+	m.mtx.Lock()
+	toClose := make([]watchers.Watcher, 0, len(m.watchers))
+	for _, ws := range m.watchers {
+		toClose = append(toClose, ws.watcher)
+	}
+	m.watchers = make(map[string]*watchedSet)
+	m.mtx.Unlock()
+	for _, w := range toClose {
+		w.Close()
+	}
+}
+
+// SetMemoryCert adds or updates an in-memory PEM pair for listenerName,
+// keyed by sourceKey. Validated and hot-swapped like file sources.
+func (m *Monitor) SetMemoryCert(listenerName, sourceKey string, certPEM, keyPEM []byte) error {
+	cert, err := tr.ValidatePair(certPEM, keyPEM)
+	if err != nil {
+		metrics.TLSCertificateValidationFailures.WithLabelValues(
+			memoryEntryKey(sourceKey)).Inc()
+		return err
+	}
+	e := tr.NewEntry(memoryEntryKey(sourceKey), tr.SourceKindMemory, cert)
+	m.mtx.Lock()
+	ln := m.listenerByName(listenerName)
+	if ln == nil {
+		m.mtx.Unlock()
+		return fmt.Errorf("no TLS listener named %s", listenerName)
+	}
+	prev := ln.memory[e.Key]
+	ln.memory[e.Key] = e
+	groupKey := ln.groupKey
+	m.mtx.Unlock()
+	m.rebuild(groupKey)
+	if prev == nil || prev.ContentHash != e.ContentHash {
+		logSwap(listenerName, e)
+		metrics.TLSCertificateSwapsTotal.WithLabelValues(listenerName, e.Key).Inc()
+	}
+	return nil
+}
+
+// RemoveMemoryCert removes an in-memory certificate from the named listener.
+func (m *Monitor) RemoveMemoryCert(listenerName, sourceKey string) error {
+	m.mtx.Lock()
+	ln := m.listenerByName(listenerName)
+	if ln == nil {
+		m.mtx.Unlock()
+		return fmt.Errorf("no TLS listener named %s", listenerName)
+	}
+	delete(ln.memory, memoryEntryKey(sourceKey))
+	groupKey := ln.groupKey
+	m.mtx.Unlock()
+	m.rebuild(groupKey)
+	return nil
+}
+
+func memoryEntryKey(sourceKey string) string {
+	return tr.SourceKindMemory + ":" + sourceKey
+}
+
+// requires m.mtx held
+func (m *Monitor) listenerByName(name string) *listenerNotifier {
+	for _, ln := range m.listeners {
+		if ln.name == name {
+			return ln
+		}
+	}
+	return nil
+}
+
+func (m *Monitor) onLoad(e *tr.Entry) {
+	m.mtx.Lock()
+	prev := m.cache[e.Key]
+	m.cache[e.Key] = e
+	changed := prev != nil && prev.ContentHash != e.ContentHash
+	affected := make([]*listenerNotifier, 0, len(m.listeners))
+	for _, ln := range m.listeners {
+		if ln.watch && slices.ContainsFunc(ln.fileSets,
+			func(f tr.FileSet) bool { return f.Key() == e.Key }) {
+			affected = append(affected, ln)
+		}
+	}
+	m.mtx.Unlock()
+	slices.SortFunc(affected, func(a, b *listenerNotifier) int {
+		return cmp.Compare(a.groupKey, b.groupKey)
+	})
+	for _, ln := range affected {
+		m.rebuild(ln.groupKey)
+		if changed {
+			logSwap(ln.name, e)
+			metrics.TLSCertificateSwapsTotal.WithLabelValues(ln.name, e.Key).Inc()
+		}
+	}
+}
+
+func logSwap(listenerName string, e *tr.Entry) {
+	pairs := logging.Pairs{logKeyListenerName: listenerName, logKeyEntry: e.Key}
+	if leaf := e.Certificate.Leaf; leaf != nil {
+		pairs["subjectAltNames"] = leaf.DNSNames
+		pairs["notAfter"] = leaf.NotAfter
+	}
+	logger.Info("tls certificate hot-swapped into listener", pairs)
+}
+
+// rebuild replaces groupKey's cert store with last-good entries. Leaves the
+// store untouched if any file set has never loaded successfully.
+func (m *Monitor) rebuild(groupKey string) {
+	m.mtx.Lock()
+	ln, ok := m.listeners[groupKey]
+	if !ok || m.group == nil {
+		m.mtx.Unlock()
+		return
+	}
+	entries := make([]*tr.Entry, 0, len(ln.fileSets)+len(ln.memory))
+	for _, fs := range ln.fileSets {
+		e := m.cache[fs.Key()]
+		if e == nil {
+			e = m.loadFileSet(fs)
+		}
+		if e == nil {
+			// incomplete load: leave store as config path populated it
+			m.mtx.Unlock()
+			return
+		}
+		entries = append(entries, e)
+	}
+	memoryKeys := make([]string, 0, len(ln.memory))
+	for key := range ln.memory {
+		memoryKeys = append(memoryKeys, key)
+	}
+	slices.Sort(memoryKeys)
+	for _, key := range memoryKeys {
+		entries = append(entries, ln.memory[key])
+	}
+	group := m.group
+	name := ln.name
+	m.mtx.Unlock()
+
+	l := group.Get(groupKey)
+	if l == nil || l.CertSwapper() == nil {
+		return
+	}
+	store, ok := l.CertSwapper().(tr.CertStore)
+	if !ok {
+		return
+	}
+	store.SetEntries(entries)
+	clearListenerMetrics(name)
+	infos := store.Entries()
+	metrics.TLSCertificateStoreSize.WithLabelValues(name).Set(float64(len(infos)))
+	for _, info := range infos {
+		metrics.TLSCertificateNotAfter.WithLabelValues(name, info.Key).
+			Set(float64(info.NotAfter.Unix()))
+		metrics.TLSCertificateLastLoad.WithLabelValues(name, info.Key).
+			Set(float64(info.LastLoad.Unix()))
+	}
+}
+
+// loadFileSet loads and caches a file set when no watcher entry exists yet.
+// Requires m.mtx held.
+func (m *Monitor) loadFileSet(fs tr.FileSet) *tr.Entry {
+	certPEM, err := os.ReadFile(fs.CertPath) // #nosec G703 -- path comes from operator-provided config
+	if err != nil {
+		logger.Warn("unable to read tls certificate source", logging.Pairs{
+			logKeyEntry: fs.Key(), logKeyDetail: err.Error(),
+		})
+		return nil
+	}
+	keyPEM, err := os.ReadFile(fs.KeyPath) // #nosec G703 -- path comes from operator-provided config
+	if err != nil {
+		logger.Warn("unable to read tls certificate source", logging.Pairs{
+			logKeyEntry: fs.Key(), logKeyDetail: err.Error(),
+		})
+		return nil
+	}
+	cert, err := tr.ValidatePair(certPEM, keyPEM)
+	if err != nil {
+		logger.Warn("tls certificate source failed validation", logging.Pairs{
+			logKeyEntry: fs.Key(), logKeyDetail: err.Error(),
+		})
+		return nil
+	}
+	e := tr.NewEntry(fs.Key(), tr.SourceKindFile, cert)
+	m.cache[fs.Key()] = e
+	return e
+}
+
+func watchKey(fs tr.FileSet, interval time.Duration) string {
+	return fs.Key() + "@" + interval.String()
+}
+
+func clearListenerMetrics(listenerName string) {
+	labels := prometheus.Labels{"listener": listenerName}
+	metrics.TLSCertificateNotAfter.DeletePartialMatch(labels)
+	metrics.TLSCertificateLastLoad.DeletePartialMatch(labels)
+	metrics.TLSCertificateStoreSize.Delete(labels)
+}

--- a/pkg/proxy/tls/monitor/monitor_test.go
+++ b/pkg/proxy/tls/monitor/monitor_test.go
@@ -1,0 +1,363 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package monitor
+
+import (
+	"bufio"
+	"crypto/tls"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+	"time"
+
+	bo "github.com/trickstercache/trickster/v2/pkg/backends/options"
+	"github.com/trickstercache/trickster/v2/pkg/config"
+	listenerconfig "github.com/trickstercache/trickster/v2/pkg/config/listener"
+	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
+	"github.com/trickstercache/trickster/v2/pkg/proxy/listener"
+	tr "github.com/trickstercache/trickster/v2/pkg/proxy/tls"
+	to "github.com/trickstercache/trickster/v2/pkg/proxy/tls/options"
+	tlstest "github.com/trickstercache/trickster/v2/pkg/testutil/tls"
+)
+
+const testWatchInterval = 10 * time.Millisecond
+
+func writePair(t *testing.T, certPath, keyPath string, names ...string) {
+	t.Helper()
+	k, c, err := tlstest.GetTestKeyAndCertWithNames(names...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, k, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certPath, c, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return condition()
+}
+
+func testConfig(t *testing.T, interval time.Duration) (*config.Config, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	certPath, keyPath := filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key")
+	writePair(t, certPath, keyPath, "one.example.com")
+	conf := config.NewConfig()
+	lo := conf.Listeners[listenerconfig.DefaultFrontendName]
+	lo.ServeTLS = true
+	lo.TLSWatchInterval = timeconv.Duration(interval)
+	conf.Backends = map[string]*bo.Options{
+		"test": {
+			ListenerName: listenerconfig.DefaultFrontendName,
+			TLS: &to.Options{
+				ServeTLS:          true,
+				FullChainCertPath: certPath,
+				PrivateKeyPath:    keyPath,
+			},
+		},
+	}
+	return conf, certPath, keyPath
+}
+
+func startTLSListener(t *testing.T, certPath, keyPath string) (*listener.Group, string, string) {
+	t.Helper()
+	tlsCfg, err := tlsServerConfig(certPath, keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lg := listener.NewGroup()
+	key := listener.GroupKey(listenerconfig.DefaultFrontendName, "", true)
+	go lg.StartListener(key, "127.0.0.1", 0, 0, tlsCfg,
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		}), nil, nil, time.Second, time.Second)
+	if !waitFor(t, 5*time.Second, func() bool { return lg.Get(key) != nil }) {
+		t.Fatal("listener not found in group")
+	}
+	l := lg.Get(key)
+	if !l.WaitForReady(5 * time.Second) {
+		t.Fatal("listener not ready")
+	}
+	t.Cleanup(func() { lg.Shutdown(0) })
+	return lg, key, l.Addr().String()
+}
+
+func tlsServerConfig(certPath, keyPath string) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}, nil
+}
+
+func handshakeSAN(t *testing.T, address string) string {
+	t.Helper()
+	conn, err := tls.Dial("tcp", address, &tls.Config{
+		InsecureSkipVerify: true, // #nosec G402 -- test client against self-signed test cert
+		ServerName:         "one.example.com",
+	})
+	if err != nil {
+		t.Fatalf("handshake failed: %v", err)
+	}
+	defer conn.Close()
+	leaf := conn.ConnectionState().PeerCertificates[0]
+	if len(leaf.DNSNames) == 0 {
+		return ""
+	}
+	return leaf.DNSNames[0]
+}
+
+func TestMonitorRotationHotSwap(t *testing.T) {
+	conf, certPath, keyPath := testConfig(t, testWatchInterval)
+	lg, key, address := startTLSListener(t, certPath, keyPath)
+
+	m := New()
+	defer m.Close()
+	m.Apply(conf, lg)
+
+	// establish a keep-alive connection on the original cert
+	established, err := tls.Dial("tcp", address, &tls.Config{
+		InsecureSkipVerify: true, // #nosec G402 -- test client against self-signed test cert
+		ServerName:         "one.example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer established.Close()
+	reader := bufio.NewReader(established)
+	doRequest := func() {
+		t.Helper()
+		if _, err := established.Write([]byte("GET / HTTP/1.1\r\nHost: one.example.com\r\n\r\n")); err != nil {
+			t.Fatalf("write on established connection failed: %v", err)
+		}
+		resp, err := http.ReadResponse(reader, nil)
+		if err != nil {
+			t.Fatalf("read on established connection failed: %v", err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("unexpected status on established connection: %d", resp.StatusCode)
+		}
+	}
+	doRequest()
+
+	if san := handshakeSAN(t, address); san != "one.example.com" {
+		t.Fatalf("expected original cert before rotation, got %s", san)
+	}
+
+	// rotate the pair in place; config remains untouched
+	writePair(t, certPath, keyPath, "two.example.com")
+
+	if !waitFor(t, 5*time.Second, func() bool {
+		conn, err := tls.Dial("tcp", address, &tls.Config{
+			InsecureSkipVerify: true, // #nosec G402 -- test client against self-signed test cert
+		})
+		if err != nil {
+			t.Fatalf("handshake failed during rotation: %v", err)
+		}
+		defer conn.Close()
+		leaf := conn.ConnectionState().PeerCertificates[0]
+		return len(leaf.DNSNames) > 0 && leaf.DNSNames[0] == "two.example.com"
+	}) {
+		t.Fatal("new handshakes did not pick up the rotated certificate")
+	}
+
+	// the established connection must be untouched by the swap
+	doRequest()
+
+	// a config reload arriving mid-rotation is safe and preserves watcher
+	// continuity; a subsequent rotation is still detected
+	m.Apply(conf, lg)
+	doRequest()
+	writePair(t, certPath, keyPath, "three.example.com")
+	if !waitFor(t, 5*time.Second, func() bool {
+		conn, err := tls.Dial("tcp", address, &tls.Config{
+			InsecureSkipVerify: true, // #nosec G402 -- test client against self-signed test cert
+		})
+		if err != nil {
+			return false
+		}
+		defer conn.Close()
+		leaf := conn.ConnectionState().PeerCertificates[0]
+		return len(leaf.DNSNames) > 0 && leaf.DNSNames[0] == "three.example.com"
+	}) {
+		t.Fatal("rotation after reload not detected")
+	}
+	doRequest()
+
+	if key == "" {
+		t.Fatal("unexpected empty listener key")
+	}
+}
+
+func storeFor(t *testing.T, lg *listener.Group, key string) tr.CertStore {
+	t.Helper()
+	l := lg.Get(key)
+	if l == nil || l.CertSwapper() == nil {
+		t.Fatal("no swapper for listener")
+	}
+	store, ok := l.CertSwapper().(tr.CertStore)
+	if !ok {
+		t.Fatal("swapper does not implement CertStore")
+	}
+	return store
+}
+
+func TestMonitorMemoryCerts(t *testing.T) {
+	conf, certPath, keyPath := testConfig(t, testWatchInterval)
+	lg, key, _ := startTLSListener(t, certPath, keyPath)
+
+	m := New()
+	defer m.Close()
+	m.Apply(conf, lg)
+
+	k, c, err := tlstest.GetTestKeyAndCertWithNames("secret.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := m.SetMemoryCert("no-such-listener", "ns/name", c, k); err == nil {
+		t.Error("expected error for unknown listener")
+	}
+	if err := m.SetMemoryCert(listenerconfig.DefaultFrontendName, "ns/name", c, k); err != nil {
+		t.Fatal(err)
+	}
+	store := storeFor(t, lg, key)
+	entries := store.Entries()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(entries))
+	}
+	idx := slices.IndexFunc(entries, func(e tr.EntryInfo) bool {
+		return e.SourceKind == tr.SourceKindMemory
+	})
+	if idx < 0 || entries[idx].Key != "memory:ns/name" ||
+		entries[idx].CommonName != "secret.example.com" {
+		t.Errorf("unexpected memory entry: %+v", entries)
+	}
+
+	// an invalid pair must be rejected by the same coherence validation
+	if err := m.SetMemoryCert(listenerconfig.DefaultFrontendName, "ns/name",
+		c, []byte("garbage")); err == nil {
+		t.Error("expected validation error for invalid memory pair")
+	}
+
+	if err := m.RemoveMemoryCert(listenerconfig.DefaultFrontendName, "ns/name"); err != nil {
+		t.Fatal(err)
+	}
+	if entries := storeFor(t, lg, key).Entries(); len(entries) != 1 {
+		t.Errorf("expected 1 entry after removal, got %d", len(entries))
+	}
+}
+
+func TestMonitorDisabledWatch(t *testing.T) {
+	conf, certPath, keyPath := testConfig(t, 0)
+	lg, key, address := startTLSListener(t, certPath, keyPath)
+
+	m := New()
+	defer m.Close()
+	m.Apply(conf, lg)
+
+	// with watching disabled, the store is still resynced with keyed entries
+	entries := storeFor(t, lg, key).Entries()
+	if len(entries) != 1 || entries[0].SourceKind != tr.SourceKindFile {
+		t.Fatalf("expected 1 file-sourced entry, got %+v", entries)
+	}
+
+	// but a rotation is not auto-detected
+	writePair(t, certPath, keyPath, "two.example.com")
+	time.Sleep(100 * time.Millisecond)
+	if san := handshakeSAN(t, address); san != "one.example.com" {
+		t.Errorf("rotation applied despite disabled watching; got %s", san)
+	}
+}
+
+func TestMonitorUnreadableSourceKeepsStore(t *testing.T) {
+	conf, certPath, keyPath := testConfig(t, 0)
+	lg, key, _ := startTLSListener(t, certPath, keyPath)
+
+	m := New()
+	defer m.Close()
+
+	for _, breakage := range []func(){
+		func() { os.Remove(certPath) },
+		func() { writePair(t, certPath, keyPath, "two.example.com"); os.Remove(keyPath) },
+		func() {
+			writePair(t, certPath, keyPath, "two.example.com")
+			if err := os.WriteFile(keyPath, []byte("garbage"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		},
+	} {
+		breakage()
+		m.cache = make(map[string]*tr.Entry) // force a reload attempt
+		m.Apply(conf, lg)
+		entries := storeFor(t, lg, key).Entries()
+		if len(entries) != 1 || entries[0].SourceKind != tr.SourceKindConfig {
+			t.Fatalf("store should retain its config-populated entry, got %+v", entries)
+		}
+	}
+}
+
+func TestMonitorApplyLifecycle(t *testing.T) {
+	conf, certPath, keyPath := testConfig(t, testWatchInterval)
+	lg, key, _ := startTLSListener(t, certPath, keyPath)
+
+	before := runtime.NumGoroutine()
+	m := New()
+	m.Apply(conf, lg)
+
+	// soak: rapid rotation loop; the store must track the latest coherent pair
+	for i := range 5 {
+		names := []string{"one.example.com", "two.example.com"}
+		writePair(t, certPath, keyPath, names[i%2])
+	}
+	writePair(t, certPath, keyPath, "final.example.com")
+	if !waitFor(t, 5*time.Second, func() bool {
+		entries := storeFor(t, lg, key).Entries()
+		return len(entries) == 1 && entries[0].CommonName == "final.example.com"
+	}) {
+		t.Fatal("store did not converge to the final rotated certificate")
+	}
+
+	// a reload that drops all TLS backends must stop the watchers
+	confNoTLS := config.NewConfig()
+	confNoTLS.Listeners[listenerconfig.DefaultFrontendName].ServeTLS = false
+	m.Apply(confNoTLS, lg)
+	m.Close()
+	if !waitFor(t, 3*time.Second, func() bool {
+		return runtime.NumGoroutine() <= before
+	}) {
+		t.Errorf("goroutine leak: before=%d after=%d", before, runtime.NumGoroutine())
+	}
+}

--- a/pkg/proxy/tls/store.go
+++ b/pkg/proxy/tls/store.go
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"crypto/sha256"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/hex"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// source kinds for Entry.SourceKind
+const (
+	// SourceKindConfig identifies certificates loaded via the config reload
+	// path, where no per-source identity is available.
+	SourceKindConfig = "config"
+	// SourceKindFile identifies certificates loaded from a watched file pair.
+	SourceKindFile = "file"
+	// SourceKindMemory identifies certificates supplied at runtime as
+	// in-memory PEM (e.g. from a Kubernetes Secret).
+	SourceKindMemory = "memory"
+)
+
+// Entry is a single certificate held by a CertStore, keyed by a stable
+// source identity so it can be updated in place when its source changes.
+type Entry struct {
+	// Key is the stable source identity of the certificate
+	Key string
+	// SourceKind is one of SourceKindConfig, SourceKindFile or SourceKindMemory
+	SourceKind string
+	// Certificate is the parsed certificate; Leaf is always populated
+	Certificate tls.Certificate
+	// ContentHash is the sha256 hash of the certificate chain's DER bytes
+	ContentHash string
+	// LastLoad is the time the certificate was last loaded from its source
+	LastLoad time.Time
+}
+
+// EntryInfo describes an Entry for read-only inventory purposes and never
+// includes key material.
+type EntryInfo struct {
+	Key        string    `json:"id"`
+	SourceKind string    `json:"source"`
+	CommonName string    `json:"common_name,omitempty"`
+	DNSNames   []string  `json:"dns_names,omitempty"`
+	NotBefore  time.Time `json:"not_before"`
+	NotAfter   time.Time `json:"not_after"`
+	LastLoad   time.Time `json:"last_load"`
+}
+
+// CertStore extends CertSwapper with source-keyed entries, an SNI index and
+// a read-only inventory. NewSwapper returns a CertStore.
+type CertStore interface {
+	CertSwapper
+	// SetEntries atomically replaces the full entry set
+	SetEntries([]*Entry)
+	// Entries returns read-only metadata for the current entry set
+	Entries() []EntryInfo
+}
+
+// ValidatePair parses and validates a PEM-encoded certificate chain and
+// private key as a coherent pair, returning the certificate with its leaf
+// parsed. Both file and in-memory sources flow through this validation.
+func ValidatePair(certPEM, keyPEM []byte) (tls.Certificate, error) {
+	// X509KeyPair parses the chain, verifies the key matches the leaf, and
+	// populates Leaf
+	return tls.X509KeyPair(certPEM, keyPEM)
+}
+
+// NewEntry returns an Entry for the provided certificate with its content
+// hash and load time populated
+func NewEntry(key, sourceKind string, cert tls.Certificate) *Entry {
+	return &Entry{
+		Key:         key,
+		SourceKind:  sourceKind,
+		Certificate: cert,
+		ContentHash: hashChain(cert),
+		LastLoad:    time.Now(),
+	}
+}
+
+func hashChain(cert tls.Certificate) string {
+	h := sha256.New()
+	for _, der := range cert.Certificate {
+		h.Write(der)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// storeSnapshot is the immutable state swapped into the store; GetCert only
+// ever loads a snapshot, so the handshake path is lock-free.
+type storeSnapshot struct {
+	entries  []*Entry
+	certs    []*tls.Certificate
+	exact    map[string]*tls.Certificate
+	wildcard map[string]*tls.Certificate
+}
+
+// certStore implements CertStore
+type certStore struct {
+	snapshot atomic.Pointer[storeSnapshot]
+}
+
+// NewStore returns a new CertStore populated with the provided entries
+func NewStore(entries []*Entry) CertStore {
+	s := &certStore{}
+	s.SetEntries(entries)
+	return s
+}
+
+// GetCert returns the best-matching certificate for the provided clientHello.
+// Selection order: exact SNI match, wildcard SNI match, linear
+// SupportsCertificate scan (covers no-SNI clients and IP SANs), then the
+// first certificate.
+func (s *certStore) GetCert(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	snap := s.snapshot.Load()
+	if snap == nil || len(snap.certs) == 0 {
+		return nil, ErrNoCertificates
+	}
+	if len(snap.certs) == 1 {
+		// There's only one choice, so no point doing any work.
+		return snap.certs[0], nil
+	}
+	if name := normalizeSNI(clientHello.ServerName); name != "" {
+		if cert, ok := snap.exact[name]; ok {
+			return cert, nil
+		}
+		if i := strings.IndexByte(name, '.'); i > 0 {
+			if cert, ok := snap.wildcard[name[i+1:]]; ok {
+				return cert, nil
+			}
+		}
+	}
+	for _, cert := range snap.certs {
+		if err := clientHello.SupportsCertificate(cert); err == nil {
+			return cert, nil
+		}
+	}
+	// If nothing matches, return the first certificate.
+	return snap.certs[0], nil
+}
+
+// SetCerts safely updates the certs list for the subject store. Certificates
+// set this way carry no source identity and are keyed by content hash.
+func (s *certStore) SetCerts(certs []tls.Certificate) {
+	entries := make([]*Entry, len(certs))
+	for i, cert := range certs {
+		if cert.Leaf == nil && len(cert.Certificate) > 0 {
+			// tolerated: an unparsable leaf only bypasses the SNI index
+			cert.Leaf, _ = x509.ParseCertificate(cert.Certificate[0])
+		}
+		entries[i] = NewEntry("", SourceKindConfig, cert)
+		entries[i].Key = SourceKindConfig + ":" + entries[i].ContentHash
+	}
+	s.SetEntries(entries)
+}
+
+// SetEntries atomically replaces the full entry set, deduplicating entries
+// with identical content and rebuilding the SNI index
+func (s *certStore) SetEntries(entries []*Entry) {
+	snap := &storeSnapshot{
+		entries:  make([]*Entry, 0, len(entries)),
+		certs:    make([]*tls.Certificate, 0, len(entries)),
+		exact:    make(map[string]*tls.Certificate),
+		wildcard: make(map[string]*tls.Certificate),
+	}
+	seen := make(map[string]bool, len(entries))
+	for _, e := range entries {
+		if e == nil || seen[e.ContentHash] {
+			continue
+		}
+		seen[e.ContentHash] = true
+		snap.entries = append(snap.entries, e)
+		cert := &e.Certificate
+		snap.certs = append(snap.certs, cert)
+		indexCert(snap, cert)
+	}
+	s.snapshot.Store(snap)
+}
+
+// indexCert adds the cert's SANs (and legacy CN fallback) to the SNI index;
+// on collision, the first-indexed certificate wins, matching the ordering
+// semantics of the linear scan.
+func indexCert(snap *storeSnapshot, cert *tls.Certificate) {
+	if cert.Leaf == nil {
+		return
+	}
+	names := cert.Leaf.DNSNames
+	if len(names) == 0 && cert.Leaf.Subject.CommonName != "" {
+		names = []string{cert.Leaf.Subject.CommonName}
+	}
+	for _, name := range names {
+		name = strings.ToLower(name)
+		if base, ok := strings.CutPrefix(name, "*."); ok {
+			if _, exists := snap.wildcard[base]; !exists {
+				snap.wildcard[base] = cert
+			}
+			continue
+		}
+		if _, exists := snap.exact[name]; !exists {
+			snap.exact[name] = cert
+		}
+	}
+}
+
+// Entries returns read-only metadata for the current entry set
+func (s *certStore) Entries() []EntryInfo {
+	snap := s.snapshot.Load()
+	if snap == nil {
+		return nil
+	}
+	out := make([]EntryInfo, len(snap.entries))
+	for i, e := range snap.entries {
+		info := EntryInfo{
+			Key:        e.Key,
+			SourceKind: e.SourceKind,
+			LastLoad:   e.LastLoad,
+		}
+		if leaf := e.Certificate.Leaf; leaf != nil {
+			info.CommonName = leaf.Subject.CommonName
+			info.DNSNames = leaf.DNSNames
+			info.NotBefore = leaf.NotBefore
+			info.NotAfter = leaf.NotAfter
+		}
+		out[i] = info
+	}
+	return out
+}
+
+func normalizeSNI(serverName string) string {
+	return strings.ToLower(strings.TrimSuffix(serverName, "."))
+}

--- a/pkg/proxy/tls/store_bench_test.go
+++ b/pkg/proxy/tls/store_bench_test.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"fmt"
+	"testing"
+
+	tlstest "github.com/trickstercache/trickster/v2/pkg/testutil/tls"
+)
+
+// benchStore builds a store with n certificates: n-1 exact-host certs and
+// one wildcard cert
+func benchStore(b *testing.B, n int) CertStore {
+	b.Helper()
+	entries := make([]*Entry, 0, n)
+	for i := range n - 1 {
+		host := fmt.Sprintf("host%d.example.com", i)
+		k, c, err := tlstest.GetTestKeyAndCertWithNames(host)
+		if err != nil {
+			b.Fatal(err)
+		}
+		cert, err := ValidatePair(c, k)
+		if err != nil {
+			b.Fatal(err)
+		}
+		entries = append(entries, NewEntry(host, SourceKindFile, cert))
+	}
+	k, c, err := tlstest.GetTestKeyAndCertWithNames("*.wild.example.com")
+	if err != nil {
+		b.Fatal(err)
+	}
+	cert, err := ValidatePair(c, k)
+	if err != nil {
+		b.Fatal(err)
+	}
+	entries = append(entries, NewEntry("wild", SourceKindFile, cert))
+	return NewStore(entries)
+}
+
+// BenchmarkGetCert demonstrates that the SNI index makes per-handshake
+// selection cost independent of certificate count (compare hit cases across
+// sizes), while a full miss falls back to the linear scan
+func BenchmarkGetCert(b *testing.B) {
+	for _, n := range []int{4, 128, 512} {
+		store := benchStore(b, n)
+		b.Run(fmt.Sprintf("exact-hit-%d", n), func(b *testing.B) {
+			chi := helloFor(fmt.Sprintf("host%d.example.com", n-2))
+			b.ResetTimer()
+			for range b.N {
+				if _, err := store.GetCert(chi); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("wildcard-hit-%d", n), func(b *testing.B) {
+			chi := helloFor("anything.wild.example.com")
+			b.ResetTimer()
+			for range b.N {
+				if _, err := store.GetCert(chi); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+		b.Run(fmt.Sprintf("fallback-miss-%d", n), func(b *testing.B) {
+			chi := helloFor("miss.invalid")
+			b.ResetTimer()
+			for range b.N {
+				if _, err := store.GetCert(chi); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/proxy/tls/store_test.go
+++ b/pkg/proxy/tls/store_test.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"crypto/tls"
+	"sync"
+	"testing"
+
+	tlstest "github.com/trickstercache/trickster/v2/pkg/testutil/tls"
+)
+
+func testEntry(t *testing.T, key string, names ...string) *Entry {
+	t.Helper()
+	k, c, err := tlstest.GetTestKeyAndCertWithNames(names...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := ValidatePair(c, k)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewEntry(key, SourceKindFile, cert)
+}
+
+func helloFor(host string) *tls.ClientHelloInfo {
+	return &tls.ClientHelloInfo{ServerName: host}
+}
+
+func TestGetCertSNISelection(t *testing.T) {
+	e1 := testEntry(t, "e1", "www.example.com", "example.com")
+	e2 := testEntry(t, "e2", "*.wild.example.com")
+	e3 := testEntry(t, "e3", "trickster.io")
+	store := NewStore([]*Entry{e1, e2, e3})
+
+	tests := []struct {
+		name     string
+		sni      string
+		expected *Entry
+	}{
+		{"exact match", "www.example.com", e1},
+		{"exact match secondary SAN", "example.com", e1},
+		{"exact match other cert", "trickster.io", e3},
+		{"wildcard match", "foo.wild.example.com", e2},
+		{"case-insensitive with trailing dot", "WWW.Example.COM.", e1},
+		{"unknown host falls back to first", "unknown.invalid", e1},
+		{"no SNI falls back to first", "", e1},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cert, err := store.GetCert(helloFor(test.sni))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cert.Leaf == nil || test.expected.Certificate.Leaf == nil ||
+				!cert.Leaf.Equal(test.expected.Certificate.Leaf) {
+				t.Errorf("wrong certificate selected for %q", test.sni)
+			}
+		})
+	}
+}
+
+func TestGetCertSingleAndEmpty(t *testing.T) {
+	store := NewStore(nil)
+	if _, err := store.GetCert(helloFor("any")); err != ErrNoCertificates {
+		t.Errorf("expected ErrNoCertificates, got %v", err)
+	}
+	e1 := testEntry(t, "e1", "one.example.com")
+	store.SetEntries([]*Entry{e1})
+	// a single cert is always returned, even on SNI mismatch, preserving the
+	// legacy swapper behavior
+	cert, err := store.GetCert(helloFor("mismatch.invalid"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !cert.Leaf.Equal(e1.Certificate.Leaf) {
+		t.Error("expected the sole certificate to be returned")
+	}
+}
+
+func TestSetEntriesDedupe(t *testing.T) {
+	e1 := testEntry(t, "e1", "dupe.example.com")
+	e2 := &Entry{
+		Key: "e2", SourceKind: SourceKindMemory,
+		Certificate: e1.Certificate, ContentHash: e1.ContentHash,
+	}
+	e3 := testEntry(t, "e3", "other.example.com")
+	store := NewStore([]*Entry{e1, e2, e3})
+	entries := store.Entries()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries after dedupe, got %d", len(entries))
+	}
+	if entries[0].Key != "e1" || entries[1].Key != "e3" {
+		t.Errorf("unexpected entry keys after dedupe: %s, %s",
+			entries[0].Key, entries[1].Key)
+	}
+}
+
+func TestEntriesMetadata(t *testing.T) {
+	e1 := testEntry(t, "e1", "meta.example.com")
+	store := NewStore([]*Entry{e1})
+	entries := store.Entries()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	info := entries[0]
+	if info.SourceKind != SourceKindFile || info.CommonName != "meta.example.com" ||
+		len(info.DNSNames) != 1 || info.DNSNames[0] != "meta.example.com" ||
+		info.NotAfter.IsZero() || info.LastLoad.IsZero() {
+		t.Errorf("unexpected entry metadata: %+v", info)
+	}
+}
+
+func TestConcurrentSwapAndHandshake(t *testing.T) {
+	e1 := testEntry(t, "e1", "a.example.com")
+	e2 := testEntry(t, "e2", "b.example.com")
+	store := NewStore([]*Entry{e1, e2})
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+	for range 4 {
+		wg.Go(func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				if _, err := store.GetCert(helloFor("a.example.com")); err != nil {
+					t.Error(err)
+					return
+				}
+			}
+		})
+	}
+	for range 200 {
+		store.SetEntries([]*Entry{e2, e1})
+		store.SetEntries([]*Entry{e1, e2})
+	}
+	close(done)
+	wg.Wait()
+}
+
+func TestValidatePair(t *testing.T) {
+	k1, c1, err := tlstest.GetTestKeyAndCertWithNames("pair.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ValidatePair(c1, k1); err != nil {
+		t.Error(err)
+	}
+	// a mismatched pair (mid-rotation state) must fail validation
+	k2, _, err := tlstest.GetTestKeyAndCertWithNames("pair.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ValidatePair(c1, k2); err == nil {
+		t.Error("expected validation error for mismatched pair")
+	}
+	if _, err := ValidatePair([]byte("garbage"), k1); err == nil {
+		t.Error("expected validation error for invalid cert PEM")
+	}
+}

--- a/pkg/proxy/tls/swapper.go
+++ b/pkg/proxy/tls/swapper.go
@@ -19,7 +19,6 @@ package tls
 import (
 	"crypto/tls"
 	"errors"
-	"sync/atomic"
 )
 
 // CertSwapper is used by a TLSConfig to dynamically update the running
@@ -33,49 +32,10 @@ type CertSwapper interface {
 // ErrNoCertificates is returned by GetCert() when no certs are configured
 var ErrNoCertificates = errors.New("tls: no certificates configured")
 
-// NewSwapper returns a new CertSwapper based on the provided certList
+// NewSwapper returns a new CertSwapper based on the provided certList.
+// The returned value also implements CertStore.
 func NewSwapper(certList []tls.Certificate) CertSwapper {
-	sw := &certSwapper{}
+	sw := &certStore{}
 	sw.SetCerts(certList)
 	return sw
-}
-
-// certSwapper implements the CertSwapper interface
-type certSwapper struct {
-	Certificates atomic.Value
-	hasCerts     bool
-}
-
-// GetCert returns the best-matching certificate for the provided clientHello
-func (c *certSwapper) GetCert(clientHello *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	if !c.hasCerts {
-		return nil, ErrNoCertificates
-	}
-	certs, ok := c.Certificates.Load().([]tls.Certificate)
-	if !ok || len(certs) == 0 {
-		return nil, ErrNoCertificates
-	}
-
-	if len(certs) == 1 {
-		// There's only one choice, so no point doing any work.
-		return &certs[0], nil
-	}
-
-	for _, cert := range certs {
-		if err := clientHello.SupportsCertificate(&cert); err == nil {
-			return &cert, nil
-		}
-	}
-
-	// If nothing matches, return the first certificate.
-	return &certs[0], nil
-}
-
-// SetCerts safely updates the certs list for the subject *certSwapper
-func (c *certSwapper) SetCerts(certs []tls.Certificate) {
-	if certs == nil {
-		certs = []tls.Certificate{}
-	}
-	c.Certificates.Store(certs)
-	c.hasCerts = len(certs) > 0
 }

--- a/pkg/proxy/tls/swapper_test.go
+++ b/pkg/proxy/tls/swapper_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func getSwapper(t *testing.T) (*certSwapper, *tls.Config, func()) {
+func getSwapper(t *testing.T) (*certStore, *tls.Config, func()) {
 	options, closer, err := tlsConfig("")
 	if closer != nil {
 		defer closer()
@@ -37,7 +37,7 @@ func getSwapper(t *testing.T) (*certSwapper, *tls.Config, func()) {
 		t.Fatal(err)
 	}
 
-	sw := NewSwapper(tlscfg1.Certificates).(*certSwapper)
+	sw := NewSwapper(tlscfg1.Certificates).(*certStore)
 	return sw, tlscfg1, closer
 }
 
@@ -56,8 +56,7 @@ func TestGetSetCert(t *testing.T) {
 	if closer2 != nil {
 		defer closer2()
 	}
-	certs := sw.Certificates.Load().([]tls.Certificate)
-	certs = append(certs, cfg2.Certificates...)
+	certs := append(cfg.Certificates, cfg2.Certificates...)
 	sw.SetCerts(certs)
 	_, err = sw.GetCert(chi)
 	if err != nil {

--- a/pkg/proxy/tls/watcher.go
+++ b/pkg/proxy/tls/watcher.go
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"strings"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
+	"github.com/trickstercache/trickster/v2/pkg/watchers"
+	"github.com/trickstercache/trickster/v2/pkg/watchers/filesystem"
+)
+
+// FileSet identifies the set of related TLS source files that are watched
+// and validated as one unit, so a mid-rotation partial state (e.g. cert file
+// updated before key file) is never swapped into a live listener.
+type FileSet struct {
+	CertPath string
+	KeyPath  string
+	// CAPaths optionally names CA bundle files associated with the same
+	// identity; a change to any of them re-fires the load callback.
+	CAPaths []string
+}
+
+// Key returns the stable source identity for the FileSet
+func (fs FileSet) Key() string {
+	parts := append([]string{SourceKindFile + ":" + fs.CertPath, fs.KeyPath}, fs.CAPaths...)
+	return strings.Join(parts, "|")
+}
+
+// paths returns all files in the set, cert and key first
+func (fs FileSet) paths() []string {
+	return append([]string{fs.CertPath, fs.KeyPath}, fs.CAPaths...)
+}
+
+// NewFileSetWatcher starts a filesystem watcher (see watchers/filesystem for
+// the hybrid event+poll detection strategy) over the provided FileSet,
+// layering TLS pair-coherence validation on top: onLoad is never invoked
+// with an invalid or mismatched pair — a mid-rotation partial state keeps
+// the last-good certificate serving and is retried once the pair settles.
+// An initial load is performed synchronously: if the set is currently valid,
+// onLoad is invoked with the loaded Entry before this function returns, and
+// each subsequent detected-and-validated change invokes it again from the
+// watch goroutine. If interval is <= 0, no watcher is started and nil is
+// returned. Watchers are control-plane only: nothing here runs on the
+// handshake path.
+func NewFileSetWatcher(fs FileSet, interval time.Duration,
+	onLoad func(*Entry),
+) watchers.Watcher {
+	if interval <= 0 {
+		return nil
+	}
+	entryID := fs.CertPath
+	w, err := filesystem.StartNew(&filesystem.Options{
+		Name:     entryID,
+		Paths:    fs.paths(),
+		Interval: interval,
+		OnChange: func(contents [][]byte) error {
+			cert, err := ValidatePair(contents[0], contents[1])
+			if err != nil {
+				// likely a mid-rotation partial state; keep serving the
+				// last-good pair and retry once the content settles
+				metrics.TLSCertificateValidationFailures.WithLabelValues(entryID).Inc()
+				logger.Debug("tls certificate change failed validation", logging.Pairs{
+					"entry": entryID, "detail": err.Error(),
+				})
+				return err
+			}
+			if onLoad != nil {
+				onLoad(NewEntry(fs.Key(), SourceKindFile, cert))
+			}
+			return nil
+		},
+		OnReadError: func(_ error) {
+			metrics.TLSWatcherErrors.WithLabelValues(entryID).Inc()
+		},
+	})
+	if err != nil {
+		// unreachable with a validated interval and a non-empty FileSet
+		logger.Error("unable to start tls certificate watcher", logging.Pairs{
+			"entry": entryID, "detail": err.Error(),
+		})
+		return nil
+	}
+	return w
+}

--- a/pkg/proxy/tls/watcher_test.go
+++ b/pkg/proxy/tls/watcher_test.go
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	tlstest "github.com/trickstercache/trickster/v2/pkg/testutil/tls"
+)
+
+const testPollInterval = 10 * time.Millisecond
+
+type loadRecorder struct {
+	mtx     sync.Mutex
+	entries []*Entry
+}
+
+func (r *loadRecorder) onLoad(e *Entry) {
+	r.mtx.Lock()
+	r.entries = append(r.entries, e)
+	r.mtx.Unlock()
+}
+
+func (r *loadRecorder) count() int {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return len(r.entries)
+}
+
+func (r *loadRecorder) last() *Entry {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	if len(r.entries) == 0 {
+		return nil
+	}
+	return r.entries[len(r.entries)-1]
+}
+
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return condition()
+}
+
+func writePair(t *testing.T, certPath, keyPath string, names ...string) {
+	t.Helper()
+	k, c, err := tlstest.GetTestKeyAndCertWithNames(names...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// key first so a reader never observes a new cert with the old key
+	if err := os.WriteFile(keyPath, k, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certPath, c, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestFileSetWatcherDetectsRotation(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key")
+	writePair(t, certPath, keyPath, "one.example.com")
+
+	rec := &loadRecorder{}
+	w := NewFileSetWatcher(FileSet{CertPath: certPath, KeyPath: keyPath},
+		testPollInterval, rec.onLoad)
+	if w == nil {
+		t.Fatal("expected a watcher")
+	}
+	defer w.Close()
+
+	// the initial load is synchronous
+	if rec.count() != 1 {
+		t.Fatalf("expected 1 initial load, got %d", rec.count())
+	}
+	first := rec.last()
+	if first.Key != (FileSet{CertPath: certPath, KeyPath: keyPath}).Key() ||
+		first.SourceKind != SourceKindFile {
+		t.Errorf("unexpected initial entry: %+v", first)
+	}
+
+	// rotate in place via atomic rename, as certbot-style tooling does
+	nextCert, nextKey := filepath.Join(dir, "next.crt"), filepath.Join(dir, "next.key")
+	writePair(t, nextCert, nextKey, "two.example.com")
+	if err := os.Rename(nextKey, keyPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(nextCert, certPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 2 }) {
+		t.Fatal("rotation not detected")
+	}
+	last := rec.last()
+	if last.ContentHash == first.ContentHash {
+		t.Error("expected a different certificate after rotation")
+	}
+	if last.Certificate.Leaf.DNSNames[0] != "two.example.com" {
+		t.Errorf("unexpected rotated cert SAN: %s", last.Certificate.Leaf.DNSNames[0])
+	}
+}
+
+// TestFileSetWatcherPartialRotation verifies pair coherence: when the cert
+// file changes before the key file, the mismatched pair is never delivered;
+// the swap fires only once both halves are in place.
+func TestFileSetWatcherPartialRotation(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key")
+	writePair(t, certPath, keyPath, "one.example.com")
+
+	rec := &loadRecorder{}
+	w := NewFileSetWatcher(FileSet{CertPath: certPath, KeyPath: keyPath},
+		testPollInterval, rec.onLoad)
+	defer w.Close()
+
+	k2, c2, err := tlstest.GetTestKeyAndCertWithNames("two.example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// write only the new cert; the key on disk still matches the old cert
+	if err := os.WriteFile(certPath, c2, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(10 * testPollInterval)
+	if rec.count() != 1 {
+		t.Fatalf("mid-rotation partial state was delivered; loads = %d", rec.count())
+	}
+	// complete the rotation
+	if err := os.WriteFile(keyPath, k2, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 2 }) {
+		t.Fatal("completed rotation not detected")
+	}
+	if rec.last().Certificate.Leaf.DNSNames[0] != "two.example.com" {
+		t.Error("expected the completed rotation's certificate")
+	}
+}
+
+// TestFileSetWatcherCABundleChange verifies a change to only the CA bundle
+// member of the set re-fires the load callback.
+func TestFileSetWatcherCABundleChange(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key")
+	caPath := filepath.Join(dir, "ca.crt")
+	writePair(t, certPath, keyPath, "one.example.com")
+	if err := os.WriteFile(caPath, []byte("ca one\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := &loadRecorder{}
+	w := NewFileSetWatcher(
+		FileSet{CertPath: certPath, KeyPath: keyPath, CAPaths: []string{caPath}},
+		testPollInterval, rec.onLoad)
+	defer w.Close()
+
+	if err := os.WriteFile(caPath, []byte("ca two\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 2 }) {
+		t.Fatal("CA-bundle-only change not detected")
+	}
+}
+
+func TestFileSetWatcherDisabled(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := filepath.Join(dir, "tls.crt"), filepath.Join(dir, "tls.key")
+	writePair(t, certPath, keyPath, "one.example.com")
+	if w := NewFileSetWatcher(FileSet{CertPath: certPath, KeyPath: keyPath},
+		0, nil); w != nil {
+		t.Error("expected nil watcher for disabled interval")
+	}
+}

--- a/pkg/testutil/tls/tls.go
+++ b/pkg/testutil/tls/tls.go
@@ -19,6 +19,8 @@ package tls
 
 import (
 	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -56,6 +58,49 @@ func WriteTestKeyAndCert(isCA bool, keyPath, certPath string) error {
 	}
 
 	return nil
+}
+
+// GetTestKeyAndCertWithNames returns a self-signed test TLS key and
+// certificate bearing the provided DNS names (wildcards permitted) as its
+// Subject Alternative Names, using a fast ECDSA key
+func GetTestKeyAndCertWithNames(names ...string) ([]byte, []byte, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	notBefore := time.Now()
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, _ := rand.Int(rand.Reader, serialNumberLimit)
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			Organization: []string{"Trickster Test Certificate DO NOT USE"},
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		DNSNames:              names,
+	}
+	if len(names) > 0 {
+		template.Subject.CommonName = names[0]
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template,
+		&priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	certBuff := bytes.NewBuffer(nil)
+	pem.Encode(certBuff, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	privBytes, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, err
+	}
+	keyBuff := bytes.NewBuffer(nil)
+	pem.Encode(keyBuff, &pem.Block{Type: "PRIVATE KEY", Bytes: privBytes})
+	return keyBuff.Bytes(), certBuff.Bytes(), nil
 }
 
 // GetTestKeyAndCert returns a self-sign test TLS key and certificate

--- a/pkg/watchers/filesystem/filesystem.go
+++ b/pkg/watchers/filesystem/filesystem.go
@@ -1,0 +1,291 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package filesystem provides a watchers.Watcher using fsnotify plus a
+// content-comparing poll backstop; watches parent dirs for atomic renames.
+package filesystem
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
+	"github.com/trickstercache/trickster/v2/pkg/observability/logging/logger"
+	"github.com/trickstercache/trickster/v2/pkg/util/safego"
+	"github.com/trickstercache/trickster/v2/pkg/watchers"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// FailureThreshold consecutive failed checks before escalating to a WARN log.
+const FailureThreshold = 5
+
+// eventDebounce coalesces filesystem event bursts into one check.
+const eventDebounce = 250 * time.Millisecond
+
+// Options configures a filesystem Watcher
+type Options struct {
+	// Name identifies the Watcher in log events
+	Name string
+	// Paths is the set of files watched and delivered as one unit
+	Paths []string
+	// Interval is the backstop poll interval; it must be > 0
+	Interval time.Duration
+	// OnChange is called with Path-ordered contents when the set changes,
+	// including Start's initial read. An error rejects and retries later.
+	OnChange func(contents [][]byte) error
+	// OnReadError is optionally invoked when a check fails to read a file
+	OnReadError func(error)
+}
+
+// errors returned by New
+var (
+	ErrNilOptions      = errors.New("filesystem watcher: nil options")
+	ErrNoPaths         = errors.New("filesystem watcher: no paths to watch")
+	ErrInvalidInterval = errors.New("filesystem watcher: interval must be > 0")
+)
+
+// Watcher is a restartable filesystem watchers.Watcher. After Close, Start
+// resumes and delivers any missed content change via its initial check.
+type Watcher struct {
+	opts      Options
+	eventDirs []string
+
+	// lastApplied/consecutiveFailures: Start/Close exclusivity (Close waits
+	// for goroutine exit) makes access safe without additional locking
+	lastApplied         string
+	consecutiveFailures int
+
+	mtx     sync.Mutex
+	running bool
+	done    chan struct{}
+	stopped chan struct{}
+	// events is nil when fsnotify is unavailable; detection is poll-only
+	events *fsnotify.Watcher
+}
+
+var _ watchers.Watcher = &Watcher{}
+
+// New returns a Watcher for Options without starting it; call Start to begin.
+func New(o *Options) (*Watcher, error) {
+	if o == nil {
+		return nil, ErrNilOptions
+	}
+	if len(o.Paths) == 0 {
+		return nil, ErrNoPaths
+	}
+	if o.Interval <= 0 {
+		return nil, ErrInvalidInterval
+	}
+	w := &Watcher{opts: *o}
+	w.opts.Paths = slices.Clone(o.Paths)
+	for _, path := range w.opts.Paths {
+		dir := filepath.Dir(path)
+		if !slices.Contains(w.eventDirs, dir) {
+			w.eventDirs = append(w.eventDirs, dir)
+		}
+	}
+	return w, nil
+}
+
+// StartNew returns a started Watcher. OnChange may run before StartNew returns
+// if content is currently readable and accepted.
+func StartNew(o *Options) (*Watcher, error) {
+	w, err := New(o)
+	if err != nil {
+		return nil, err
+	}
+	w.Start()
+	return w, nil
+}
+
+// Start begins or resumes watching. The initial check runs synchronously and
+// may deliver OnChange before Start returns. No-op if already running.
+func (w *Watcher) Start() {
+	w.mtx.Lock()
+	if w.running {
+		w.mtx.Unlock()
+		return
+	}
+	prevStopped := w.stopped
+	w.running = true
+	w.done = make(chan struct{})
+	w.stopped = make(chan struct{})
+	w.mtx.Unlock()
+	if prevStopped != nil {
+		// wait for previous cycle's goroutine before overlapping a restart
+		<-prevStopped
+	}
+	w.check()
+	w.startEventWatches()
+	safego.Go(func(r any, stack []byte) {
+		logger.Error("filesystem watcher goroutine panic", logging.Pairs{
+			"name": w.opts.Name, "panic": r, "stack": string(stack),
+		})
+	}, w.run)
+}
+
+// Close stops the Watcher and waits for its goroutine to exit. No-op if stopped.
+func (w *Watcher) Close() {
+	w.mtx.Lock()
+	if !w.running {
+		w.mtx.Unlock()
+		return
+	}
+	w.running = false
+	done, stopped := w.done, w.stopped
+	w.mtx.Unlock()
+	close(done)
+	<-stopped
+}
+
+// startEventWatches best-effort arms fsnotify on parent dirs; failure is poll-only.
+func (w *Watcher) startEventWatches() {
+	ew, err := fsnotify.NewWatcher()
+	if err != nil {
+		logger.Debug("fsnotify unavailable; filesystem watcher is poll-only",
+			logging.Pairs{"name": w.opts.Name, "detail": err.Error()})
+		return
+	}
+	added := 0
+	for _, dir := range w.eventDirs {
+		if err := ew.Add(dir); err != nil {
+			logger.Debug("unable to event-watch directory",
+				logging.Pairs{"name": w.opts.Name, "dir": dir, "detail": err.Error()})
+			continue
+		}
+		added++
+	}
+	if added == 0 {
+		ew.Close()
+		return
+	}
+	w.events = ew
+}
+
+// rearmEventWatches re-adds dropped directory watches on the poll cadence.
+func (w *Watcher) rearmEventWatches() {
+	if w.events == nil {
+		return
+	}
+	watched := w.events.WatchList()
+	for _, dir := range w.eventDirs {
+		if !slices.Contains(watched, dir) {
+			_ = w.events.Add(dir) // best-effort; retried on the next tick
+		}
+	}
+}
+
+func (w *Watcher) run() {
+	defer close(w.stopped)
+	ticker := time.NewTicker(w.opts.Interval)
+	defer ticker.Stop()
+	var eventC chan fsnotify.Event
+	var errC chan error
+	if events := w.events; events != nil {
+		defer func() {
+			events.Close()
+			w.events = nil
+		}()
+		eventC = events.Events
+		errC = events.Errors
+	}
+	var debounce *time.Timer
+	var debounceC <-chan time.Time
+	defer func() {
+		if debounce != nil {
+			debounce.Stop()
+		}
+	}()
+	for {
+		select {
+		case <-w.done:
+			return
+		case <-ticker.C:
+			w.check()
+			w.rearmEventWatches()
+		case <-debounceC:
+			debounceC = nil
+			w.check()
+		case _, ok := <-eventC:
+			if !ok {
+				eventC = nil
+				continue
+			}
+			// any watched-dir event schedules a content-comparing check
+			if debounceC == nil {
+				debounce = time.NewTimer(eventDebounce)
+				debounceC = debounce.C
+			}
+		case err, ok := <-errC:
+			if !ok {
+				errC = nil
+				continue
+			}
+			logger.Debug("filesystem watcher event error", logging.Pairs{
+				"name": w.opts.Name, "detail": err.Error(),
+			})
+		}
+	}
+}
+
+// check reads the set and applies OnChange on content change. Read errors and
+// rejections leave last-accepted content in effect; deletion is a read failure.
+func (w *Watcher) check() {
+	contents := make([][]byte, len(w.opts.Paths))
+	hash := sha256.New()
+	for i, path := range w.opts.Paths {
+		b, err := os.ReadFile(path) // #nosec G703 -- paths are provided by the operator-configured consumer
+		if err != nil {
+			if w.opts.OnReadError != nil {
+				w.opts.OnReadError(err)
+			}
+			w.recordFailure("filesystem watcher unable to read watched file", err)
+			return
+		}
+		contents[i] = b
+		hash.Write(b)
+	}
+	setHash := hex.EncodeToString(hash.Sum(nil))
+	if setHash == w.lastApplied {
+		w.consecutiveFailures = 0
+		return
+	}
+	if w.opts.OnChange != nil {
+		if err := w.opts.OnChange(contents); err != nil {
+			w.recordFailure("filesystem watcher change rejected", err)
+			return
+		}
+	}
+	w.lastApplied = setHash
+	w.consecutiveFailures = 0
+}
+
+func (w *Watcher) recordFailure(event string, err error) {
+	w.consecutiveFailures++
+	if w.consecutiveFailures == FailureThreshold {
+		logger.Warn(event, logging.Pairs{
+			"name": w.opts.Name, "detail": err.Error(),
+			"consecutiveFailures": w.consecutiveFailures,
+		})
+	}
+}

--- a/pkg/watchers/filesystem/filesystem_test.go
+++ b/pkg/watchers/filesystem/filesystem_test.go
@@ -1,0 +1,445 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filesystem
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+const testPollInterval = 10 * time.Millisecond
+
+type changeRecorder struct {
+	mtx      sync.Mutex
+	accepted [][][]byte
+	// reject causes OnChange to reject observations whose members are not
+	// all identical, simulating a consumer's coherence validation
+	reject bool
+}
+
+var errIncoherent = errors.New("file set members do not match")
+
+func (r *changeRecorder) onChange(contents [][]byte) error {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	if r.reject {
+		for _, c := range contents[1:] {
+			if !bytes.Equal(c, contents[0]) {
+				return errIncoherent
+			}
+		}
+	}
+	r.accepted = append(r.accepted, contents)
+	return nil
+}
+
+func (r *changeRecorder) count() int {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	return len(r.accepted)
+}
+
+func (r *changeRecorder) last() [][]byte {
+	r.mtx.Lock()
+	defer r.mtx.Unlock()
+	if len(r.accepted) == 0 {
+		return nil
+	}
+	return r.accepted[len(r.accepted)-1]
+}
+
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return true
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	return condition()
+}
+
+func writeFiles(t *testing.T, content string, paths ...string) {
+	t.Helper()
+	for _, path := range paths {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func testPaths(t *testing.T) (string, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	a, b := filepath.Join(dir, "a.txt"), filepath.Join(dir, "b.txt")
+	writeFiles(t, "one", a, b)
+	return dir, a, b
+}
+
+func TestNewValidation(t *testing.T) {
+	if _, err := New(nil); !errors.Is(err, ErrNilOptions) {
+		t.Errorf("expected ErrNilOptions, got %v", err)
+	}
+	if _, err := New(&Options{Interval: time.Second}); !errors.Is(err, ErrNoPaths) {
+		t.Errorf("expected ErrNoPaths, got %v", err)
+	}
+	if _, err := New(&Options{Paths: []string{"x"}}); !errors.Is(err, ErrInvalidInterval) {
+		t.Errorf("expected ErrInvalidInterval, got %v", err)
+	}
+	if _, err := StartNew(&Options{Paths: []string{"x"}}); !errors.Is(err, ErrInvalidInterval) {
+		t.Errorf("expected ErrInvalidInterval from StartNew, got %v", err)
+	}
+}
+
+// TestNewDoesNotStart verifies that New does not begin watching until Start
+// is called, while StartNew delivers the initial content synchronously
+func TestNewDoesNotStart(t *testing.T) {
+	_, a, b := testPaths(t)
+	rec := &changeRecorder{}
+	w, err := New(&Options{Name: "test", Paths: []string{a, b},
+		Interval: testPollInterval, OnChange: rec.onChange})
+	if err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * testPollInterval)
+	if rec.count() != 0 {
+		t.Fatalf("watcher delivered before Start; count = %d", rec.count())
+	}
+	w.Start()
+	defer w.Close()
+	if rec.count() != 1 {
+		t.Fatalf("expected 1 initial delivery after Start, got %d", rec.count())
+	}
+	w.Start() // Start on a running watcher is a no-op
+	if rec.count() != 1 {
+		t.Fatalf("second Start re-delivered; count = %d", rec.count())
+	}
+}
+
+func TestDetectsChange(t *testing.T) {
+	_, a, b := testPaths(t)
+	rec := &changeRecorder{}
+	w, err := StartNew(&Options{Name: "test", Paths: []string{a, b},
+		Interval: testPollInterval, OnChange: rec.onChange})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	if rec.count() != 1 {
+		t.Fatalf("expected 1 initial delivery, got %d", rec.count())
+	}
+	// change via atomic rename, as rotation tooling does
+	dir := filepath.Dir(a)
+	next := filepath.Join(dir, "next.txt")
+	writeFiles(t, "two", next, b)
+	if err := os.Rename(next, a); err != nil {
+		t.Fatal(err)
+	}
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 2 }) {
+		t.Fatal("change not detected")
+	}
+	if string(rec.last()[0]) != "two" {
+		t.Errorf("unexpected content delivered: %q", rec.last()[0])
+	}
+}
+
+// TestRejectedChangeIsRetried verifies the OnChange rejection contract: a
+// rejected observation (e.g. a consumer's mid-rotation coherence check) is
+// not recorded as applied and is re-delivered once the content settles
+func TestRejectedChangeIsRetried(t *testing.T) {
+	_, a, b := testPaths(t)
+	rec := &changeRecorder{reject: true}
+	w, err := StartNew(&Options{Name: "test", Paths: []string{a, b},
+		Interval: testPollInterval, OnChange: rec.onChange})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	// write only half the set; the incoherent state must never be accepted
+	writeFiles(t, "two", a)
+	time.Sleep(10 * testPollInterval)
+	if rec.count() != 1 {
+		t.Fatalf("incoherent state was accepted; count = %d", rec.count())
+	}
+	// complete the change
+	writeFiles(t, "two", b)
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 2 }) {
+		t.Fatal("settled change not delivered")
+	}
+	if string(rec.last()[0]) != "two" || string(rec.last()[1]) != "two" {
+		t.Errorf("unexpected content delivered: %q %q", rec.last()[0], rec.last()[1])
+	}
+}
+
+// TestSymlinkSwap simulates the kubelet AtomicWriter layout used by
+// Kubernetes secret and projected volumes, where file paths are symlinks
+// through a ..data directory that is swapped atomically. Content comparison
+// must see through the swap even though the top-level path's inode never
+// changes.
+func TestSymlinkSwap(t *testing.T) {
+	dir := t.TempDir()
+	dataDir1 := filepath.Join(dir, "..data_1")
+	dataDir2 := filepath.Join(dir, "..data_2")
+	for _, d := range []string{dataDir1, dataDir2} {
+		if err := os.Mkdir(d, 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFiles(t, "one", filepath.Join(dataDir1, "a.txt"))
+	writeFiles(t, "two", filepath.Join(dataDir2, "a.txt"))
+	dataLink := filepath.Join(dir, "..data")
+	if err := os.Symlink(dataDir1, dataLink); err != nil {
+		t.Fatal(err)
+	}
+	a := filepath.Join(dir, "a.txt")
+	if err := os.Symlink(filepath.Join(dataLink, "a.txt"), a); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := &changeRecorder{}
+	w, err := StartNew(&Options{Name: "test", Paths: []string{a},
+		Interval: testPollInterval, OnChange: rec.onChange})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	if rec.count() != 1 {
+		t.Fatalf("expected 1 initial delivery, got %d", rec.count())
+	}
+
+	// atomic symlink swap: point ..data at the new payload via rename
+	tmpLink := filepath.Join(dir, "..data_tmp")
+	if err := os.Symlink(dataDir2, tmpLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(tmpLink, dataLink); err != nil {
+		t.Fatal(err)
+	}
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 2 }) {
+		t.Fatal("symlink-swap change not detected")
+	}
+	if string(rec.last()[0]) != "two" {
+		t.Errorf("unexpected content delivered: %q", rec.last()[0])
+	}
+}
+
+// TestDeletionAndRecovery verifies that deletion is a persistent read
+// failure rather than a delivery, the loop survives past FailureThreshold,
+// OnReadError is invoked, and watching resumes when the files return
+func TestDeletionAndRecovery(t *testing.T) {
+	_, a, b := testPaths(t)
+	rec := &changeRecorder{}
+	var readErrs int
+	var readErrsMtx sync.Mutex
+	w, err := StartNew(&Options{Name: "test", Paths: []string{a, b},
+		Interval: testPollInterval, OnChange: rec.onChange,
+		OnReadError: func(error) {
+			readErrsMtx.Lock()
+			readErrs++
+			readErrsMtx.Unlock()
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	if err := os.Remove(a); err != nil {
+		t.Fatal(err)
+	}
+	// enough ticks to exceed FailureThreshold; loop must survive
+	time.Sleep(time.Duration(FailureThreshold+3) * testPollInterval)
+	if rec.count() != 1 {
+		t.Fatalf("deletion should not deliver; count = %d", rec.count())
+	}
+	readErrsMtx.Lock()
+	sawErrs := readErrs
+	readErrsMtx.Unlock()
+	if sawErrs == 0 {
+		t.Error("expected OnReadError invocations for the deleted file")
+	}
+
+	writeFiles(t, "two", a, b)
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 2 }) {
+		t.Fatal("watcher did not recover after files returned")
+	}
+}
+
+// TestEventDriven verifies the fsnotify fast path: with a poll interval far
+// too long to explain detection, a change must still be picked up promptly
+// via filesystem events. (On filesystems without event support the watcher
+// silently degrades to poll-only, which the other tests cover.)
+func TestEventDriven(t *testing.T) {
+	_, a, b := testPaths(t)
+	rec := &changeRecorder{}
+	w, err := StartNew(&Options{Name: "test", Paths: []string{a, b},
+		Interval: time.Hour, OnChange: rec.onChange})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	if w.events == nil {
+		t.Skip("fsnotify unavailable on this filesystem; poll-only covered elsewhere")
+	}
+	writeFiles(t, "two", a, b)
+	if !waitFor(t, 5*time.Second, func() bool { return rec.count() >= 2 }) {
+		t.Fatal("change not detected via filesystem events")
+	}
+}
+
+// TestRestart verifies Close followed by Start: the restarted watcher
+// delivers changes that occurred while it was stopped, keeps detecting
+// subsequent changes, and does not re-deliver unchanged content
+func TestRestart(t *testing.T) {
+	_, a, b := testPaths(t)
+	rec := &changeRecorder{}
+	w, err := StartNew(&Options{Name: "test", Paths: []string{a, b},
+		Interval: testPollInterval, OnChange: rec.onChange})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.count() != 1 {
+		t.Fatalf("expected 1 initial delivery, got %d", rec.count())
+	}
+
+	w.Close()
+	w.Close() // Close on a stopped watcher is a no-op
+
+	// a restart with unchanged content must not re-deliver
+	w.Start()
+	if rec.count() != 1 {
+		t.Fatalf("restart re-delivered unchanged content; count = %d", rec.count())
+	}
+	w.Close()
+
+	// a change made while stopped is delivered by the next Start's initial check
+	writeFiles(t, "two", a, b)
+	time.Sleep(5 * testPollInterval)
+	if rec.count() != 1 {
+		t.Fatalf("stopped watcher delivered; count = %d", rec.count())
+	}
+	w.Start()
+	if rec.count() != 2 || string(rec.last()[0]) != "two" {
+		t.Fatalf("restart did not deliver the change made while stopped; count = %d", rec.count())
+	}
+
+	// the restarted watcher keeps detecting live changes
+	writeFiles(t, "three", a, b)
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 3 }) {
+		t.Fatal("restarted watcher did not detect a live change")
+	}
+	w.Close()
+}
+
+// TestDirectoryRecreationRearm verifies that when a watched directory is
+// removed and recreated (dropping its fsnotify watch), the timed poll both
+// keeps detection alive and re-arms the event watch
+func TestDirectoryRecreationRearm(t *testing.T) {
+	base := t.TempDir()
+	dir := filepath.Join(base, "sub")
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	a := filepath.Join(dir, "a.txt")
+	writeFiles(t, "one", a)
+
+	rec := &changeRecorder{}
+	w, err := StartNew(&Options{Name: "test", Paths: []string{a},
+		Interval: testPollInterval, OnChange: rec.onChange})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	if rec.count() != 1 {
+		t.Fatalf("expected 1 initial delivery, got %d", rec.count())
+	}
+
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(5 * testPollInterval)
+	if err := os.Mkdir(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeFiles(t, "two", a)
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 2 }) {
+		t.Fatal("watcher did not recover after directory recreation")
+	}
+	if string(rec.last()[0]) != "two" {
+		t.Errorf("unexpected content delivered: %q", rec.last()[0])
+	}
+}
+
+// TestEventWatchUnavailableDirs verifies graceful poll-only degradation when
+// no watched file's directory can be event-watched (e.g. it does not exist
+// yet), and that polling delivers once the files appear
+func TestEventWatchUnavailableDirs(t *testing.T) {
+	base := t.TempDir()
+	a := filepath.Join(base, "missing", "a.txt")
+	rec := &changeRecorder{}
+	w, err := StartNew(&Options{Name: "test", Paths: []string{a},
+		Interval: testPollInterval, OnChange: rec.onChange})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	if w.events != nil {
+		t.Error("expected poll-only mode when no directory can be event-watched")
+	}
+	if rec.count() != 0 {
+		t.Fatalf("expected no delivery for unreadable set, got %d", rec.count())
+	}
+	if err := os.Mkdir(filepath.Dir(a), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeFiles(t, "one", a)
+	if !waitFor(t, 3*time.Second, func() bool { return rec.count() >= 1 }) {
+		t.Fatal("poll-only watcher did not deliver once the file appeared")
+	}
+}
+
+func TestLifecycleNoLeaks(t *testing.T) {
+	_, a, b := testPaths(t)
+	before := runtime.NumGoroutine()
+	ws := make([]*Watcher, 0, 8)
+	for range 8 {
+		w, err := StartNew(&Options{Name: "test", Paths: []string{a, b},
+			Interval: testPollInterval})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ws = append(ws, w)
+	}
+	// exercise a restart cycle on one of them before teardown
+	ws[0].Close()
+	ws[0].Start()
+	for _, w := range ws {
+		w.Close()
+	}
+	if !waitFor(t, 3*time.Second, func() bool {
+		return runtime.NumGoroutine() <= before
+	}) {
+		t.Errorf("goroutine leak: before=%d after=%d", before, runtime.NumGoroutine())
+	}
+}

--- a/pkg/watchers/watchers.go
+++ b/pkg/watchers/watchers.go
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package watchers defines the generic interface for change monitors that
+// observe an external source (e.g. files on disk) and notify a consumer when
+// its content changes. Implementations live in subpackages (e.g.
+// watchers/filesystem); consumers supply what to watch and how to react.
+package watchers
+
+// Watcher is a monitor for out-of-band changes to an external source.
+// Implementations are expected to be restartable: Start after Close begins
+// watching again, and any changes that occurred while stopped are observed
+// on the next start.
+type Watcher interface {
+	// Start begins (or resumes) watching. It is a no-op if the Watcher is
+	// already running.
+	Start()
+	// Close stops watching and waits for the watch goroutine to exit. It is
+	// a no-op if the Watcher is not running.
+	Close()
+}


### PR DESCRIPTION
## Description
<!-- Describe changes and the problem solved -->
This enables Trickster to automatically monitor changes in TLS certificate files referenced in the Trickster Config, and reload/refresh those certs dynamically without dropping connections or restarting the listener.  This already happened on config reload, so this change just adds a separate watcher for TLS cert reload, allowing cert updates even when the underlying config doesn't change.  The Watcher interface and FileWatcher implementations are reusable in other areas of the project as needed.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [ ] Bug fix
- - [x] New feature
- - [ ] Optimization
- - [x] Test coverage
- - [x] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
