### PR TITLE
refactor: move empty extent trimming to ExtentList

### DIFF
--- a/pkg/proxy/engines/deltaproxycache.go
+++ b/pkg/proxy/engines/deltaproxycache.go
@@ -885,27 +885,10 @@ func fetchExtents(
 	eg.Wait()
 
 	fullFaults := false
-	trimmedList := trimEmptyExtents(errTs)
+	trimmedList := errTs.TrimEmptyExtents()
 	if trimmedList.Len() == el.Len() {
 		fullFaults = true
 	}
 
 	return mts, uncachedValueCount.Load(), mresp, trimmedList, fullFaults
-}
-
-func trimEmptyExtents(failedExtents timeseries.ExtentList) timeseries.ExtentList {
-	trimmedList := make(timeseries.ExtentList, len(failedExtents))
-	emptyExtent := timeseries.Extent{}
-
-	var cursor int
-	for _, extent := range failedExtents {
-		if extent == emptyExtent {
-			continue
-		}
-
-		trimmedList[cursor] = extent
-		cursor++
-	}
-
-	return trimmedList[:cursor]
 }

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -348,6 +348,20 @@ func (el ExtentList) Clone() ExtentList {
 	return c
 }
 
+// TrimEmptyExtents returns a copy of the ExtentList with empty Extents removed.
+func (el ExtentList) TrimEmptyExtents() ExtentList {
+	trimmed := make(ExtentList, len(el))
+	var cursor int
+	for _, extent := range el {
+		if extent == (Extent{}) {
+			continue
+		}
+		trimmed[cursor] = extent
+		cursor++
+	}
+	return trimmed[:cursor]
+}
+
 // CloneRange returns a perfect copy of the ExtentList, cloning only the
 // Extents in the provided index range (upper-bound exclusive)
 func (el ExtentList) CloneRange(start, end int) ExtentList {

--- a/pkg/timeseries/extent_list.go
+++ b/pkg/timeseries/extent_list.go
@@ -350,16 +350,14 @@ func (el ExtentList) Clone() ExtentList {
 
 // TrimEmptyExtents returns a copy of the ExtentList with empty Extents removed.
 func (el ExtentList) TrimEmptyExtents() ExtentList {
-	trimmed := make(ExtentList, len(el))
-	var cursor int
+	trimmed := make(ExtentList, 0, len(el))
 	for _, extent := range el {
 		if extent == (Extent{}) {
 			continue
 		}
-		trimmed[cursor] = extent
-		cursor++
+		trimmed = append(trimmed, extent)
 	}
-	return trimmed[:cursor]
+	return trimmed
 }
 
 // CloneRange returns a perfect copy of the ExtentList, cloning only the

--- a/pkg/timeseries/extent_list_test.go
+++ b/pkg/timeseries/extent_list_test.go
@@ -799,6 +799,58 @@ func TestTimestampCount(t *testing.T) {
 	}
 }
 
+func TestTrimEmptyExtents(t *testing.T) {
+	tests := []struct {
+		name     string
+		el       ExtentList
+		expected ExtentList
+	}{
+		{
+			name: "interspersed empty extents",
+			el: ExtentList{
+				Extent{},
+				Extent{Start: t100, End: t200},
+				Extent{},
+				Extent{Start: t600, End: t900},
+				Extent{},
+			},
+			expected: ExtentList{
+				Extent{Start: t100, End: t200},
+				Extent{Start: t600, End: t900},
+			},
+		},
+		{
+			name:     "only empty extents",
+			el:       ExtentList{Extent{}, Extent{}},
+			expected: ExtentList{},
+		},
+		{
+			name:     "empty list",
+			el:       ExtentList{},
+			expected: ExtentList{},
+		},
+		{
+			name: "no empty extents",
+			el: ExtentList{
+				Extent{Start: t100, End: t200},
+				Extent{Start: t600, End: t900},
+			},
+			expected: ExtentList{
+				Extent{Start: t100, End: t200},
+				Extent{Start: t600, End: t900},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if result := test.el.TrimEmptyExtents(); !slices.Equal(result, test.expected) {
+				t.Errorf("TrimEmptyExtents() = %v, want %v", result, test.expected)
+			}
+		})
+	}
+}
+
 func TestSplice(t *testing.T) {
 	tests := []struct {
 		name                       string


### PR DESCRIPTION
## Description

Move the empty extent filtering logic from the delta proxy cache implementation into `timeseries.ExtentList`.

This change:

- adds `ExtentList.TrimEmptyExtents()`;
- updates `fetchExtents` to use the new method;
- removes the standalone `trimEmptyExtents` function from `deltaproxycache.go`;
- adds table-driven unit tests covering interspersed empty extents, all-empty lists, empty lists, and lists without empty extents.

This keeps the existing behavior while making `ExtentList` responsible for managing its own representation.

Closes #1126

## Type of Change

- - [ ] Bug fix
- - [ ] New feature
- - [x] Optimization
- - [x] Test coverage
- - [ ] Documentation
- - [ ] Infrastructure

## Testing

- `make build`
- `make lint`
- `make test`
- `make data-race-test`

All checks pass. The project test suite reports 91.02% statement coverage, and `TrimEmptyExtents` has 100% statement coverage.

## AI Disclosure

- - [ ] This contribution DOES NOT include AI-generated changes
- - [x] This contribution DOES include AI-generated changes, and I have reviewed the relevant contributing guidelines.
