### PR TITLE
refactor: replace external dns client

### DIFF
--- a/docs/developer/discovery-providers.md
+++ b/docs/developer/discovery-providers.md
@@ -106,7 +106,7 @@ Fill `discovery.Member` as completely as your source allows:
    [pkg/discovery/registry](../../pkg/discovery/registry/registry.go)'s
    `SupportedProviders` map.
 6. **Test** without network dependencies: an in-process fake of your
-   source (client-go fake clientset, an in-process miekg/dns server, a
+   source (client-go fake clientset, `pkg/testutil/dnsserver`, a
    temp dir). Cover: initial snapshot, add/remove transitions, the
    failure-keeps-last-good path, emit-on-change suppression, and
    unsubscribe/Stop termination (no goroutine leaks — the shared suite in

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/influxdata/influxdb v1.13.0
 	github.com/influxdata/influxql v1.4.1
 	github.com/klauspost/compress v1.19.2
-	github.com/miekg/dns v1.1.73
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/common v0.70.1

--- a/go.sum
+++ b/go.sum
@@ -797,8 +797,6 @@ github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhg
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgechev/revive v1.15.0 h1:vJ0HzSBzfNyPbHKolgiFjHxLek9KUijhqh42yGoqZ8Q=
 github.com/mgechev/revive v1.15.0/go.mod h1:LlAKO3QQe9OJ0pVZzI2GPa8CbXGZ/9lNpCGvK4T/a8A=
-github.com/miekg/dns v1.1.73 h1:uhT8nJxmTrPJYClxVxTCX+CVn6qnzSiybRk72Z6DgrE=
-github.com/miekg/dns v1.1.73/go.mod h1:RW2Obtfd5NZHvOFe3zYG0W8koWOQtAzyHaLo8vASBuQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -92,7 +92,6 @@ require (
 	github.com/lib/pq v1.12.3 // indirect
 	github.com/lmittmann/tint v1.1.3 // indirect
 	github.com/mattn/go-isatty v0.0.21 // indirect
-	github.com/miekg/dns v1.1.73 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/integration/go.sum
+++ b/integration/go.sum
@@ -521,8 +521,6 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-isatty v0.0.21 h1:xYae+lCNBP7QuW4PUnNG61ffM4hVIfm+zUzDuSzYLGs=
 github.com/mattn/go-isatty v0.0.21/go.mod h1:ZXfXG4SQHsB/w3ZeOYbR0PrPwLy+n6xiMrJlRFqopa4=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/miekg/dns v1.1.73 h1:uhT8nJxmTrPJYClxVxTCX+CVn6qnzSiybRk72Z6DgrE=
-github.com/miekg/dns v1.1.73/go.mod h1:RW2Obtfd5NZHvOFe3zYG0W8koWOQtAzyHaLo8vASBuQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
 github.com/mitchellh/go-testing-interface v0.0.0-20171004221916-a61a99592b77/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=

--- a/pkg/discovery/dns/dns.go
+++ b/pkg/discovery/dns/dns.go
@@ -43,11 +43,10 @@ import (
 	"github.com/trickstercache/trickster/v2/pkg/discovery"
 	do "github.com/trickstercache/trickster/v2/pkg/discovery/options"
 	"github.com/trickstercache/trickster/v2/pkg/discovery/providers"
+	dnsclient "github.com/trickstercache/trickster/v2/pkg/dns/client"
 	"github.com/trickstercache/trickster/v2/pkg/observability/keys"
 	"github.com/trickstercache/trickster/v2/pkg/observability/logging"
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
-
-	"github.com/miekg/dns"
 )
 
 // ErrStopped aliases discovery.ErrStopped for callers of this package
@@ -194,7 +193,7 @@ func (s *subscription) resolve(ctx context.Context) (discovery.Snapshot, time.Du
 
 // resolveSRV maps the highest-priority tier of the SRV answer onto members
 func (s *subscription) resolveSRV(ctx context.Context) (discovery.Snapshot, time.Duration, error) {
-	answers, ttl, err := s.p.res.lookupSRV(ctx, dns.Fqdn(s.q.SRVName))
+	answers, ttl, err := s.p.res.lookupSRV(ctx, dnsclient.Fqdn(s.q.SRVName))
 	if err != nil {
 		return nil, 0, err
 	}
@@ -227,7 +226,7 @@ func (s *subscription) resolveSRV(ctx context.Context) (discovery.Snapshot, time
 // resolveA maps each A/AAAA answer onto a member with the query's fixed
 // port and scheme
 func (s *subscription) resolveA(ctx context.Context) (discovery.Snapshot, time.Duration, error) {
-	ips, ttl, err := s.p.res.lookupIP(ctx, dns.Fqdn(s.q.Hostname))
+	ips, ttl, err := s.p.res.lookupIP(ctx, dnsclient.Fqdn(s.q.Hostname))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/discovery/dns/dns_test.go
+++ b/pkg/discovery/dns/dns_test.go
@@ -19,73 +19,19 @@ package dns
 import (
 	"context"
 	"net"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/trickstercache/trickster/v2/pkg/discovery"
 	do "github.com/trickstercache/trickster/v2/pkg/discovery/options"
+	dnsclient "github.com/trickstercache/trickster/v2/pkg/dns/client"
 	"github.com/trickstercache/trickster/v2/pkg/observability/metrics"
 	"github.com/trickstercache/trickster/v2/pkg/parsing/timeconv"
+	"github.com/trickstercache/trickster/v2/pkg/testutil/dnsserver"
 
-	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 )
-
-// recordStore is a mutable in-process DNS zone for tests
-type recordStore struct {
-	mtx  sync.Mutex
-	rrs  map[uint16][]dns.RR // by qtype
-	fail bool                // respond SERVFAIL when set
-}
-
-func (r *recordStore) setFail(fail bool) {
-	r.mtx.Lock()
-	r.fail = fail
-	r.mtx.Unlock()
-}
-
-func (r *recordStore) set(qtype uint16, records ...string) {
-	rrs := make([]dns.RR, len(records))
-	for i, s := range records {
-		rr, err := dns.NewRR(s)
-		if err != nil {
-			panic(err)
-		}
-		rrs[i] = rr
-	}
-	r.mtx.Lock()
-	if r.rrs == nil {
-		r.rrs = make(map[uint16][]dns.RR)
-	}
-	r.rrs[qtype] = rrs
-	r.mtx.Unlock()
-}
-
-func (r *recordStore) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
-	m := new(dns.Msg)
-	m.SetReply(req)
-	r.mtx.Lock()
-	if r.fail {
-		m.Rcode = dns.RcodeServerFailure
-	} else if len(req.Question) > 0 {
-		m.Answer = append(m.Answer, r.rrs[req.Question[0].Qtype]...)
-	}
-	r.mtx.Unlock()
-	_ = w.WriteMsg(m)
-}
-
-// startTestDNS runs an in-process DNS server and returns its address
-func startTestDNS(t *testing.T, store *recordStore) string {
-	t.Helper()
-	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	srv := &dns.Server{PacketConn: pc, Handler: store}
-	go func() { _ = srv.ActivateAndServe() }()
-	t.Cleanup(func() { _ = srv.Shutdown() })
-	return pc.LocalAddr().String()
-}
 
 type snapCollector struct {
 	ch chan discovery.Snapshot
@@ -129,16 +75,16 @@ func testOptions(server string, interval time.Duration) *do.Options {
 }
 
 func TestSRVDiscovery(t *testing.T) {
-	store := &recordStore{}
-	store.set(dns.TypeSRV,
-		"_prom._tcp.example.com. 0 IN SRV 10 1 9090 prom-a.example.com.",
-		"_prom._tcp.example.com. 0 IN SRV 10 3 9090 prom-b.example.com.",
+	srv := dnsserver.New(t)
+	const zone = "_prom._tcp.example.com."
+	srv.Set(dnsclient.TypeSRV,
+		dnsserver.SRV(zone, 0, 10, 1, 9090, "prom-a.example.com."),
+		dnsserver.SRV(zone, 0, 10, 3, 9090, "prom-b.example.com."),
 		// lower tier (higher priority value): standby, excluded in v1
-		"_prom._tcp.example.com. 0 IN SRV 20 1 9090 prom-standby.example.com.",
+		dnsserver.SRV(zone, 0, 20, 1, 9090, "prom-standby.example.com."),
 	)
-	addr := startTestDNS(t, store)
 
-	d, err := NewSRV("test-dns", testOptions(addr, 25*time.Millisecond))
+	d, err := NewSRV("test-dns", testOptions(srv.Addr(), 25*time.Millisecond))
 	require.NoError(t, err)
 	require.NoError(t, d.Start(t.Context()))
 	defer d.Stop()
@@ -159,25 +105,24 @@ func TestSRVDiscovery(t *testing.T) {
 	require.Equal(t, "10", snap[0].Labels["priority"])
 
 	// record mutation is picked up on the next poll
-	store.set(dns.TypeSRV,
-		"_prom._tcp.example.com. 0 IN SRV 10 1 9090 prom-b.example.com.")
+	srv.Set(dnsclient.TypeSRV,
+		dnsserver.SRV(zone, 0, 10, 1, 9090, "prom-b.example.com."))
 	snap = col.next(t)
 	require.Len(t, snap, 1)
 	require.Equal(t, "prom-b.example.com", snap[0].Name)
 }
 
 func TestADiscovery(t *testing.T) {
-	store := &recordStore{}
-	store.set(dns.TypeA,
-		"prom.example.com. 0 IN A 10.0.0.1",
-		"prom.example.com. 0 IN A 10.0.0.2",
+	srv := dnsserver.New(t)
+	srv.Set(dnsclient.TypeA,
+		dnsserver.A("prom.example.com.", 0, "10.0.0.1"),
+		dnsserver.A("prom.example.com.", 0, "10.0.0.2"),
 	)
-	store.set(dns.TypeAAAA,
-		"prom.example.com. 0 IN AAAA 2001:db8::1",
+	srv.Set(dnsclient.TypeAAAA,
+		dnsserver.AAAA("prom.example.com.", 0, "2001:db8::1"),
 	)
-	addr := startTestDNS(t, store)
 
-	d, err := NewA("test-dns", testOptions(addr, 25*time.Millisecond))
+	d, err := NewA("test-dns", testOptions(srv.Addr(), 25*time.Millisecond))
 	require.NoError(t, err)
 	require.NoError(t, d.Start(t.Context()))
 	defer d.Stop()
@@ -201,19 +146,41 @@ func TestADiscovery(t *testing.T) {
 	require.Contains(t, addrs, "[2001:db8::1]:9090")
 
 	// rotation: one address replaced
-	store.set(dns.TypeA, "prom.example.com. 0 IN A 10.0.0.3")
-	store.set(dns.TypeAAAA)
+	srv.Set(dnsclient.TypeA, dnsserver.A("prom.example.com.", 0, "10.0.0.3"))
+	srv.Set(dnsclient.TypeAAAA)
 	snap = col.next(t)
 	require.Len(t, snap, 1)
 	require.Equal(t, "10.0.0.3:9090", snap[0].Address)
 }
 
-func TestTTLFloor(t *testing.T) {
-	store := &recordStore{}
-	store.set(dns.TypeA, "prom.example.com. 3600 IN A 10.0.0.1")
-	addr := startTestDNS(t, store)
+// TestTruncatedAnswer proves the UDP-to-TCP retry keeps discovery working
+// when an answer does not fit in a datagram
+func TestTruncatedAnswer(t *testing.T) {
+	srv := dnsserver.New(t)
+	srv.Set(dnsclient.TypeA, dnsserver.A("prom.example.com.", 0, "10.0.0.1"))
+	srv.SetTruncate(true)
 
-	d, err := NewA("test-dns", testOptions(addr, 25*time.Millisecond))
+	d, err := NewA("test-dns", testOptions(srv.Addr(), 25*time.Millisecond))
+	require.NoError(t, err)
+	require.NoError(t, d.Start(t.Context()))
+	defer d.Stop()
+
+	col := newSnapCollector()
+	unsub, err := d.Subscribe(&do.Query{
+		Hostname: "prom.example.com", Port: "80"}, col.handle)
+	require.NoError(t, err)
+	defer unsub()
+
+	snap := col.next(t)
+	require.Len(t, snap, 1)
+	require.Equal(t, "10.0.0.1:80", snap[0].Address)
+}
+
+func TestTTLFloor(t *testing.T) {
+	srv := dnsserver.New(t)
+	srv.Set(dnsclient.TypeA, dnsserver.A("prom.example.com.", 3600, "10.0.0.1"))
+
+	d, err := NewA("test-dns", testOptions(srv.Addr(), 25*time.Millisecond))
 	require.NoError(t, err)
 	require.NoError(t, d.Start(t.Context()))
 	defer d.Stop()
@@ -227,16 +194,15 @@ func TestTTLFloor(t *testing.T) {
 	require.Len(t, col.next(t), 1)
 	// with a 1h TTL, the 25ms interval must NOT re-resolve; a record
 	// mutation therefore goes unseen within the test window
-	store.set(dns.TypeA, "prom.example.com. 3600 IN A 10.0.0.9")
+	srv.Set(dnsclient.TypeA, dnsserver.A("prom.example.com.", 3600, "10.0.0.9"))
 	col.expectNone(t, 400*time.Millisecond)
 }
 
 func TestResolutionFailureKeepsLastGood(t *testing.T) {
-	store := &recordStore{}
-	store.set(dns.TypeA, "prom.example.com. 0 IN A 10.0.0.1")
-	addr := startTestDNS(t, store)
+	srv := dnsserver.New(t)
+	srv.Set(dnsclient.TypeA, dnsserver.A("prom.example.com.", 0, "10.0.0.1"))
 
-	d, err := NewA("test-dns", testOptions(addr, 25*time.Millisecond))
+	d, err := NewA("test-dns", testOptions(srv.Addr(), 25*time.Millisecond))
 	require.NoError(t, err)
 	require.NoError(t, d.Start(t.Context()))
 	defer d.Stop()
@@ -254,22 +220,22 @@ func TestResolutionFailureKeepsLastGood(t *testing.T) {
 	// refresh-errors metric
 	errs0 := testutil.ToFloat64(metrics.DiscoveryRefreshErrors.
 		WithLabelValues("test-dns", "dns_a"))
-	store.setFail(true)
+	srv.SetRCode(dnsclient.RCodeServerFailure)
 	col.expectNone(t, 300*time.Millisecond)
 	require.Greater(t, testutil.ToFloat64(metrics.DiscoveryRefreshErrors.
 		WithLabelValues("test-dns", "dns_a")), errs0)
 
 	// on recovery, the (changed) answer is emitted again
-	store.setFail(false)
-	store.set(dns.TypeA, "prom.example.com. 0 IN A 10.0.0.2")
+	srv.SetRCode(dnsclient.RCodeSuccess)
+	srv.Set(dnsclient.TypeA, dnsserver.A("prom.example.com.", 0, "10.0.0.2"))
 	snap := col.next(t)
 	require.Len(t, snap, 1)
 	require.Equal(t, "10.0.0.2:80", snap[0].Address)
 
 	// an authoritative empty answer is different: it is a valid membership
 	// and empties the pool's discovered set
-	store.set(dns.TypeA)
-	store.set(dns.TypeAAAA)
+	srv.Set(dnsclient.TypeA)
+	srv.Set(dnsclient.TypeAAAA)
 	require.Empty(t, col.next(t))
 }
 
@@ -287,9 +253,8 @@ func TestNewDiscovererErrors(t *testing.T) {
 }
 
 func TestSubscribeLifecycle(t *testing.T) {
-	store := &recordStore{}
-	addr := startTestDNS(t, store)
-	d, err := NewSRV("test-dns", testOptions(addr, 25*time.Millisecond))
+	srv := dnsserver.New(t)
+	d, err := NewSRV("test-dns", testOptions(srv.Addr(), 25*time.Millisecond))
 	require.NoError(t, err)
 
 	// subscribing before Start launches on Start
@@ -311,18 +276,17 @@ func TestSubscribeLifecycle(t *testing.T) {
 // TestStdResolver exercises the stdlib-resolver fallback against the
 // in-process DNS server via a custom Dial
 func TestStdResolver(t *testing.T) {
-	store := &recordStore{}
-	store.set(dns.TypeSRV,
-		"_prom._tcp.example.com. 30 IN SRV 10 2 9090 prom-a.example.com.")
-	store.set(dns.TypeA, "prom.example.com. 30 IN A 10.0.0.1")
-	store.set(dns.TypeAAAA)
-	addr := startTestDNS(t, store)
+	srv := dnsserver.New(t)
+	srv.Set(dnsclient.TypeSRV, dnsserver.SRV("_prom._tcp.example.com.", 30,
+		10, 2, 9090, "prom-a.example.com."))
+	srv.Set(dnsclient.TypeA, dnsserver.A("prom.example.com.", 30, "10.0.0.1"))
+	srv.Set(dnsclient.TypeAAAA)
 
 	r := &stdResolver{r: &net.Resolver{
 		PreferGo: true,
 		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
 			var d net.Dialer
-			return d.DialContext(ctx, network, addr)
+			return d.DialContext(ctx, network, srv.Addr())
 		},
 	}}
 	srvs, ttl, err := r.lookupSRV(t.Context(), "_prom._tcp.example.com.")
@@ -340,7 +304,7 @@ func TestStdResolver(t *testing.T) {
 	// a NOERROR answer with no records: the stdlib surfaces empty IP
 	// answers as a lookup error, which the poll loop treats as a
 	// resolution failure (keep last-good)
-	store.set(dns.TypeA)
+	srv.Set(dnsclient.TypeA)
 	_, _, err = r.lookupIP(t.Context(), "prom.example.com.")
 	require.Error(t, err)
 }

--- a/pkg/discovery/dns/resolver.go
+++ b/pkg/discovery/dns/resolver.go
@@ -22,19 +22,17 @@ import (
 	"net"
 	"time"
 
-	"github.com/miekg/dns"
+	dnsclient "github.com/trickstercache/trickster/v2/pkg/dns/client"
 )
 
 // resolver abstracts record resolution so the provider can use a specific
 // DNS server (with TTL access) or fall back to the system resolver
 type resolver interface {
 	// lookupSRV returns the SRV answer and its shortest TTL
-	lookupSRV(ctx context.Context, fqdn string) ([]*dns.SRV, time.Duration, error)
+	lookupSRV(ctx context.Context, fqdn string) ([]*dnsclient.SRV, time.Duration, error)
 	// lookupIP returns the A+AAAA answer and its shortest TTL
 	lookupIP(ctx context.Context, fqdn string) ([]string, time.Duration, error)
 }
-
-const resolvConfPath = "/etc/resolv.conf"
 
 // newResolver returns a direct resolver against the configured server, or
 // the first system nameserver from resolv.conf; when neither is available
@@ -42,58 +40,56 @@ const resolvConfPath = "/etc/resolv.conf"
 // provides no TTLs, so the poll interval alone paces re-resolution
 func newResolver(server string) (resolver, error) {
 	if server != "" {
-		return &directResolver{server: server}, nil
+		return newDirectResolver(server), nil
 	}
-	if cc, err := dns.ClientConfigFromFile(resolvConfPath); err == nil &&
-		len(cc.Servers) > 0 {
-		return &directResolver{
-			server: net.JoinHostPort(cc.Servers[0], cc.Port),
-		}, nil
+	if rc, err := dnsclient.LoadResolvConf(
+		dnsclient.DefaultResolvConfPath); err == nil {
+		return newDirectResolver(rc.Servers[0]), nil
 	}
 	return &stdResolver{r: net.DefaultResolver}, nil
 }
 
-// directResolver queries one DNS server via miekg/dns, retrying over TCP
-// when a UDP answer is truncated
+// directResolver queries one DNS server directly, which is what makes record
+// TTLs visible; the client retries over TCP when a UDP answer is truncated
 type directResolver struct {
 	server string
+	client *dnsclient.Client
 }
 
-func (d *directResolver) exchange(ctx context.Context, fqdn string,
-	qtype uint16,
-) (*dns.Msg, error) {
-	m := new(dns.Msg)
-	m.SetQuestion(fqdn, qtype)
-	c := &dns.Client{Timeout: 5 * time.Second}
-	r, _, err := c.ExchangeContext(ctx, m, d.server)
-	if err == nil && r != nil && r.Truncated {
-		c.Net = "tcp"
-		r, _, err = c.ExchangeContext(ctx, m, d.server)
+func newDirectResolver(server string) *directResolver {
+	return &directResolver{
+		server: server,
+		client: &dnsclient.Client{Timeout: dnsclient.DefaultTimeout},
 	}
+}
+
+func (d *directResolver) query(ctx context.Context, fqdn string,
+	qtype dnsclient.Type,
+) (*dnsclient.Msg, error) {
+	r, err := d.client.Query(ctx, d.server, fqdn, qtype)
 	if err != nil {
 		return nil, err
 	}
-	if r.Rcode != dns.RcodeSuccess {
-		return nil, fmt.Errorf("dns query for %s returned %s",
-			fqdn, dns.RcodeToString[r.Rcode])
+	if r.RCode != dnsclient.RCodeSuccess {
+		return nil, fmt.Errorf("dns query for %s returned %s", fqdn, r.RCode)
 	}
 	return r, nil
 }
 
-func (d *directResolver) lookupSRV(ctx context.Context, fqdn string) ([]*dns.SRV, time.Duration, error) {
-	r, err := d.exchange(ctx, fqdn, dns.TypeSRV)
+func (d *directResolver) lookupSRV(ctx context.Context, fqdn string) ([]*dnsclient.SRV, time.Duration, error) {
+	r, err := d.query(ctx, fqdn, dnsclient.TypeSRV)
 	if err != nil {
 		return nil, 0, err
 	}
-	out := make([]*dns.SRV, 0, len(r.Answer))
+	out := make([]*dnsclient.SRV, 0, len(r.Answers))
 	ttl := time.Duration(0)
-	for _, rr := range r.Answer {
-		srv, ok := rr.(*dns.SRV)
+	for _, rr := range r.Answers {
+		srv, ok := rr.(*dnsclient.SRV)
 		if !ok {
 			continue
 		}
 		out = append(out, srv)
-		ttl = minTTL(ttl, srv.Hdr.Ttl)
+		ttl = minTTL(ttl, srv.Hdr.TTL)
 	}
 	return out, ttl, nil
 }
@@ -102,20 +98,20 @@ func (d *directResolver) lookupIP(ctx context.Context, fqdn string) ([]string, t
 	var out []string
 	ttl := time.Duration(0)
 	var lastErr error
-	for _, qtype := range []uint16{dns.TypeA, dns.TypeAAAA} {
-		r, err := d.exchange(ctx, fqdn, qtype)
+	for _, qtype := range []dnsclient.Type{dnsclient.TypeA, dnsclient.TypeAAAA} {
+		r, err := d.query(ctx, fqdn, qtype)
 		if err != nil {
 			lastErr = err
 			continue
 		}
-		for _, rr := range r.Answer {
+		for _, rr := range r.Answers {
 			switch a := rr.(type) {
-			case *dns.A:
-				out = append(out, a.A.String())
-				ttl = minTTL(ttl, a.Hdr.Ttl)
-			case *dns.AAAA:
-				out = append(out, a.AAAA.String())
-				ttl = minTTL(ttl, a.Hdr.Ttl)
+			case *dnsclient.A:
+				out = append(out, a.Addr.String())
+				ttl = minTTL(ttl, a.Hdr.TTL)
+			case *dnsclient.AAAA:
+				out = append(out, a.Addr.String())
+				ttl = minTTL(ttl, a.Hdr.TTL)
 			}
 		}
 	}
@@ -140,14 +136,14 @@ type stdResolver struct {
 	r *net.Resolver
 }
 
-func (s *stdResolver) lookupSRV(ctx context.Context, fqdn string) ([]*dns.SRV, time.Duration, error) {
+func (s *stdResolver) lookupSRV(ctx context.Context, fqdn string) ([]*dnsclient.SRV, time.Duration, error) {
 	_, addrs, err := s.r.LookupSRV(ctx, "", "", fqdn)
 	if err != nil {
 		return nil, 0, err
 	}
-	out := make([]*dns.SRV, len(addrs))
+	out := make([]*dnsclient.SRV, len(addrs))
 	for i, a := range addrs {
-		out[i] = &dns.SRV{
+		out[i] = &dnsclient.SRV{
 			Target:   a.Target,
 			Port:     a.Port,
 			Priority: a.Priority,

--- a/pkg/dns/client/client.go
+++ b/pkg/dns/client/client.go
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package client is a minimal DNS stub resolver covering only what Trickster
+// needs: querying a specific server for A, AAAA and SRV records and reading
+// the TTLs of the answers, over UDP with automatic retry on TCP.
+package client
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"io"
+	"net"
+	"time"
+)
+
+const (
+	// DefaultTimeout bounds a single exchange, including connection setup
+	DefaultTimeout = 5 * time.Second
+	// DefaultUDPSize is the EDNS0 buffer size advertised on UDP queries; it
+	// is the size the DNS flag day recommends for avoiding fragmentation
+	DefaultUDPSize = 1232
+	// minUDPSize is the response ceiling of DNS over UDP without EDNS0
+	minUDPSize = 512
+	maxTCPSize = 65535
+	netUDP     = "udp"
+	netTCP     = "tcp"
+)
+
+// Client queries a single DNS server. The zero value queries over UDP with
+// EDNS0 enabled and is ready to use.
+type Client struct {
+	// Net is the transport for the initial query, "udp" (the default) or
+	// "tcp". UDP answers that come back truncated are retried on TCP.
+	Net string
+	// Timeout bounds each exchange; DefaultTimeout applies when unset
+	Timeout time.Duration
+	// UDPSize is the EDNS0 buffer size advertised on UDP queries. Unset uses
+	// DefaultUDPSize; a negative value disables EDNS0.
+	UDPSize int
+	// Dialer, when set, establishes the connection to the server
+	Dialer *net.Dialer
+}
+
+// Query asks server (host:port) for the records of type t at name, and
+// returns the response regardless of its response code
+func (c *Client) Query(ctx context.Context, server, name string, t Type) (*Msg, error) {
+	m := &Msg{
+		ID:               messageID(),
+		RecursionDesired: true,
+		Questions: []Question{{
+			Name:  Fqdn(name),
+			Type:  t,
+			Class: ClassINET,
+		}},
+	}
+	return c.Exchange(ctx, m, server)
+}
+
+// Exchange sends m to server (host:port) and returns its response, retrying
+// over TCP when a UDP answer comes back truncated
+func (c *Client) Exchange(ctx context.Context, m *Msg, server string) (*Msg, error) {
+	network := c.Net
+	if network == "" {
+		network = netUDP
+	}
+	r, err := c.exchange(ctx, network, m, server)
+	if err != nil || network != netUDP || !r.Truncated {
+		return r, err
+	}
+	// a truncated answer is incomplete by definition, and TCP has no such
+	// size ceiling, so the retry is the only way to see the full answer
+	return c.exchange(ctx, netTCP, m, server)
+}
+
+func (c *Client) exchange(ctx context.Context, network string, m *Msg,
+	server string,
+) (*Msg, error) {
+	q := *m
+	q.UDPSize = 0
+	if network == netUDP {
+		q.UDPSize = c.udpSize()
+	}
+	wire, err := q.Pack()
+	if err != nil {
+		return nil, err
+	}
+	timeout := c.Timeout
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	d := c.Dialer
+	if d == nil {
+		d = &net.Dialer{}
+	}
+	conn, err := d.DialContext(ctx, network, server)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+	if dl, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(dl)
+	}
+	if network == netTCP {
+		return exchangeTCP(conn, &q, wire)
+	}
+	return exchangeUDP(conn, &q, wire, int(q.UDPSize))
+}
+
+// udpSize resolves the advertised EDNS0 buffer size; a negative configured
+// value disables EDNS0 by returning zero
+func (c *Client) udpSize() uint16 {
+	switch {
+	case c.UDPSize < 0:
+		return 0
+	case c.UDPSize == 0:
+		return DefaultUDPSize
+	case c.UDPSize > maxTCPSize:
+		return maxTCPSize
+	default:
+		return uint16(c.UDPSize)
+	}
+}
+
+func exchangeUDP(conn net.Conn, q *Msg, wire []byte, bufSize int) (*Msg, error) {
+	if _, err := conn.Write(wire); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, max(bufSize, minUDPSize))
+	for {
+		n, err := conn.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+		r := &Msg{}
+		// datagrams that are malformed or answer a different question are
+		// off-path noise; the deadline bounds the wait for the real answer
+		if err := r.Unpack(buf[:n]); err != nil || !r.answers(q) {
+			continue
+		}
+		return r, nil
+	}
+}
+
+func exchangeTCP(conn net.Conn, q *Msg, wire []byte) (*Msg, error) {
+	n := len(wire)
+	if n > maxTCPSize {
+		return nil, ErrLongMessage
+	}
+	framed := make([]byte, 2, n+2)
+	binary.BigEndian.PutUint16(framed, uint16(n))
+	if _, err := conn.Write(append(framed, wire...)); err != nil {
+		return nil, err
+	}
+	var sz [2]byte
+	if _, err := io.ReadFull(conn, sz[:]); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, binary.BigEndian.Uint16(sz[:]))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return nil, err
+	}
+	r := &Msg{}
+	if err := r.Unpack(buf); err != nil {
+		return nil, err
+	}
+	if !r.answers(q) {
+		return nil, ErrNoResponse
+	}
+	return r, nil
+}
+
+// messageID returns an unpredictable query ID, which together with the
+// question match in answers() is the stub resolver's spoofing defense
+func messageID() uint16 {
+	var b [2]byte
+	_, _ = rand.Read(b[:])
+	return binary.BigEndian.Uint16(b[:])
+}

--- a/pkg/dns/client/client_internal_test.go
+++ b/pkg/dns/client/client_internal_test.go
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientUDPSize(t *testing.T) {
+	require.Equal(t, uint16(DefaultUDPSize), (&Client{}).udpSize())
+	require.Equal(t, uint16(0), (&Client{UDPSize: -1}).udpSize(),
+		"a negative size disables EDNS0")
+	require.Equal(t, uint16(4096), (&Client{UDPSize: 4096}).udpSize())
+	require.Equal(t, uint16(maxTCPSize), (&Client{UDPSize: 1 << 20}).udpSize(),
+		"the advertised size cannot exceed what the field can hold")
+}
+
+func TestExchangeTCPOversizeQuery(t *testing.T) {
+	_, err := exchangeTCP(nil, &Msg{}, make([]byte, maxTCPSize+1))
+	require.ErrorIs(t, err, ErrLongMessage,
+		"the two-byte length prefix cannot frame a larger query")
+}
+
+func TestMessageIDVaries(t *testing.T) {
+	seen := make(map[uint16]struct{}, 32)
+	for range 32 {
+		seen[messageID()] = struct{}{}
+	}
+	require.Greater(t, len(seen), 1, "query IDs must not be constant")
+}

--- a/pkg/dns/client/client_test.go
+++ b/pkg/dns/client/client_test.go
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/dns/client"
+	"github.com/trickstercache/trickster/v2/pkg/testutil/dnsserver"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testHost = "prom.example.com."
+
+func testServer(t *testing.T) *dnsserver.Server {
+	t.Helper()
+	srv := dnsserver.New(t)
+	srv.Set(client.TypeA,
+		dnsserver.A(testHost, 300, "10.0.0.1"),
+		dnsserver.A(testHost, 60, "10.0.0.2"),
+	)
+	srv.Set(client.TypeAAAA, dnsserver.AAAA(testHost, 120, "2001:db8::1"))
+	srv.Set(client.TypeSRV,
+		dnsserver.SRV("_prom._tcp.example.com.", 90, 10, 5, 9090, "prom-a.example.com."))
+	return srv
+}
+
+func TestQueryA(t *testing.T) {
+	srv := testServer(t)
+	c := &client.Client{}
+	// the unqualified name is what a config carries; Query qualifies it
+	r, err := c.Query(t.Context(), srv.Addr(), "prom.example.com", client.TypeA)
+	require.NoError(t, err)
+	require.Equal(t, client.RCodeSuccess, r.RCode)
+	require.True(t, r.Response)
+	require.Len(t, r.Answers, 2)
+	first := r.Answers[0].(*client.A)
+	require.Equal(t, "10.0.0.1", first.Addr.String())
+	require.Equal(t, uint32(300), first.Hdr.TTL)
+	require.Equal(t, testHost, first.Hdr.Name)
+	require.Equal(t, uint32(60), r.Answers[1].Header().TTL)
+}
+
+func TestQueryAAAAAndSRV(t *testing.T) {
+	srv := testServer(t)
+	c := &client.Client{}
+	r, err := c.Query(t.Context(), srv.Addr(), testHost, client.TypeAAAA)
+	require.NoError(t, err)
+	require.Len(t, r.Answers, 1)
+	require.Equal(t, "2001:db8::1", r.Answers[0].(*client.AAAA).Addr.String())
+
+	r, err = c.Query(t.Context(), srv.Addr(), "_prom._tcp.example.com", client.TypeSRV)
+	require.NoError(t, err)
+	require.Len(t, r.Answers, 1)
+	got := r.Answers[0].(*client.SRV)
+	require.Equal(t, uint16(10), got.Priority)
+	require.Equal(t, uint16(5), got.Weight)
+	require.Equal(t, uint16(9090), got.Port)
+	require.Equal(t, "prom-a.example.com.", got.Target)
+	require.Equal(t, uint32(90), got.Hdr.TTL)
+}
+
+// TestTruncatedRetriesOverTCP proves a truncated UDP answer is re-asked on
+// TCP, where the full record set comes back
+func TestTruncatedRetriesOverTCP(t *testing.T) {
+	srv := testServer(t)
+	srv.SetTruncate(true)
+	c := &client.Client{}
+	r, err := c.Query(t.Context(), srv.Addr(), testHost, client.TypeA)
+	require.NoError(t, err)
+	require.False(t, r.Truncated)
+	require.Len(t, r.Answers, 2)
+}
+
+func TestQueryOverTCP(t *testing.T) {
+	srv := testServer(t)
+	c := &client.Client{Net: "tcp"}
+	r, err := c.Query(t.Context(), srv.Addr(), testHost, client.TypeA)
+	require.NoError(t, err)
+	require.Len(t, r.Answers, 2)
+}
+
+func TestQueryWithoutEDNS0(t *testing.T) {
+	srv := testServer(t)
+	c := &client.Client{UDPSize: -1}
+	r, err := c.Query(t.Context(), srv.Addr(), testHost, client.TypeA)
+	require.NoError(t, err)
+	require.Len(t, r.Answers, 2)
+}
+
+// TestQueryFailureRCode: a server-side failure is a valid response, not a
+// transport error; the caller decides what to do with the code
+func TestQueryFailureRCode(t *testing.T) {
+	srv := testServer(t)
+	srv.SetRCode(client.RCodeServerFailure)
+	c := &client.Client{}
+	r, err := c.Query(t.Context(), srv.Addr(), testHost, client.TypeA)
+	require.NoError(t, err)
+	require.Equal(t, client.RCodeServerFailure, r.RCode)
+	require.Equal(t, "SERVFAIL", r.RCode.String())
+	require.Empty(t, r.Answers)
+}
+
+func TestQueryUnknownType(t *testing.T) {
+	srv := dnsserver.New(t)
+	c := &client.Client{}
+	r, err := c.Query(t.Context(), srv.Addr(), testHost, client.TypeA)
+	require.NoError(t, err)
+	require.Empty(t, r.Answers, "an authoritative empty answer is not an error")
+}
+
+func TestQueryDialFailure(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	addr := pc.LocalAddr().String()
+	require.NoError(t, pc.Close())
+
+	c := &client.Client{Timeout: 500 * time.Millisecond}
+	_, err = c.Query(t.Context(), addr, testHost, client.TypeA)
+	require.Error(t, err)
+
+	_, err = c.Query(t.Context(), "not-a-host-port", testHost, client.TypeA)
+	require.Error(t, err)
+
+	c = &client.Client{Net: "tcp", Timeout: 500 * time.Millisecond}
+	_, err = c.Query(t.Context(), addr, testHost, client.TypeA)
+	require.Error(t, err)
+}
+
+func TestQueryUnencodableName(t *testing.T) {
+	srv := testServer(t)
+	c := &client.Client{}
+	_, err := c.Query(t.Context(), srv.Addr(), "a..b", client.TypeA)
+	require.ErrorIs(t, err, client.ErrInvalidName)
+}
+
+func TestQueryCanceledContext(t *testing.T) {
+	srv := testServer(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	c := &client.Client{}
+	_, err := c.Query(ctx, srv.Addr(), testHost, client.TypeA)
+	require.Error(t, err)
+}
+
+func TestClientDialer(t *testing.T) {
+	srv := testServer(t)
+	c := &client.Client{Dialer: &net.Dialer{LocalAddr: &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)}}}
+	r, err := c.Query(t.Context(), srv.Addr(), testHost, client.TypeA)
+	require.NoError(t, err)
+	require.Len(t, r.Answers, 2)
+}
+
+// TestExchangeIgnoresUnrelatedDatagrams proves an off-path answer with a
+// mismatched ID does not satisfy the query
+func TestExchangeIgnoresUnrelatedDatagrams(t *testing.T) {
+	spoof, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { spoof.Close() })
+	go func() {
+		buf := make([]byte, 512)
+		for {
+			n, addr, err := spoof.ReadFrom(buf)
+			if err != nil {
+				return
+			}
+			bad := &client.Msg{ID: 0, Response: true}
+			// the query IDs are random, so a zero ID is near-certainly wrong
+			if wire, err := bad.Pack(); err == nil {
+				spoof.WriteTo(wire, addr)
+			}
+			_ = n
+		}
+	}()
+
+	c := &client.Client{Timeout: 300 * time.Millisecond}
+	_, err = c.Query(t.Context(), spoof.LocalAddr().String(), testHost, client.TypeA)
+	require.Error(t, err, "the deadline expires rather than accepting the reply")
+}

--- a/pkg/dns/client/errors.go
+++ b/pkg/dns/client/errors.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import "errors"
+
+var (
+	// ErrShortMessage is returned when a message ends before a field it
+	// claims to contain
+	ErrShortMessage = errors.New("dns message is shorter than its contents")
+	// ErrLongMessage is returned when a message or one of its sections
+	// exceeds the size the wire format can express
+	ErrLongMessage = errors.New("dns message exceeds the maximum encodable size")
+	// ErrInvalidName is returned for a domain name that cannot be encoded
+	// or that is malformed on the wire
+	ErrInvalidName = errors.New("invalid dns domain name")
+	// ErrNameLoop is returned when compression pointers in a message form
+	// a cycle
+	ErrNameLoop = errors.New("dns name compression pointer loop")
+	// ErrInvalidRecord is returned when a record's data does not match the
+	// layout its type requires
+	ErrInvalidRecord = errors.New("invalid dns resource record data")
+	// ErrNoResponse is returned when a server's reply does not answer the
+	// question that was asked
+	ErrNoResponse = errors.New("dns response does not match the query")
+	// ErrNoServers is returned when a resolver configuration file names no
+	// usable nameservers
+	ErrNoServers = errors.New("no dns nameservers configured")
+)

--- a/pkg/dns/client/fuzz_test.go
+++ b/pkg/dns/client/fuzz_test.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"encoding/binary"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// packedSeed packs a message that the seed corpus needs, failing the fuzz
+// setup rather than the fuzz run when the fixture itself is wrong
+func packedSeed(f *testing.F, m *Msg) []byte {
+	f.Helper()
+	b, err := m.Pack()
+	require.NoError(f, err)
+	return b
+}
+
+func packedRecordSeed(f *testing.F, rr Record) []byte {
+	f.Helper()
+	b, err := packRecord(nil, rr)
+	require.NoError(f, err)
+	return b
+}
+
+func seedHeader(qdCount, anCount uint16, flags uint16) []byte {
+	b := make([]byte, headerLen)
+	binary.BigEndian.PutUint16(b[0:2], 0x1234)
+	binary.BigEndian.PutUint16(b[2:4], flags)
+	binary.BigEndian.PutUint16(b[4:6], qdCount)
+	binary.BigEndian.PutUint16(b[6:8], anCount)
+	return b
+}
+
+// compressedResponse is the shape real servers send: the answer's name is a
+// pointer back to the question rather than a repeated set of labels
+func compressedResponse() []byte {
+	b := seedHeader(1, 1, flagResponse|flagRecurseReq|flagRecurseOK)
+	b = append(b, "\x07example\x03com\x00"...)
+	b = binary.BigEndian.AppendUint16(b, uint16(TypeA))
+	b = binary.BigEndian.AppendUint16(b, uint16(ClassINET))
+	b = append(b, 0xc0, headerLen) // pointer to the question's name
+	b = binary.BigEndian.AppendUint16(b, uint16(TypeA))
+	b = binary.BigEndian.AppendUint16(b, uint16(ClassINET))
+	b = binary.BigEndian.AppendUint32(b, 60)
+	b = binary.BigEndian.AppendUint16(b, 4)
+	return append(b, 10, 0, 0, 1)
+}
+
+func seedNames() [][]byte {
+	return [][]byte{
+		[]byte("\x07example\x03com\x00"),
+		[]byte("\x03com\x00\x03foo\xc0\x00"),
+		{0},
+		{4, 'a', '.', 'b', 0x01, 0},
+		{0xc0, 0x00},
+		{0xc0, 0xff},
+		{0xc0},
+		{0x40},
+		{0x03, 'a'},
+		{0x01, 'a'},
+		overlongName(),
+	}
+}
+
+// overlongName is five maximum-length labels, which overruns the 255-byte
+// ceiling on a whole name
+func overlongName() []byte {
+	var b []byte
+	for range 5 {
+		b = append(b, maxLabelLen)
+		b = append(b, strings.Repeat("a", maxLabelLen)...)
+	}
+	return append(b, 0)
+}
+
+func seedRecords(f *testing.F) [][]byte {
+	f.Helper()
+	hdr := func(qtype Type) RecordHeader {
+		return RecordHeader{Name: "example.com.", Type: qtype, Class: ClassINET, TTL: 60}
+	}
+	return [][]byte{
+		packedRecordSeed(f, &A{Hdr: hdr(TypeA), Addr: netip.MustParseAddr("10.0.0.1")}),
+		packedRecordSeed(f, &AAAA{Hdr: hdr(TypeAAAA), Addr: netip.MustParseAddr("2001:db8::1")}),
+		packedRecordSeed(f, &SRV{Hdr: hdr(TypeSRV), Priority: 10, Weight: 5,
+			Port: 9090, Target: "prom-a.example.com."}),
+		packedRecordSeed(f, &Unknown{Hdr: hdr(99), Data: []byte{1, 2, 3}}),
+	}
+}
+
+// FuzzUnpackName drives name decoding, where compression pointers let a
+// hostile message steer the decoder's offset
+func FuzzUnpackName(f *testing.F) {
+	for _, seed := range seedNames() {
+		f.Add(seed, 0)
+	}
+	f.Add([]byte("\x03com\x00\x03foo\xc0\x00"), 5)
+	f.Add([]byte{0}, 9)
+	f.Add([]byte{0}, -1)
+	f.Add(compressedResponse(), headerLen)
+
+	f.Fuzz(func(t *testing.T, msg []byte, off int) {
+		name, next, err := unpackName(msg, off)
+		if err != nil {
+			return
+		}
+		require.GreaterOrEqual(t, next, 0)
+		require.LessOrEqual(t, next, len(msg),
+			"the resume offset must stay inside the message")
+		require.True(t, strings.HasSuffix(name, "."),
+			"decoded names are always fully qualified")
+		require.LessOrEqual(t, len(name), maxNameLen*4,
+			"escaping expands a byte to at most four characters")
+	})
+}
+
+// FuzzUnpackRecord drives resource record decoding for the types the client
+// interprets, plus the raw carry-through of every other type
+func FuzzUnpackRecord(f *testing.F) {
+	for _, seed := range seedRecords(f) {
+		f.Add(seed, 0)
+	}
+	for _, seed := range seedNames() {
+		f.Add(seed, 0)
+	}
+	f.Add(compressedResponse(), headerLen)
+	f.Add(compressedResponse(), -1)
+
+	f.Fuzz(func(t *testing.T, msg []byte, off int) {
+		rr, next, err := unpackRecord(msg, off)
+		if err != nil {
+			return
+		}
+		require.NotNil(t, rr)
+		require.GreaterOrEqual(t, next, 0)
+		require.LessOrEqual(t, next, len(msg),
+			"the resume offset must stay inside the message")
+		require.Greater(t, next, off,
+			"a decoded record must advance past its own bytes")
+		require.True(t, strings.HasSuffix(rr.Header().Name, "."))
+	})
+}
+
+// FuzzMsgUnpack drives the whole response decoder, which is the code path
+// that reads bytes straight off the network
+func FuzzMsgUnpack(f *testing.F) {
+	full := &Msg{
+		ID:                 0xbeef,
+		Response:           true,
+		RecursionDesired:   true,
+		RecursionAvailable: true,
+		Questions:          []Question{{Name: "example.com.", Type: TypeA, Class: ClassINET}},
+		Answers: []Record{
+			&A{
+				Hdr:  RecordHeader{Name: "example.com.", Type: TypeA, Class: ClassINET, TTL: 300},
+				Addr: netip.MustParseAddr("10.0.0.1"),
+			},
+			&AAAA{
+				Hdr:  RecordHeader{Name: "example.com.", Type: TypeAAAA, Class: ClassINET, TTL: 120},
+				Addr: netip.MustParseAddr("2001:db8::1"),
+			},
+			&SRV{
+				Hdr:    RecordHeader{Name: "_prom._tcp.example.com.", Type: TypeSRV, Class: ClassINET, TTL: 90},
+				Port:   9090,
+				Target: "prom-a.example.com.",
+			},
+		},
+	}
+	f.Add(packedSeed(f, full))
+
+	edns := &Msg{
+		ID:        1,
+		Questions: []Question{{Name: "example.com.", Type: TypeA, Class: ClassINET}},
+		UDPSize:   DefaultUDPSize,
+	}
+	f.Add(packedSeed(f, edns))
+	f.Add(compressedResponse())
+	f.Add(seedHeader(1, 0, 0))
+	f.Add(append(seedHeader(1, 0, 0), 0))
+	f.Add(seedHeader(0, 1, 0))
+	f.Add(seedHeader(0, 4, flagResponse|flagTruncated))
+	f.Add(make([]byte, headerLen-1))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, wire []byte) {
+		m := &Msg{}
+		if err := m.Unpack(wire); err != nil {
+			return
+		}
+		for _, q := range m.Questions {
+			require.True(t, strings.HasSuffix(q.Name, "."))
+		}
+		for _, rr := range m.Answers {
+			require.NotNil(t, rr)
+			require.True(t, strings.HasSuffix(rr.Header().Name, "."))
+		}
+		// re-encoding a decoded message must fail cleanly rather than panic;
+		// names carrying escapes are legitimately not re-encodable
+		if b, err := m.Pack(); err == nil {
+			require.NoError(t, (&Msg{}).Unpack(b))
+		}
+	})
+}

--- a/pkg/dns/client/message.go
+++ b/pkg/dns/client/message.go
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"encoding/binary"
+	"strings"
+)
+
+const (
+	headerLen      = 12
+	maxSectionLen  = 65535
+	packBufSize    = 512
+	minRecordLen   = 12
+	flagResponse   = 1 << 15
+	flagAuthorit   = 1 << 10
+	flagTruncated  = 1 << 9
+	flagRecurseReq = 1 << 8
+	flagRecurseOK  = 1 << 7
+	opcodeShift    = 11
+	opcodeMask     = 0xF
+	rcodeMask      = 0xF
+)
+
+// Question is a single entry in a message's question section
+type Question struct {
+	Name  string
+	Type  Type
+	Class Class
+}
+
+func (q *Question) pack(dst []byte) ([]byte, error) {
+	dst, err := packName(dst, q.Name)
+	if err != nil {
+		return nil, err
+	}
+	dst = binary.BigEndian.AppendUint16(dst, uint16(q.Type))
+	return binary.BigEndian.AppendUint16(dst, uint16(q.Class)), nil
+}
+
+func unpackQuestion(msg []byte, off int) (Question, int, error) {
+	name, off, err := unpackName(msg, off)
+	if err != nil {
+		return Question{}, 0, err
+	}
+	if off+4 > len(msg) {
+		return Question{}, 0, ErrShortMessage
+	}
+	return Question{
+		Name:  name,
+		Type:  Type(binary.BigEndian.Uint16(msg[off : off+2])),
+		Class: Class(binary.BigEndian.Uint16(msg[off+2 : off+4])),
+	}, off + 4, nil
+}
+
+// Msg is a DNS message. Only the question and answer sections are modeled;
+// authority and additional records are not read, as nothing here consumes them.
+type Msg struct {
+	ID                 uint16
+	Opcode             uint8
+	RCode              RCode
+	Response           bool
+	Authoritative      bool
+	Truncated          bool
+	RecursionDesired   bool
+	RecursionAvailable bool
+	Questions          []Question
+	Answers            []Record
+	// UDPSize, when non-zero, packs an EDNS0 OPT record advertising the
+	// sender's UDP reassembly buffer, raising the 512-byte response ceiling
+	UDPSize uint16
+}
+
+// Pack encodes the message into its wire format
+func (m *Msg) Pack() ([]byte, error) {
+	qdCount := len(m.Questions)
+	anCount := len(m.Answers)
+	if qdCount > maxSectionLen || anCount > maxSectionLen {
+		return nil, ErrLongMessage
+	}
+	var arCount uint16
+	if m.UDPSize > 0 {
+		arCount = 1
+	}
+	b := make([]byte, headerLen, packBufSize)
+	binary.BigEndian.PutUint16(b[0:2], m.ID)
+	binary.BigEndian.PutUint16(b[2:4], m.flags())
+	binary.BigEndian.PutUint16(b[4:6], uint16(qdCount))
+	binary.BigEndian.PutUint16(b[6:8], uint16(anCount))
+	binary.BigEndian.PutUint16(b[10:12], arCount)
+	var err error
+	for i := range m.Questions {
+		if b, err = m.Questions[i].pack(b); err != nil {
+			return nil, err
+		}
+	}
+	for _, rr := range m.Answers {
+		if b, err = packRecord(b, rr); err != nil {
+			return nil, err
+		}
+	}
+	if arCount > 0 {
+		b = packOPT(b, m.UDPSize)
+	}
+	return b, nil
+}
+
+// Unpack decodes a wire-format message. A short answer section is tolerated
+// when the truncated bit is set, since the caller retries such answers on TCP.
+func (m *Msg) Unpack(b []byte) error {
+	if len(b) < headerLen {
+		return ErrShortMessage
+	}
+	m.ID = binary.BigEndian.Uint16(b[0:2])
+	m.setFlags(binary.BigEndian.Uint16(b[2:4]))
+	qdCount := int(binary.BigEndian.Uint16(b[4:6]))
+	anCount := int(binary.BigEndian.Uint16(b[6:8]))
+	off := headerLen
+	m.Questions = make([]Question, 0, sectionCap(qdCount, len(b)))
+	for range qdCount {
+		q, next, err := unpackQuestion(b, off)
+		if err != nil {
+			return err
+		}
+		m.Questions = append(m.Questions, q)
+		off = next
+	}
+	m.Answers = make([]Record, 0, sectionCap(anCount, len(b)))
+	for range anCount {
+		rr, next, err := unpackRecord(b, off)
+		if err != nil {
+			if m.Truncated {
+				return nil
+			}
+			return err
+		}
+		m.Answers = append(m.Answers, rr)
+		off = next
+	}
+	return nil
+}
+
+// sectionCap bounds a section's preallocation by what the message could
+// actually hold, so a bogus count cannot drive a large allocation
+func sectionCap(count, msgLen int) int {
+	return min(count, msgLen/minRecordLen+1)
+}
+
+func (m *Msg) flags() uint16 {
+	f := uint16(m.Opcode&opcodeMask)<<opcodeShift | uint16(m.RCode)&rcodeMask
+	if m.Response {
+		f |= flagResponse
+	}
+	if m.Authoritative {
+		f |= flagAuthorit
+	}
+	if m.Truncated {
+		f |= flagTruncated
+	}
+	if m.RecursionDesired {
+		f |= flagRecurseReq
+	}
+	if m.RecursionAvailable {
+		f |= flagRecurseOK
+	}
+	return f
+}
+
+func (m *Msg) setFlags(f uint16) {
+	m.Response = f&flagResponse != 0
+	m.Opcode = uint8(f >> opcodeShift & opcodeMask)
+	m.Authoritative = f&flagAuthorit != 0
+	m.Truncated = f&flagTruncated != 0
+	m.RecursionDesired = f&flagRecurseReq != 0
+	m.RecursionAvailable = f&flagRecurseOK != 0
+	m.RCode = RCode(f & rcodeMask)
+}
+
+// packOPT appends the EDNS0 pseudo-record, which carries the advertised UDP
+// buffer size in the class field of a record on the root name
+func packOPT(dst []byte, udpSize uint16) []byte {
+	dst = append(dst, 0)
+	dst = binary.BigEndian.AppendUint16(dst, uint16(TypeOPT))
+	dst = binary.BigEndian.AppendUint16(dst, udpSize)
+	dst = binary.BigEndian.AppendUint32(dst, 0)
+	return binary.BigEndian.AppendUint16(dst, 0)
+}
+
+// answers reports whether m is a reply to the question asked in q
+func (m *Msg) answers(q *Msg) bool {
+	if !m.Response || m.ID != q.ID || len(m.Questions) != len(q.Questions) {
+		return false
+	}
+	for i, asked := range q.Questions {
+		got := m.Questions[i]
+		if got.Type != asked.Type || got.Class != asked.Class ||
+			!strings.EqualFold(got.Name, asked.Name) {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/dns/client/message_test.go
+++ b/pkg/dns/client/message_test.go
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"encoding/binary"
+	"net/netip"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testQuestion() Question {
+	return Question{Name: "example.com.", Type: TypeA, Class: ClassINET}
+}
+
+func TestMsgRoundTrip(t *testing.T) {
+	m := &Msg{
+		ID:                 0xbeef,
+		Response:           true,
+		Authoritative:      true,
+		Truncated:          true,
+		RecursionDesired:   true,
+		RecursionAvailable: true,
+		Opcode:             2,
+		RCode:              RCodeRefused,
+		Questions:          []Question{testQuestion()},
+		Answers: []Record{&A{
+			Hdr:  RecordHeader{Name: "example.com.", Type: TypeA, Class: ClassINET, TTL: 300},
+			Addr: netip.MustParseAddr("10.0.0.1"),
+		}},
+	}
+	b, err := m.Pack()
+	require.NoError(t, err)
+
+	got := &Msg{}
+	require.NoError(t, got.Unpack(b))
+	require.Equal(t, m.ID, got.ID)
+	require.True(t, got.Response)
+	require.True(t, got.Authoritative)
+	require.True(t, got.Truncated)
+	require.True(t, got.RecursionDesired)
+	require.True(t, got.RecursionAvailable)
+	require.Equal(t, uint8(2), got.Opcode)
+	require.Equal(t, RCodeRefused, got.RCode)
+	require.Equal(t, m.Questions, got.Questions)
+	require.Len(t, got.Answers, 1)
+	require.Equal(t, m.Answers[0], got.Answers[0])
+}
+
+func TestMsgPackEDNS0(t *testing.T) {
+	m := &Msg{ID: 1, Questions: []Question{testQuestion()}, UDPSize: DefaultUDPSize}
+	b, err := m.Pack()
+	require.NoError(t, err)
+	require.Equal(t, uint16(1), binary.BigEndian.Uint16(b[10:12]),
+		"the OPT record is counted in the additional section")
+	opt := b[len(b)-11:]
+	require.Equal(t, byte(0), opt[0], "OPT is attached to the root name")
+	require.Equal(t, uint16(TypeOPT), binary.BigEndian.Uint16(opt[1:3]))
+	require.Equal(t, uint16(DefaultUDPSize), binary.BigEndian.Uint16(opt[3:5]),
+		"the advertised buffer size rides in the class field")
+
+	// the additional section is not modeled, so it round-trips as absent
+	got := &Msg{}
+	require.NoError(t, got.Unpack(b))
+	require.Zero(t, got.UDPSize)
+	require.Empty(t, got.Answers)
+}
+
+func TestMsgPackErrors(t *testing.T) {
+	m := &Msg{Questions: []Question{{Name: "a..b.", Type: TypeA, Class: ClassINET}}}
+	_, err := m.Pack()
+	require.ErrorIs(t, err, ErrInvalidName)
+
+	m = &Msg{Answers: []Record{&A{
+		Hdr:  RecordHeader{Name: "example.com.", Type: TypeA},
+		Addr: netip.MustParseAddr("::1"),
+	}}}
+	_, err = m.Pack()
+	require.ErrorIs(t, err, ErrInvalidRecord)
+
+	m = &Msg{Answers: []Record{&Unknown{
+		Hdr:  RecordHeader{Name: "example.com.", Type: 99},
+		Data: make([]byte, maxRDataLen+1),
+	}}}
+	_, err = m.Pack()
+	require.ErrorIs(t, err, ErrLongMessage)
+}
+
+func TestMsgUnpackErrors(t *testing.T) {
+	m := &Msg{}
+	require.ErrorIs(t, m.Unpack(make([]byte, headerLen-1)), ErrShortMessage)
+
+	// a question count with no question section behind it
+	b := make([]byte, headerLen)
+	binary.BigEndian.PutUint16(b[4:6], 1)
+	require.ErrorIs(t, m.Unpack(b), ErrShortMessage)
+
+	// a name that unpacks but has no type/class following it
+	b = append(b, 0)
+	require.ErrorIs(t, m.Unpack(b), ErrShortMessage)
+
+	// an answer count with no answer section behind it
+	b = make([]byte, headerLen)
+	binary.BigEndian.PutUint16(b[6:8], 1)
+	require.ErrorIs(t, m.Unpack(b), ErrShortMessage)
+}
+
+// TestMsgUnpackTruncated covers servers that set the truncated bit while
+// leaving the section counts describing the full, unsent answer
+func TestMsgUnpackTruncated(t *testing.T) {
+	b := make([]byte, headerLen)
+	binary.BigEndian.PutUint16(b[2:4], flagResponse|flagTruncated)
+	binary.BigEndian.PutUint16(b[6:8], 4)
+	m := &Msg{}
+	require.NoError(t, m.Unpack(b))
+	require.True(t, m.Truncated)
+	require.Empty(t, m.Answers)
+}
+
+func TestMsgAnswers(t *testing.T) {
+	q := &Msg{ID: 7, Questions: []Question{testQuestion()}}
+	reply := func(mutate func(*Msg)) *Msg {
+		m := &Msg{ID: 7, Response: true, Questions: []Question{testQuestion()}}
+		if mutate != nil {
+			mutate(m)
+		}
+		return m
+	}
+	require.True(t, reply(nil).answers(q))
+	require.True(t, reply(func(m *Msg) {
+		m.Questions[0].Name = strings.ToUpper(m.Questions[0].Name)
+	}).answers(q), "question names compare case-insensitively")
+
+	require.False(t, reply(func(m *Msg) { m.Response = false }).answers(q))
+	require.False(t, reply(func(m *Msg) { m.ID = 8 }).answers(q))
+	require.False(t, reply(func(m *Msg) { m.Questions = nil }).answers(q))
+	require.False(t, reply(func(m *Msg) { m.Questions[0].Type = TypeSRV }).answers(q))
+	require.False(t, reply(func(m *Msg) { m.Questions[0].Class = 3 }).answers(q))
+	require.False(t, reply(func(m *Msg) { m.Questions[0].Name = "other.com." }).answers(q))
+}
+
+func TestSectionCap(t *testing.T) {
+	require.Equal(t, 2, sectionCap(2, 512))
+	require.Equal(t, 5, sectionCap(65535, headerLen*4),
+		"a bogus section count cannot drive a large allocation")
+}

--- a/pkg/dns/client/name.go
+++ b/pkg/dns/client/name.go
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import "strings"
+
+const (
+	maxNameLen  = 255
+	maxLabelLen = 63
+	// ptrMask marks a length byte as a compression pointer; the remaining
+	// 14 bits are the offset of the name being referenced
+	ptrMask = 0xC0
+	// maxPtrJumps bounds pointer chasing so a cyclic message cannot spin
+	maxPtrJumps = 16
+)
+
+// Fqdn returns name with the trailing dot the wire format requires
+func Fqdn(name string) string {
+	if name == "" {
+		return "."
+	}
+	if strings.HasSuffix(name, ".") {
+		return name
+	}
+	return name + "."
+}
+
+// packName appends name to dst in label form. Names are written uncompressed,
+// which every resolver accepts and keeps queries self-contained.
+func packName(dst []byte, name string) ([]byte, error) {
+	if name == "" || name == "." {
+		return append(dst, 0), nil
+	}
+	name = strings.TrimSuffix(name, ".")
+	total := 1
+	for label := range strings.SplitSeq(name, ".") {
+		n := len(label)
+		if n == 0 || n > maxLabelLen {
+			return nil, ErrInvalidName
+		}
+		total += n + 1
+		if total > maxNameLen {
+			return nil, ErrInvalidName
+		}
+		dst = append(dst, byte(n))
+		dst = append(dst, label...)
+	}
+	return append(dst, 0), nil
+}
+
+// unpackName reads the name at off, following compression pointers, and
+// returns it with a trailing dot along with the offset just past the name
+func unpackName(msg []byte, off int) (string, int, error) {
+	var sb strings.Builder
+	next := -1
+	var jumps int
+	for {
+		if off < 0 || off >= len(msg) {
+			return "", 0, ErrShortMessage
+		}
+		l := int(msg[off])
+		switch {
+		case l == 0:
+			off++
+			if next < 0 {
+				next = off
+			}
+			if sb.Len() == 0 {
+				return ".", next, nil
+			}
+			return sb.String(), next, nil
+		case l&ptrMask == ptrMask:
+			if off+1 >= len(msg) {
+				return "", 0, ErrShortMessage
+			}
+			ptr := (l&^ptrMask)<<8 | int(msg[off+1])
+			if next < 0 {
+				next = off + 2
+			}
+			if jumps++; jumps > maxPtrJumps {
+				return "", 0, ErrNameLoop
+			}
+			off = ptr
+		case l > maxLabelLen:
+			// 0b01 and 0b10 length prefixes are reserved and unusable
+			return "", 0, ErrInvalidName
+		default:
+			off++
+			if off+l > len(msg) {
+				return "", 0, ErrShortMessage
+			}
+			if sb.Len()+l+1 > maxNameLen {
+				return "", 0, ErrInvalidName
+			}
+			writeLabel(&sb, msg[off:off+l])
+			sb.WriteByte('.')
+			off += l
+		}
+	}
+}
+
+// writeLabel appends a label to sb in presentation form, escaping the
+// characters that would otherwise be read as label separators or be unprintable
+func writeLabel(sb *strings.Builder, label []byte) {
+	for _, c := range label {
+		switch {
+		case c == '.' || c == '\\':
+			sb.WriteByte('\\')
+			sb.WriteByte(c)
+		case c < '!' || c > '~':
+			sb.WriteByte('\\')
+			sb.WriteByte('0' + c/100)
+			sb.WriteByte('0' + (c/10)%10)
+			sb.WriteByte('0' + c%10)
+		default:
+			sb.WriteByte(c)
+		}
+	}
+}

--- a/pkg/dns/client/name_test.go
+++ b/pkg/dns/client/name_test.go
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFqdn(t *testing.T) {
+	require.Equal(t, ".", Fqdn(""))
+	require.Equal(t, "example.com.", Fqdn("example.com"))
+	require.Equal(t, "example.com.", Fqdn("example.com."))
+}
+
+func TestPackName(t *testing.T) {
+	b, err := packName(nil, "example.com.")
+	require.NoError(t, err)
+	require.Equal(t, []byte("\x07example\x03com\x00"), b)
+
+	b, err = packName(nil, ".")
+	require.NoError(t, err)
+	require.Equal(t, []byte{0}, b)
+
+	b, err = packName(nil, "")
+	require.NoError(t, err)
+	require.Equal(t, []byte{0}, b)
+}
+
+func TestPackNameErrors(t *testing.T) {
+	_, err := packName(nil, "a..b")
+	require.ErrorIs(t, err, ErrInvalidName, "empty labels are not encodable")
+
+	_, err = packName(nil, strings.Repeat("a", maxLabelLen+1)+".com")
+	require.ErrorIs(t, err, ErrInvalidName, "labels cap at 63 bytes")
+
+	long := strings.TrimSuffix(strings.Repeat(strings.Repeat("a", 63)+".", 5), ".")
+	_, err = packName(nil, long)
+	require.ErrorIs(t, err, ErrInvalidName, "names cap at 255 bytes")
+}
+
+func TestUnpackName(t *testing.T) {
+	msg := []byte("\x03com\x00\x03foo\xc0\x00")
+	name, next, err := unpackName(msg, 5)
+	require.NoError(t, err)
+	require.Equal(t, "foo.com.", name)
+	require.Equal(t, 11, next, "the offset resumes after the pointer, not the target")
+
+	name, next, err = unpackName(msg, 0)
+	require.NoError(t, err)
+	require.Equal(t, "com.", name)
+	require.Equal(t, 5, next)
+
+	name, next, err = unpackName([]byte{0}, 0)
+	require.NoError(t, err)
+	require.Equal(t, ".", name)
+	require.Equal(t, 1, next)
+}
+
+func TestUnpackNameEscapes(t *testing.T) {
+	name, _, err := unpackName([]byte{4, 'a', '.', 'b', 0x01, 0}, 0)
+	require.NoError(t, err)
+	require.Equal(t, `a\.b\001.`, name,
+		"separators and unprintable bytes are escaped in presentation form")
+}
+
+func TestUnpackNameErrors(t *testing.T) {
+	tests := map[string]struct {
+		msg  []byte
+		off  int
+		want error
+	}{
+		"self-referential pointer": {[]byte{0xc0, 0x00}, 0, ErrNameLoop},
+		"reserved length prefix":   {[]byte{0x40}, 0, ErrInvalidName},
+		"label runs past the end":  {[]byte{0x03, 'a'}, 0, ErrShortMessage},
+		"pointer past the end":     {[]byte{0xc0, 0xff}, 0, ErrShortMessage},
+		"pointer is a lone byte":   {[]byte{0xc0}, 0, ErrShortMessage},
+		"offset past the end":      {[]byte{0}, 9, ErrShortMessage},
+		"unterminated name":        {[]byte{0x01, 'a'}, 0, ErrShortMessage},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := unpackName(test.msg, test.off)
+			require.ErrorIs(t, err, test.want)
+		})
+	}
+}
+
+func TestUnpackNameTooLong(t *testing.T) {
+	// 5 maximum-length labels overrun the 255-byte name ceiling
+	var msg []byte
+	for range 5 {
+		msg = append(msg, maxLabelLen)
+		msg = append(msg, strings.Repeat("a", maxLabelLen)...)
+	}
+	msg = append(msg, 0)
+	_, _, err := unpackName(msg, 0)
+	require.ErrorIs(t, err, ErrInvalidName)
+}

--- a/pkg/dns/client/record.go
+++ b/pkg/dns/client/record.go
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"bytes"
+	"encoding/binary"
+	"net/netip"
+)
+
+const (
+	// recordFixedLen is the size of the type, class, TTL and data-length
+	// fields that follow a record's name
+	recordFixedLen = 10
+	// srvFixedLen is the size of the priority, weight and port fields that
+	// precede an SRV record's target name
+	srvFixedLen = 6
+	maxRDataLen = 65535
+)
+
+// RecordHeader is the preamble every resource record carries
+type RecordHeader struct {
+	Name  string
+	Type  Type
+	Class Class
+	TTL   uint32
+}
+
+// Record is a DNS resource record. Only the types this client resolves have
+// concrete representations; every other type is carried as an *Unknown.
+type Record interface {
+	// Header returns the record's name, type, class and TTL
+	Header() RecordHeader
+	packRData(dst []byte) ([]byte, error)
+}
+
+// A is an IPv4 address record
+type A struct {
+	Hdr  RecordHeader
+	Addr netip.Addr
+}
+
+// Header returns the record's name, type, class and TTL
+func (r *A) Header() RecordHeader { return r.Hdr }
+
+func (r *A) packRData(dst []byte) ([]byte, error) {
+	if !r.Addr.Is4() {
+		return nil, ErrInvalidRecord
+	}
+	b := r.Addr.As4()
+	return append(dst, b[:]...), nil
+}
+
+// AAAA is an IPv6 address record
+type AAAA struct {
+	Hdr  RecordHeader
+	Addr netip.Addr
+}
+
+// Header returns the record's name, type, class and TTL
+func (r *AAAA) Header() RecordHeader { return r.Hdr }
+
+func (r *AAAA) packRData(dst []byte) ([]byte, error) {
+	if !r.Addr.IsValid() || r.Addr.Is4() {
+		return nil, ErrInvalidRecord
+	}
+	b := r.Addr.As16()
+	return append(dst, b[:]...), nil
+}
+
+// SRV is a service location record
+type SRV struct {
+	Hdr      RecordHeader
+	Priority uint16
+	Weight   uint16
+	Port     uint16
+	Target   string
+}
+
+// Header returns the record's name, type, class and TTL
+func (r *SRV) Header() RecordHeader { return r.Hdr }
+
+func (r *SRV) packRData(dst []byte) ([]byte, error) {
+	dst = binary.BigEndian.AppendUint16(dst, r.Priority)
+	dst = binary.BigEndian.AppendUint16(dst, r.Weight)
+	dst = binary.BigEndian.AppendUint16(dst, r.Port)
+	return packName(dst, r.Target)
+}
+
+// Unknown carries the raw data of a record whose type this client does not
+// interpret, so that unrelated answers do not fail a message
+type Unknown struct {
+	Hdr  RecordHeader
+	Data []byte
+}
+
+// Header returns the record's name, type, class and TTL
+func (r *Unknown) Header() RecordHeader { return r.Hdr }
+
+func (r *Unknown) packRData(dst []byte) ([]byte, error) {
+	return append(dst, r.Data...), nil
+}
+
+// packRecord appends rr to dst, backfilling the data-length field once the
+// record's data has been written
+func packRecord(dst []byte, rr Record) ([]byte, error) {
+	h := rr.Header()
+	dst, err := packName(dst, h.Name)
+	if err != nil {
+		return nil, err
+	}
+	dst = binary.BigEndian.AppendUint16(dst, uint16(h.Type))
+	dst = binary.BigEndian.AppendUint16(dst, uint16(h.Class))
+	dst = binary.BigEndian.AppendUint32(dst, h.TTL)
+	lenOff := len(dst)
+	dst = binary.BigEndian.AppendUint16(dst, 0)
+	if dst, err = rr.packRData(dst); err != nil {
+		return nil, err
+	}
+	n := len(dst) - lenOff - 2
+	if n > maxRDataLen {
+		return nil, ErrLongMessage
+	}
+	// #nosec G115 -- n is a section length, range-checked above
+	binary.BigEndian.PutUint16(dst[lenOff:lenOff+2], uint16(n))
+	return dst, nil
+}
+
+// unpackRecord reads the record at off and returns the offset just past it
+func unpackRecord(msg []byte, off int) (Record, int, error) {
+	name, off, err := unpackName(msg, off)
+	if err != nil {
+		return nil, 0, err
+	}
+	if off+recordFixedLen > len(msg) {
+		return nil, 0, ErrShortMessage
+	}
+	h := RecordHeader{
+		Name:  name,
+		Type:  Type(binary.BigEndian.Uint16(msg[off : off+2])),
+		Class: Class(binary.BigEndian.Uint16(msg[off+2 : off+4])),
+		TTL:   binary.BigEndian.Uint32(msg[off+4 : off+8]),
+	}
+	rdLen := int(binary.BigEndian.Uint16(msg[off+8 : off+10]))
+	off += recordFixedLen
+	end := off + rdLen
+	if end > len(msg) {
+		return nil, 0, ErrShortMessage
+	}
+	rr, err := unpackRData(h, msg, off, end)
+	if err != nil {
+		return nil, 0, err
+	}
+	return rr, end, nil
+}
+
+func unpackRData(h RecordHeader, msg []byte, off, end int) (Record, error) {
+	switch h.Type {
+	case TypeA:
+		addr, ok := netip.AddrFromSlice(msg[off:end])
+		if !ok || !addr.Is4() {
+			return nil, ErrInvalidRecord
+		}
+		return &A{Hdr: h, Addr: addr}, nil
+	case TypeAAAA:
+		addr, ok := netip.AddrFromSlice(msg[off:end])
+		if !ok || addr.Is4() {
+			return nil, ErrInvalidRecord
+		}
+		return &AAAA{Hdr: h, Addr: addr}, nil
+	case TypeSRV:
+		if off+srvFixedLen >= end {
+			return nil, ErrInvalidRecord
+		}
+		target, _, err := unpackName(msg, off+srvFixedLen)
+		if err != nil {
+			return nil, err
+		}
+		return &SRV{
+			Hdr:      h,
+			Priority: binary.BigEndian.Uint16(msg[off : off+2]),
+			Weight:   binary.BigEndian.Uint16(msg[off+2 : off+4]),
+			Port:     binary.BigEndian.Uint16(msg[off+4 : off+6]),
+			Target:   target,
+		}, nil
+	default:
+		return &Unknown{Hdr: h, Data: bytes.Clone(msg[off:end])}, nil
+	}
+}

--- a/pkg/dns/client/record_test.go
+++ b/pkg/dns/client/record_test.go
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func packOne(t *testing.T, rr Record) []byte {
+	t.Helper()
+	b, err := packRecord(nil, rr)
+	require.NoError(t, err)
+	return b
+}
+
+func TestRecordRoundTrip(t *testing.T) {
+	hdr := func(qtype Type) RecordHeader {
+		return RecordHeader{Name: "example.com.", Type: qtype, Class: ClassINET, TTL: 60}
+	}
+	tests := map[string]Record{
+		"A":    &A{Hdr: hdr(TypeA), Addr: netip.MustParseAddr("10.0.0.1")},
+		"AAAA": &AAAA{Hdr: hdr(TypeAAAA), Addr: netip.MustParseAddr("2001:db8::1")},
+		"SRV": &SRV{Hdr: hdr(TypeSRV), Priority: 10, Weight: 5, Port: 9090,
+			Target: "prom-a.example.com."},
+		"unrecognized type": &Unknown{Hdr: hdr(99), Data: []byte{1, 2, 3}},
+	}
+	for name, want := range tests {
+		t.Run(name, func(t *testing.T) {
+			b := packOne(t, want)
+			got, next, err := unpackRecord(b, 0)
+			require.NoError(t, err)
+			require.Equal(t, len(b), next)
+			require.Equal(t, want, got)
+			require.Equal(t, uint32(60), got.Header().TTL)
+		})
+	}
+}
+
+func TestRecordPackErrors(t *testing.T) {
+	_, err := packRecord(nil, &A{Hdr: RecordHeader{Name: "a..b."}})
+	require.ErrorIs(t, err, ErrInvalidName)
+
+	_, err = packRecord(nil, &A{
+		Hdr:  RecordHeader{Name: "example.com."},
+		Addr: netip.MustParseAddr("2001:db8::1"),
+	})
+	require.ErrorIs(t, err, ErrInvalidRecord, "an A record must hold an IPv4 address")
+
+	_, err = packRecord(nil, &AAAA{
+		Hdr:  RecordHeader{Name: "example.com."},
+		Addr: netip.MustParseAddr("10.0.0.1"),
+	})
+	require.ErrorIs(t, err, ErrInvalidRecord, "an AAAA record must hold an IPv6 address")
+
+	_, err = packRecord(nil, &AAAA{Hdr: RecordHeader{Name: "example.com."}})
+	require.ErrorIs(t, err, ErrInvalidRecord, "the zero address is not encodable")
+
+	_, err = packRecord(nil, &SRV{Hdr: RecordHeader{Name: "example.com."}, Target: "a..b."})
+	require.ErrorIs(t, err, ErrInvalidName)
+}
+
+func TestUnpackRecordErrors(t *testing.T) {
+	valid := packOne(t, &A{
+		Hdr:  RecordHeader{Name: "example.com.", Type: TypeA, Class: ClassINET},
+		Addr: netip.MustParseAddr("10.0.0.1"),
+	})
+
+	_, _, err := unpackRecord(valid[:len(valid)-1], 0)
+	require.ErrorIs(t, err, ErrShortMessage, "the record data is one byte short")
+
+	_, _, err = unpackRecord(valid[:len(valid)-6], 0)
+	require.ErrorIs(t, err, ErrShortMessage, "the fixed fields are incomplete")
+
+	_, _, err = unpackRecord([]byte{0x40}, 0)
+	require.ErrorIs(t, err, ErrInvalidName)
+}
+
+func TestUnpackRDataErrors(t *testing.T) {
+	badLen := func(qtype Type, rdLen int) error {
+		h := RecordHeader{Name: "example.com.", Type: qtype, Class: ClassINET}
+		_, err := unpackRData(h, make([]byte, rdLen), 0, rdLen)
+		return err
+	}
+	require.ErrorIs(t, badLen(TypeA, 3), ErrInvalidRecord)
+	require.ErrorIs(t, badLen(TypeA, 16), ErrInvalidRecord,
+		"a 16-byte address is not an A record")
+	require.ErrorIs(t, badLen(TypeAAAA, 4), ErrInvalidRecord,
+		"a 4-byte address is not an AAAA record")
+	require.ErrorIs(t, badLen(TypeSRV, srvFixedLen), ErrInvalidRecord,
+		"an SRV record needs a target after its fixed fields")
+	require.ErrorIs(t, badLen(TypeSRV, 2), ErrInvalidRecord)
+
+	// an SRV target that is not a decodable name
+	h := RecordHeader{Name: "example.com.", Type: TypeSRV, Class: ClassINET}
+	data := make([]byte, srvFixedLen+1)
+	data[srvFixedLen] = 0x40
+	_, err := unpackRData(h, data, 0, len(data))
+	require.ErrorIs(t, err, ErrInvalidName)
+}
+
+func TestUnknownRecordIsCopied(t *testing.T) {
+	h := RecordHeader{Name: "example.com.", Type: 99, Class: ClassINET}
+	msg := []byte{1, 2, 3}
+	rr, err := unpackRData(h, msg, 0, len(msg))
+	require.NoError(t, err)
+	msg[0] = 9
+	require.Equal(t, []byte{1, 2, 3}, rr.(*Unknown).Data,
+		"record data must not alias the message buffer")
+}

--- a/pkg/dns/client/resolvconf.go
+++ b/pkg/dns/client/resolvconf.go
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/netip"
+	"os"
+	"strings"
+)
+
+const (
+	// DefaultResolvConfPath is the conventional location of the system
+	// resolver configuration on unix hosts
+	DefaultResolvConfPath = "/etc/resolv.conf"
+	// DefaultPort is the standard DNS service port
+	DefaultPort = "53"
+
+	nameserverKeyword = "nameserver"
+)
+
+// ResolvConf is the subset of a resolver configuration file this client uses
+type ResolvConf struct {
+	// Servers are the configured nameservers, as host:port
+	Servers []string
+}
+
+// LoadResolvConf reads the nameservers from a resolv.conf-formatted file.
+// Entries that are not valid IP addresses are skipped.
+func LoadResolvConf(path string) (*ResolvConf, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return parseResolvConf(f)
+}
+
+func parseResolvConf(r io.Reader) (*ResolvConf, error) {
+	out := &ResolvConf{}
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := sc.Text()
+		if i := strings.IndexAny(line, "#;"); i >= 0 {
+			line = line[:i]
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[0] != nameserverKeyword {
+			continue
+		}
+		if addr, err := netip.ParseAddr(fields[1]); err == nil {
+			out.Servers = append(out.Servers,
+				net.JoinHostPort(addr.String(), DefaultPort))
+		}
+	}
+	if err := sc.Err(); err != nil {
+		return nil, err
+	}
+	if len(out.Servers) == 0 {
+		return nil, ErrNoServers
+	}
+	return out, nil
+}

--- a/pkg/dns/client/resolvconf_test.go
+++ b/pkg/dns/client/resolvconf_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const testResolvConf = `# a comment
+domain example.com
+search example.com example.net
+nameserver 10.0.0.53
+	nameserver	10.0.0.54	; trailing comment
+nameserver fe80::1%eth0
+nameserver not-an-address
+nameserver
+options ndots:2
+`
+
+func TestParseResolvConf(t *testing.T) {
+	rc, err := parseResolvConf(strings.NewReader(testResolvConf))
+	require.NoError(t, err)
+	require.Equal(t, []string{
+		"10.0.0.53:53",
+		"10.0.0.54:53",
+		"[fe80::1%eth0]:53",
+	}, rc.Servers, "only parsable nameserver addresses are kept, with the default port")
+}
+
+func TestParseResolvConfNoServers(t *testing.T) {
+	_, err := parseResolvConf(strings.NewReader("search example.com\n"))
+	require.ErrorIs(t, err, ErrNoServers)
+}
+
+func TestLoadResolvConf(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolv.conf")
+	require.NoError(t, os.WriteFile(path, []byte(testResolvConf), 0o600))
+	rc, err := LoadResolvConf(path)
+	require.NoError(t, err)
+	require.Equal(t, "10.0.0.53:53", rc.Servers[0])
+
+	_, err = LoadResolvConf(filepath.Join(t.TempDir(), "absent.conf"))
+	require.Error(t, err)
+}
+
+func TestRCodeString(t *testing.T) {
+	require.Equal(t, "NOERROR", RCodeSuccess.String())
+	require.Equal(t, "SERVFAIL", RCodeServerFailure.String())
+	require.Equal(t, "NXDOMAIN", RCodeNameError.String())
+	require.Equal(t, "RCODE99", RCode(99).String())
+}

--- a/pkg/dns/client/types.go
+++ b/pkg/dns/client/types.go
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import "strconv"
+
+// Type is a DNS resource record type
+type Type uint16
+
+// Resource record types recognized by this client. Records of any other
+// type unpack as *Unknown rather than failing the message.
+const (
+	TypeA    Type = 1
+	TypeAAAA Type = 28
+	TypeSRV  Type = 33
+	TypeOPT  Type = 41
+)
+
+// Class is a DNS resource record class
+type Class uint16
+
+// ClassINET is the Internet record class, the only class this client uses
+const ClassINET Class = 1
+
+// RCode is the response code returned by a DNS server
+type RCode uint16
+
+// Response codes defined by RFC 1035
+const (
+	RCodeSuccess        RCode = 0
+	RCodeFormatError    RCode = 1
+	RCodeServerFailure  RCode = 2
+	RCodeNameError      RCode = 3
+	RCodeNotImplemented RCode = 4
+	RCodeRefused        RCode = 5
+)
+
+var rcodeNames = map[RCode]string{
+	RCodeSuccess:        "NOERROR",
+	RCodeFormatError:    "FORMERR",
+	RCodeServerFailure:  "SERVFAIL",
+	RCodeNameError:      "NXDOMAIN",
+	RCodeNotImplemented: "NOTIMP",
+	RCodeRefused:        "REFUSED",
+}
+
+// String returns the response code's mnemonic, or RCODE<n> when unknown
+func (r RCode) String() string {
+	if s, ok := rcodeNames[r]; ok {
+		return s
+	}
+	return "RCODE" + strconv.Itoa(int(r))
+}

--- a/pkg/testutil/dnsserver/dnsserver.go
+++ b/pkg/testutil/dnsserver/dnsserver.go
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package dnsserver provides an in-process DNS server for tests. It serves a
+// mutable record set on a loopback port over both UDP and TCP, and can be
+// told to fail or truncate answers to exercise those paths.
+package dnsserver
+
+import (
+	"encoding/binary"
+	"io"
+	"net"
+	"net/netip"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/trickstercache/trickster/v2/pkg/dns/client"
+)
+
+const (
+	listenAttempts  = 5
+	udpReadBufSize  = 4096
+	tcpConnDeadline = 10 * time.Second
+)
+
+// Server is an in-process DNS server bound to a loopback port
+type Server struct {
+	mtx      sync.Mutex
+	records  map[client.Type][]client.Record
+	rcode    client.RCode
+	truncate bool
+
+	addr      string
+	pc        net.PacketConn
+	ln        net.Listener
+	wg        sync.WaitGroup
+	closeOnce sync.Once
+}
+
+// New starts a server on a free loopback port and stops it at test cleanup
+func New(t *testing.T) *Server {
+	t.Helper()
+	ln, pc := listenPair(t)
+	s := &Server{
+		records: make(map[client.Type][]client.Record),
+		addr:    ln.Addr().String(),
+		pc:      pc,
+		ln:      ln,
+	}
+	s.wg.Add(2)
+	go s.serveUDP()
+	go s.serveTCP()
+	t.Cleanup(s.Stop)
+	return s
+}
+
+// Addr returns the server's host:port
+func (s *Server) Addr() string { return s.addr }
+
+// Set replaces the records served for the given query type
+func (s *Server) Set(qtype client.Type, records ...client.Record) {
+	s.mtx.Lock()
+	s.records[qtype] = records
+	s.mtx.Unlock()
+}
+
+// SetRCode makes every subsequent answer carry rc and no records
+func (s *Server) SetRCode(rc client.RCode) {
+	s.mtx.Lock()
+	s.rcode = rc
+	s.mtx.Unlock()
+}
+
+// SetTruncate makes UDP answers come back with the truncated bit set and no
+// records, which drives clients to retry the query over TCP
+func (s *Server) SetTruncate(truncate bool) {
+	s.mtx.Lock()
+	s.truncate = truncate
+	s.mtx.Unlock()
+}
+
+// Stop closes the server's listeners and waits for its handlers to finish
+func (s *Server) Stop() {
+	s.closeOnce.Do(func() {
+		_ = s.pc.Close()
+		_ = s.ln.Close()
+	})
+	s.wg.Wait()
+}
+
+func (s *Server) serveUDP() {
+	defer s.wg.Done()
+	buf := make([]byte, udpReadBufSize)
+	for {
+		n, addr, err := s.pc.ReadFrom(buf)
+		if err != nil {
+			return
+		}
+		resp, err := s.respond(buf[:n], true)
+		if err != nil {
+			continue
+		}
+		_, _ = s.pc.WriteTo(resp, addr)
+	}
+}
+
+func (s *Server) serveTCP() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.ln.Accept()
+		if err != nil {
+			return
+		}
+		s.wg.Add(1)
+		go s.handleTCP(conn)
+	}
+}
+
+func (s *Server) handleTCP(conn net.Conn) {
+	defer s.wg.Done()
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(tcpConnDeadline))
+	var sz [2]byte
+	if _, err := io.ReadFull(conn, sz[:]); err != nil {
+		return
+	}
+	buf := make([]byte, binary.BigEndian.Uint16(sz[:]))
+	if _, err := io.ReadFull(conn, buf); err != nil {
+		return
+	}
+	resp, err := s.respond(buf, false)
+	if err != nil {
+		return
+	}
+	framed := make([]byte, 2, len(resp)+2)
+	// #nosec G115 -- test answers are orders of magnitude below the 64KB frame
+	binary.BigEndian.PutUint16(framed, uint16(len(resp)))
+	_, _ = conn.Write(append(framed, resp...))
+}
+
+// respond builds the wire-format answer to a query; udp answers honor the
+// configured truncation, which does not apply to TCP
+func (s *Server) respond(query []byte, udp bool) ([]byte, error) {
+	req := &client.Msg{}
+	if err := req.Unpack(query); err != nil {
+		return nil, err
+	}
+	resp := &client.Msg{
+		ID:                 req.ID,
+		Response:           true,
+		Authoritative:      true,
+		RecursionDesired:   req.RecursionDesired,
+		RecursionAvailable: true,
+		Questions:          req.Questions,
+	}
+	s.mtx.Lock()
+	resp.RCode = s.rcode
+	resp.Truncated = s.truncate && udp
+	if resp.RCode == client.RCodeSuccess && !resp.Truncated && len(req.Questions) > 0 {
+		resp.Answers = s.records[req.Questions[0].Type]
+	}
+	s.mtx.Unlock()
+	return resp.Pack()
+}
+
+// listenPair binds TCP and UDP to the same loopback port, retrying when the
+// port picked for TCP is already taken on UDP
+func listenPair(t *testing.T) (net.Listener, net.PacketConn) {
+	t.Helper()
+	for range listenAttempts {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			continue
+		}
+		pc, err := net.ListenPacket("udp", ln.Addr().String())
+		if err == nil {
+			return ln, pc
+		}
+		_ = ln.Close()
+	}
+	t.Fatal("could not bind a loopback port for both tcp and udp")
+	return nil, nil
+}
+
+// A returns an IPv4 address record, panicking on an unparsable address
+func A(name string, ttl uint32, addr string) *client.A {
+	return &client.A{
+		Hdr:  header(name, client.TypeA, ttl),
+		Addr: netip.MustParseAddr(addr),
+	}
+}
+
+// AAAA returns an IPv6 address record, panicking on an unparsable address
+func AAAA(name string, ttl uint32, addr string) *client.AAAA {
+	return &client.AAAA{
+		Hdr:  header(name, client.TypeAAAA, ttl),
+		Addr: netip.MustParseAddr(addr),
+	}
+}
+
+// SRV returns a service location record
+func SRV(name string, ttl uint32, priority, weight, port uint16,
+	target string,
+) *client.SRV {
+	return &client.SRV{
+		Hdr:      header(name, client.TypeSRV, ttl),
+		Priority: priority,
+		Weight:   weight,
+		Port:     port,
+		Target:   client.Fqdn(target),
+	}
+}
+
+func header(name string, qtype client.Type, ttl uint32) client.RecordHeader {
+	return client.RecordHeader{
+		Name:  client.Fqdn(name),
+		Type:  qtype,
+		Class: client.ClassINET,
+		TTL:   ttl,
+	}
+}

--- a/pkg/testutil/dnsserver/dnsserver_test.go
+++ b/pkg/testutil/dnsserver/dnsserver_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 The Trickster Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dnsserver
+
+import (
+	"net"
+	"testing"
+
+	"github.com/trickstercache/trickster/v2/pkg/dns/client"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServerServesBothTransports(t *testing.T) {
+	srv := New(t)
+	srv.Set(client.TypeA, A("host.example.com.", 30, "10.0.0.1"))
+	_, _, err := net.SplitHostPort(srv.Addr())
+	require.NoError(t, err)
+
+	for _, network := range []string{"udp", "tcp"} {
+		t.Run(network, func(t *testing.T) {
+			c := &client.Client{Net: network}
+			r, err := c.Query(t.Context(), srv.Addr(), "host.example.com", client.TypeA)
+			require.NoError(t, err)
+			require.Len(t, r.Answers, 1)
+			require.Equal(t, uint32(30), r.Answers[0].Header().TTL)
+		})
+	}
+}
+
+func TestServerRCodeAndTruncate(t *testing.T) {
+	srv := New(t)
+	srv.Set(client.TypeAAAA, AAAA("host.example.com.", 30, "2001:db8::1"))
+	srv.Set(client.TypeSRV, SRV("_svc._tcp.example.com.", 30, 1, 2, 80, "a.example.com"))
+	c := &client.Client{}
+
+	srv.SetRCode(client.RCodeNameError)
+	r, err := c.Query(t.Context(), srv.Addr(), "host.example.com", client.TypeAAAA)
+	require.NoError(t, err)
+	require.Equal(t, client.RCodeNameError, r.RCode)
+
+	// truncation applies to UDP only, so the client's TCP retry succeeds
+	srv.SetRCode(client.RCodeSuccess)
+	srv.SetTruncate(true)
+	r, err = c.Query(t.Context(), srv.Addr(), "_svc._tcp.example.com", client.TypeSRV)
+	require.NoError(t, err)
+	require.False(t, r.Truncated)
+	require.Len(t, r.Answers, 1)
+	require.Equal(t, "a.example.com.", r.Answers[0].(*client.SRV).Target)
+}
+
+func TestServerStopIsIdempotent(t *testing.T) {
+	srv := New(t)
+	srv.Stop()
+	srv.Stop()
+}


### PR DESCRIPTION
## Description
<!-- Describe changes and the problem solved -->

removes a deprecated third party dns client and replaces with an internal minimal solution supporting the few resolver types we need for autodiscovery.

## Type of Change
<!-- [x] all that apply below -->
<!-- like: - - [x] Bug fix -->

- - [ ] Bug fix
- - [ ] New feature
- - [x] Optimization
- - [ ] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## AI Disclosure
<!-- [x] exactly one option below -->

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
